### PR TITLE
config: remove server_type

### DIFF
--- a/include/interface/nugu_configuration.hh
+++ b/include/interface/nugu_configuration.hh
@@ -42,14 +42,12 @@ namespace NuguConfig {
         const std::string SERVER_RESPONSE_TIMEOUT_MSEC = "server_response_timeout_msec";
         const std::string MODEL_PATH = "model_path";
         const std::string TTS_ENGINE = "tts_engine";
-        const std::string SERVER_TYPE = "server_type";
         const std::string ACCESS_TOKEN = NUGU_CONFIG_KEY_TOKEN;
         const std::string USER_AGENT = NUGU_CONFIG_KEY_USER_AGENT;
         const std::string GATEWAY_REGISTRY_DNS = NUGU_CONFIG_KEY_GATEWAY_REGISTRY_DNS;
     }
 
     const NuguConfigType getDefaultValues();
-    const std::string getGatewayRegistryDns(std::string& server_type);
 }
 
 } // NuguInterface

--- a/interface/nugu_client_impl.cc
+++ b/interface/nugu_client_impl.cc
@@ -241,13 +241,13 @@ INetworkManager* NuguClientImpl::getNetworkManager()
 
 void NuguClientImpl::readEnviromentVariables()
 {
-    std::string server_type;
+    char* registry_override;
 
-    server_type = getenv("NUGU_SERVER_TYPE");
-    if (server_type.size()) {
-        config_env_map[NuguConfig::Key::SERVER_TYPE] = server_type;
-        config_env_map[NuguConfig::Key::GATEWAY_REGISTRY_DNS] = NuguConfig::getGatewayRegistryDns(server_type);
-    }
+    registry_override = getenv("NUGU_REGISTRY_SERVER");
+    if (!registry_override)
+        return;
+
+    config_env_map[NuguConfig::Key::GATEWAY_REGISTRY_DNS] = registry_override;
 }
 
 } // NuguClientKit

--- a/interface/nugu_configuration.cc
+++ b/interface/nugu_configuration.cc
@@ -33,49 +33,15 @@ namespace NuguConfig {
             { Key::SERVER_RESPONSE_TIMEOUT_MSEC, "10000" },
             { Key::MODEL_PATH, "./" },
             { Key::TTS_ENGINE, "skt" },
-            { Key::SERVER_TYPE, "PRD" },
             { Key::ACCESS_TOKEN, "" },
             { Key::USER_AGENT, NUGU_USERAGENT },
-            { Key::GATEWAY_REGISTRY_DNS, "reg-http.sktnugu.com" }
+            { Key::GATEWAY_REGISTRY_DNS, "https://reg-http.sktnugu.com" }
         };
-
-        std::string toChangeCase(const std::string& src_string, bool is_tolower = false)
-        {
-            if (src_string.empty())
-                return src_string;
-
-            std::string changed_string;
-            changed_string.resize(src_string.size());
-            std::transform(src_string.begin(), src_string.end(), changed_string.begin(), is_tolower ? tolower : toupper);
-
-            return changed_string;
-        }
-
-        bool isEqualString(std::string str1, std::string str2)
-        {
-            if (str1.empty() || str2.empty() || str1.size() != str2.size())
-                return false;
-
-            return std::equal(str1.begin(), str1.end(), str2.begin(),
-                [](const char& a, const char& b) {
-                    return (std::tolower(a) == std::tolower(b));
-                });
-        }
     }
 
     const NuguConfigType getDefaultValues()
     {
         return DEFAULT_VALUES;
-    }
-
-    const std::string getGatewayRegistryDns(std::string& server_type)
-    {
-        std::string dns = DEFAULT_VALUES[Key::GATEWAY_REGISTRY_DNS];
-
-        if (!isEqualString(server_type, DEFAULT_VALUES[Key::SERVER_TYPE]))
-            return dns.insert(0, toChangeCase(server_type, true).append("-"));
-
-        return dns;
     }
 }
 

--- a/src/http2/gateway_registry.cc
+++ b/src/http2/gateway_registry.cc
@@ -26,7 +26,7 @@
 #include "http2_network.h"
 #include "http2_request.h"
 
-#define GATEWAY_REGISTRY_URL_FORMAT "https://%s/v1/policies?protocol=H2"
+#define GATEWAY_REGISTRY_URL_FORMAT "%s/v1/policies?protocol=H2"
 
 struct _gateway_registry {
     char* body;

--- a/src/http2/http2_request.c
+++ b/src/http2/http2_request.c
@@ -321,6 +321,12 @@ int http2_request_set_url(HTTP2Request *req, const char *url)
 
 	curl_easy_setopt(req->easy, CURLOPT_URL, url);
 
+	if (strncmp(url, "http://", 7) == 0) {
+		nugu_dbg("use HTTP/2 over clean TCP");
+		curl_easy_setopt(req->easy, CURLOPT_HTTP_VERSION,
+				 CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE);
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
Because of server policy changes, server_type is no longer required. So
deleted this key and modified the full registry URL to be configurable
instead.
