### PR TITLE
config: fix the bug.

### DIFF
--- a/include/interface/nugu_configuration.hh
+++ b/include/interface/nugu_configuration.hh
@@ -49,7 +49,7 @@ namespace NuguConfig {
     }
 
     const NuguConfigType getDefaultValues();
-    const std::string& getGatewayRegistryDns(std::string& server_type);
+    const std::string getGatewayRegistryDns(std::string& server_type);
 }
 
 } // NuguInterface

--- a/interface/nugu_configuration.cc
+++ b/interface/nugu_configuration.cc
@@ -68,12 +68,14 @@ namespace NuguConfig {
         return DEFAULT_VALUES;
     }
 
-    const std::string& getGatewayRegistryDns(std::string& server_type)
+    const std::string getGatewayRegistryDns(std::string& server_type)
     {
+        std::string dns = DEFAULT_VALUES[Key::GATEWAY_REGISTRY_DNS];
+
         if (!isEqualString(server_type, DEFAULT_VALUES[Key::SERVER_TYPE]))
-            return DEFAULT_VALUES[Key::GATEWAY_REGISTRY_DNS].insert(0, toChangeCase(server_type, true).append("-"));
-        else
-            return DEFAULT_VALUES[Key::GATEWAY_REGISTRY_DNS];
+            return dns.insert(0, toChangeCase(server_type, true).append("-"));
+
+        return dns;
     }
 }
 


### PR DESCRIPTION
Even if you deinitalize the nugu client, you should not modify
the defaults because they will remain in memory.

Signed-off-by: Hyojoong Kim <hyojoong.kim@sk.com>