### PR TITLE
adjust namespace of NuguConfig

### DIFF
--- a/include/interface/capability/capability_observer.hh
+++ b/include/interface/capability/capability_observer.hh
@@ -60,6 +60,6 @@ public:
  * @}
  */
 
-} // NuguClientKit
+} // NuguInterface
 
 #endif /* __NUGU_CAPABILITY_OBSERVER_H__ */

--- a/include/interface/media_player_interface.hh
+++ b/include/interface/media_player_interface.hh
@@ -247,6 +247,6 @@ public:
  * @}
  */
 
-} // NuguCore
+} // NuguInterface
 
 #endif

--- a/include/interface/network_manager_interface.hh
+++ b/include/interface/network_manager_interface.hh
@@ -98,6 +98,6 @@ public:
  * @}
  */
 
-} // NuguCore
+} // NuguInterface
 
 #endif /* __NUGU_INETWORK_MANAGER_INTERFACE_H__ */

--- a/include/interface/nugu_configuration.hh
+++ b/include/interface/nugu_configuration.hh
@@ -22,7 +22,7 @@
 
 #include <core/nugu_config.h>
 
-namespace NuguClientKit {
+namespace NuguInterface {
 
 /**
  * @file nugu_configuration.hh
@@ -46,6 +46,6 @@ namespace NuguConfig {
     const NuguConfigType getDefaultValues(NuguConfigType& user_map);
 }
 
-} // NuguClientKit
+} // NuguInterface
 
 #endif /* __NUGU_CONFIGURATION__ */

--- a/include/interface/wakeup_interface.hh
+++ b/include/interface/wakeup_interface.hh
@@ -80,6 +80,6 @@ public:
  * @}
  */
 
-} // NuguClientKit
+} // NuguInterface
 
 #endif /* __NUGU_WAKEUP_INTERFACE_H__ */

--- a/interface/nugu_configuration.cc
+++ b/interface/nugu_configuration.cc
@@ -18,7 +18,7 @@
 
 #include <interface/nugu_configuration.hh>
 
-namespace NuguClientKit {
+namespace NuguInterface {
 
 namespace NuguConfig {
     namespace {
@@ -83,4 +83,4 @@ namespace NuguConfig {
     }
 }
 
-} // NuguClientKit
+} // NuguInterface

--- a/service/capability/asr_agent.cc
+++ b/service/capability/asr_agent.cc
@@ -28,8 +28,6 @@
 
 namespace NuguCore {
 
-using namespace NuguClientKit;
-
 static const std::string capability_version = "1.0";
 
 class ASRFocusListener : public IFocusListener {

--- a/service/capability_manager.cc
+++ b/service/capability_manager.cc
@@ -24,7 +24,7 @@
 
 namespace NuguCore {
 
-using namespace NuguClientKit;
+using namespace NuguInterface;
 
 CapabilityManager* CapabilityManager::instance = NULL;
 

--- a/service/speech_recognizer.cc
+++ b/service/speech_recognizer.cc
@@ -17,16 +17,16 @@
 #include <string.h>
 #include <unistd.h>
 
-#include "endpoint_detector.h"
-#include "interface/nugu_configuration.hh"
+#include <interface/nugu_configuration.hh>
 
+#include "endpoint_detector.h"
 #include "nugu_config.h"
 #include "nugu_log.h"
 #include "speech_recognizer.hh"
 
 namespace NuguCore {
 
-using namespace NuguClientKit;
+using namespace NuguInterface;
 
 SpeechRecognizer::SpeechRecognizer()
 {

--- a/service/wakeup_detector.cc
+++ b/service/wakeup_detector.cc
@@ -25,7 +25,7 @@
 
 namespace NuguCore {
 
-using namespace NuguClientKit;
+using namespace NuguInterface;
 
 WakeupDetector::WakeupDetector()
 {


### PR DESCRIPTION
Because namespace of NuguConfig is NuguClientKit, it cause
cross depenent between NuguCore and NuguClientKit.

So, it change namespace of NuguConfig from NuguClientKit
to NuguInterface.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>