### PR TITLE
apply custom duration in PlaySyncManager

### DIFF
--- a/service/capability/display_agent.cc
+++ b/service/capability/display_agent.cc
@@ -67,12 +67,14 @@ void DisplayAgent::processDirective(NuguDirective* ndir)
         return;
     }
     ps_id = root["playServiceId"].asString();
+    duration = root["duration"].asString();
 
     // sync display rendering with context
     PlaySyncManager::DisplayRenderer renderer;
     renderer.cap_type = getType();
     renderer.listener = this;
     renderer.only_rendering = true;
+    renderer.duration = duration;
     renderer.render_info = std::make_pair<std::string, std::string>(dname, message);
 
     playsync_manager->addContext(ps_id, getType(), renderer);

--- a/service/playsync_manager.cc
+++ b/service/playsync_manager.cc
@@ -28,6 +28,13 @@
 
 namespace NuguCore {
 
+const std::map<std::string, long> PlaySyncManager::DURATION_MAP = {
+    { "SHORT", HOLD_TIME_SHORT },
+    { "MID", HOLD_TIME_MID },
+    { "LONG", HOLD_TIME_LONG },
+    { "LONGEST", HOLD_TIME_LONGEST }
+};
+
 /*******************************************************************************
  * >>> Temp
  ******************************************************************************/
@@ -162,6 +169,7 @@ void PlaySyncManager::removeContext(std::string ps_id, CapabilityType cap_type, 
             nugu_dbg("[context] try to remove context by timer.");
 
             nugu_timer_set_callback(timer, timerCallback, &timer_cb_param);
+            setTimerInterval(ps_id);
             nugu_timer_start(timer);
         }
     }
@@ -226,6 +234,21 @@ void PlaySyncManager::removeRenderer(std::string ps_id)
         renderer_map[ps_id].listener->onReleaseContext(ps_id);
         renderer_map.erase(ps_id);
     }
+}
+
+void PlaySyncManager::setTimerInterval(const std::string& ps_id)
+{
+    long duration_time = DEFAULT_HOLD_TIME;
+
+    if (renderer_map.find(ps_id) != renderer_map.end()) {
+        try {
+            duration_time = DURATION_MAP.at(renderer_map.at(ps_id).duration);
+        } catch (std::out_of_range& exception) {
+            nugu_error(exception.what());
+        }
+    }
+
+    nugu_timer_set_interval(timer, duration_time);
 }
 
 template <typename T, typename V>

--- a/service/playsync_manager.hh
+++ b/service/playsync_manager.hh
@@ -39,16 +39,10 @@ public:
 
 class PlaySyncManager {
 public:
-    enum class HoldDuration {
-        SHORT,
-        MID,
-        LONG
-    };
-
     typedef struct display_renderer {
         IPlaySyncManagerListener* listener;
         CapabilityType cap_type;
-        HoldDuration duration = HoldDuration::SHORT;
+        std::string duration;
         std::pair<std::string, std::string> render_info;
         bool only_rendering = false;
     } DisplayRenderer;
@@ -72,6 +66,9 @@ private:
     bool removeStackElement(std::string ps_id, CapabilityType cap_type);
     void addRenderer(std::string ps_id, DisplayRenderer& renderer);
     void removeRenderer(std::string ps_id);
+    void setTimerInterval(const std::string& ps_id);
+
+    static const std::map<std::string, long> DURATION_MAP;
 
     template <typename T, typename V>
     std::vector<std::string> getKeyOfMap(std::map<T, V>& map);


### PR DESCRIPTION
In display interface, because it's possible to setup
custom duration time of displaying contents, it update
PlaySyncManager for handling this feature.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>