### PR TITLE
Refactoring SpeechRecognizer and WakeupDetector

### DIFF
--- a/service/audio_input_processor.cc
+++ b/service/audio_input_processor.cc
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "audio_input_processor.hh"
+#include "nugu_log.h"
+
+namespace NuguCore {
+
+class SyncEvent {
+public:
+    std::function<void()> action;
+    std::condition_variable cond;
+    std::mutex mutex;
+};
+
+AudioInputProcessor::~AudioInputProcessor()
+{
+    g_atomic_int_set(&destroy, 1);
+
+    stop();
+
+    mutex.lock();
+    cond.notify_all();
+    mutex.unlock();
+
+    if (thread.joinable())
+        thread.join();
+
+    nugu_recorder_free(rec);
+}
+
+void AudioInputProcessor::init(std::string name)
+{
+    if (is_initialized) {
+        nugu_dbg("It's already initialized.");
+        return;
+    }
+
+    NuguRecorderDriver* driver = nugu_recorder_driver_get_default();
+    int ret;
+
+    if (!driver) {
+        nugu_error("there is no recorder driver");
+        return;
+    }
+
+    rec = nugu_recorder_new(name.append("_rec").c_str(), driver);
+    nugu_recorder_set_property(rec, (NuguAudioProperty) { AUDIO_SAMPLE_RATE_16K, AUDIO_FORMAT_S16_LE, 1 });
+
+    thread_created = false;
+    destroy = 0;
+    thread = std::thread([this] { this->loop(); });
+
+    ret = pthread_setname_np(thread.native_handle(), name.append("_loop").c_str());
+    if (ret < 0)
+        nugu_error("pthread_setname_np() failed");
+
+    /* Wait until thread creation */
+    std::unique_lock<std::mutex> lock(mutex);
+    if (thread_created == false)
+        cond.wait(lock);
+    lock.unlock();
+
+    is_initialized = true;
+}
+
+void AudioInputProcessor::start(std::function<void()> extra_func)
+{
+    if (is_running) {
+        nugu_dbg("Thread is already running...");
+        return;
+    }
+
+    if (extra_func)
+        extra_func();
+
+    is_running = true;
+
+    mutex.lock();
+    cond.notify_all();
+    mutex.unlock();
+}
+
+void AudioInputProcessor::stop(void)
+{
+    if (!is_running) {
+        nugu_dbg("Thread is not running...");
+        return;
+    }
+
+    is_running = false;
+}
+
+static gboolean invoke_sync_event(gpointer userdata)
+{
+    SyncEvent* e = static_cast<SyncEvent*>(userdata);
+
+    if (e->action)
+        e->action();
+
+    e->mutex.lock();
+    e->cond.notify_all();
+    e->mutex.unlock();
+
+    return FALSE;
+}
+
+void AudioInputProcessor::sendSyncEvent(std::function<void()> action)
+{
+    g_return_if_fail(action != nullptr);
+
+    SyncEvent* data = new SyncEvent;
+    data->action = action;
+
+    std::unique_lock<std::mutex> lock(data->mutex);
+
+    g_main_context_invoke(NULL, invoke_sync_event, data);
+
+    data->cond.wait(lock);
+    lock.unlock();
+
+    delete data;
+}
+
+} // NuguCore

--- a/service/audio_input_processor.hh
+++ b/service/audio_input_processor.hh
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NUGU_AUDIO_INPUT_PROCESSOR_H__
+#define __NUGU_AUDIO_INPUT_PROCESSOR_H__
+
+#include <condition_variable>
+#include <functional>
+#include <glib.h>
+#include <mutex>
+#include <thread>
+
+#include <core/nugu_recorder.h>
+
+namespace NuguCore {
+
+class AudioInputProcessor {
+public:
+    AudioInputProcessor() = default;
+    virtual ~AudioInputProcessor();
+
+protected:
+    void init(std::string name);
+    void start(std::function<void()> extra_func = nullptr);
+    void stop(void);
+    void sendSyncEvent(std::function<void()> action = nullptr);
+
+    virtual void loop(void) = 0;
+
+    bool is_initialized = false;
+    bool is_running = false;
+    bool thread_created = false;
+    gint destroy;
+    std::thread thread;
+    std::condition_variable cond;
+    std::mutex mutex;
+    NuguRecorder* rec = nullptr;
+};
+
+} // NuguCore
+
+#endif /* __NUGU_AUDIO_INPUT_PROCESSOR_H__ */

--- a/service/speech_recognizer.hh
+++ b/service/speech_recognizer.hh
@@ -17,12 +17,7 @@
 #ifndef __NUGU_SPEECH_RECOGNIZER_H__
 #define __NUGU_SPEECH_RECOGNIZER_H__
 
-#include <condition_variable>
-#include <glib.h>
-#include <mutex>
-#include <thread>
-
-#include <core/nugu_recorder.h>
+#include "audio_input_processor.hh"
 
 #define EPD_MODEL_FILE "nugu_model_epd.raw"
 
@@ -49,10 +44,10 @@ public:
     virtual void onRecordData(unsigned char* buf, int length) = 0;
 };
 
-class SpeechRecognizer {
+class SpeechRecognizer : public AudioInputProcessor {
 public:
     SpeechRecognizer();
-    ~SpeechRecognizer();
+    virtual ~SpeechRecognizer() = default;
 
     void setListener(ISpeechRecognizerListener* listener);
     void startListening(void);
@@ -61,19 +56,12 @@ public:
     void stopRecorder(void);
 
 private:
-    void loopListening(void);
+    void loop(void) override;
     void sendSyncListeningEvent(ListeningState state);
 
     const unsigned int OUT_DATA_SIZE = 1024 * 9;
     int epd_ret = -1;
     ISpeechRecognizerListener* listener = nullptr;
-
-    std::thread asr_thread;
-    std::condition_variable asr_cond;
-    std::mutex asr_mutex;
-    gint asr_destroy;
-    bool asr_is_running = false;
-    NuguRecorder* rec_asr = nullptr;
 };
 
 } // NuguCore

--- a/service/wakeup_detector.hh
+++ b/service/wakeup_detector.hh
@@ -17,12 +17,7 @@
 #ifndef __NUGU_WAKEUP_DETECTOR_H__
 #define __NUGU_WAKEUP_DETECTOR_H__
 
-#include <condition_variable>
-#include <glib.h>
-#include <mutex>
-#include <thread>
-
-#include <core/nugu_recorder.h>
+#include "audio_input_processor.hh"
 
 #define WAKEUP_NET_MODEL_FILE "nugu_model_wakeup_net.raw"
 #define WAKEUP_SEARCH_MODEL_FILE "nugu_model_wakeup_search.raw"
@@ -44,27 +39,20 @@ public:
     virtual void onWakeupState(WakeupState state) = 0;
 };
 
-class WakeupDetector {
+class WakeupDetector : public AudioInputProcessor {
 public:
     WakeupDetector();
-    ~WakeupDetector();
+    virtual ~WakeupDetector() = default;
 
     void setListener(IWakeupDetectorListener* listener);
     void startWakeup(void);
     void stopWakeup(void);
 
 private:
-    void loopWakeup(void);
+    void loop(void) override;
     void sendSyncWakeupEvent(WakeupState state);
 
     IWakeupDetectorListener* listener = nullptr;
-    std::thread kwd_thread;
-    std::condition_variable kwd_cond;
-    std::mutex kwd_mutex;
-    gint kwd_destroy;
-    bool kwd_is_running = false;
-    NuguRecorder* rec_kwd = nullptr;
-    bool thread_created;
 };
 
 } // NuguCore


### PR DESCRIPTION
Because SpeechRecognizer and WakeupDetector had so many
common variables and methods, it needed to do refactoring.

As defining parent class of both to AudioInputProcessor
and inheriting this, it could remove so many duplicated codes.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>