### PR TITLE
capability: update AudioPlayer interface

### DIFF
--- a/include/interface/media_player_interface.hh
+++ b/include/interface/media_player_interface.hh
@@ -49,8 +49,10 @@ enum class MediaPlayerState {
  * @brief MediaPlayerEvent
  */
 enum class MediaPlayerEvent {
-    INVALID_MEDIA, /**< Failed to load media content */
-    LOADING_MEDIA /**< Successful loading of media content */
+    INVALID_MEDIA_URL, /**< Invalid media content url */
+    LOADING_MEDIA_FAILED, /**< Loading of media content failed */
+    LOADING_MEDIA_SUCCESS, /**< Loading of media content success */
+    PLAYING_MEDIA_FINISHED /**< Playing media content to the end */
 };
 
 /**
@@ -70,16 +72,6 @@ public:
      * @param[in] event mediaplayer playback event
      */
     virtual void mediaEventReport(MediaPlayerEvent event) = 0;
-
-    /**
-     * @brief Report the media player playing media content to the end.
-     */
-    virtual void mediaFinished() = 0;
-
-    /**
-     * @brief Report the media player loading media content successfully.
-     */
-    virtual void mediaLoaded() = 0;
 
     /**
      * @brief The media player reports that the media content has changed.

--- a/service/capability/audio_player_agent.hh
+++ b/service/capability/audio_player_agent.hh
@@ -69,9 +69,7 @@ public:
     void sendEventPlaybackStopped();
     void sendEventPlaybackPaused();
     void sendEventPlaybackResumed();
-
-    void sendEventPlaybackError(PlaybackError err, const std::string& reason);
-
+    void sendEventPlaybackFailed(PlaybackError err, const std::string& reason);
     void sendEventProgressReportDelayElapsed();
     void sendEventProgressReportIntervalElapsed();
     void sendEventByDisplayInterface(const std::string& command);


### PR DESCRIPTION
Agent doesn't send an event(PlaybackResumed) when playing after
receiving the directive and modify the mediaEventReport.
The media player supports play with seek now.

Signed-off-by: Hyojoong Kim <hyojoong.kim@sk.com>