### PR TITLE
capability manager: check directive version

### DIFF
--- a/include/interface/capability/capability_interface.hh
+++ b/include/interface/capability/capability_interface.hh
@@ -133,6 +133,18 @@ public:
     virtual CapabilityType getType() = 0;
 
     /**
+     * @brief Get the capability name of the current object.
+     * @return capability name of the object
+     */
+    virtual std::string getName() = 0;
+
+    /**
+     * @brief Get the capability version of the current object.
+     * @return capability version of the object
+     */
+    virtual std::string getVersion() = 0;
+
+    /**
      * @brief Process directive received from Directive Sequencer.
      * @param[in] ndir directive
      */

--- a/service/capability/capability.hh
+++ b/service/capability/capability.hh
@@ -43,9 +43,9 @@ public:
     std::string getTypeName(CapabilityType type) override;
     CapabilityType getType() override;
     void setName(CapabilityType type);
-    std::string getName();
+    std::string getName() override;
     void setVersion(const std::string& ver);
-    std::string getVersion();
+    std::string getVersion() override;
 
     void destoryDirective(NuguDirective* ndir);
     void sendEvent(NuguEvent* event, bool is_end = false, size_t size = 0, unsigned char* data = NULL);

--- a/service/capability_manager.hh
+++ b/service/capability_manager.hh
@@ -58,6 +58,7 @@ public:
     std::string makeAllContextInfoStack();
 
     void preprocessDirective(NuguDirective* ndir);
+    bool isSupportDirectiveVersion(std::string version, ICapabilityInterface* cap);
 
     void sendCommand(CapabilityType from, CapabilityType to, std::string command, std::string param);
     void sendCommandAll(std::string command, std::string param);


### PR DESCRIPTION
capability agent can support same major version of directive.
capability manager check the directive's version before pass
it to each the capability agent.

Signed-off-by: Hyojoong Kim <hyojoong.kim@sk.com>