### PR TITLE
rename the contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,10 @@ This project uses two programming languages, C and C++. Therefore, please follow
 
 [Submitting patches: the essential guide to getting your code into the kernel](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/process/submitting-patches.rst?id=HEAD)
 
+## Pull request
+
+Please refer to the [wiki](https://github.com/nugu-developers/nugu-linux/wiki/Pull-Request) document.
+
 ## Merge strategy
 
 This project merges PR using the rebase strategy to avoid creating unnecessary merge commits. Therefore, your PR should not conflict with the latest master branch.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ NUGU SDK provides sample application which is possible to test simple NUGU servi
 
 ## Contributing
 
-This project welcomes contributions and suggestions. The best way to contribute is to create issues or pull requests right here on Github. Please see [Contributing.md](doc/contributing.md)
+This project welcomes contributions and suggestions. The best way to contribute is to create issues or pull requests right here on Github. Please see [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## License
 


### PR DESCRIPTION
Move the doc/contributing.md to repository's root directory to make
Github recognize the contribution document. Because the Github can
recognize only if the document is in 'docs/' or root.

Signed-off-by: Inho Oh <inho.oh@sk.com>