### PR TITLE
update handling display context

### DIFF
--- a/examples/standalone/audio_player_listener.cc
+++ b/examples/standalone/audio_player_listener.cc
@@ -21,18 +21,24 @@ void AudioPlayerListener::renderDisplay(const std::string& type, const std::stri
 {
     nugu_info("got received to render display template");
 }
-void AudioPlayerListener::clearDisplay()
+
+bool AudioPlayerListener::clearDisplay(bool unconditionally)
 {
     nugu_info("got received to clear display template");
+
+    return true;
 }
+
 void AudioPlayerListener::mediaStateChanged(AudioPlayerState state)
 {
     nugu_info("%s - %d", __FUNCTION__, (int)state);
 }
+
 void AudioPlayerListener::durationChanged(int duration)
 {
     nugu_info("%s - %d", __FUNCTION__, duration);
 }
+
 void AudioPlayerListener::positionChanged(int position)
 {
     nugu_info("%s - %d", __FUNCTION__, position);

--- a/examples/standalone/audio_player_listener.hh
+++ b/examples/standalone/audio_player_listener.hh
@@ -25,7 +25,7 @@ class AudioPlayerListener : public IAudioPlayerListener {
 public:
     virtual ~AudioPlayerListener() = default;
     void renderDisplay(const std::string& type, const std::string& json) override;
-    void clearDisplay() override;
+    bool clearDisplay(bool unconditionally) override;
     void mediaStateChanged(AudioPlayerState state) override;
     void durationChanged(int duration) override;
     void positionChanged(int position) override;

--- a/examples/standalone/display_listener.cc
+++ b/examples/standalone/display_listener.cc
@@ -24,7 +24,17 @@ void DisplayListener::renderDisplay(const std::string& type, const std::string& 
     nugu_info("got received to render display template");
 }
 
-void DisplayListener::clearDisplay()
+bool DisplayListener::clearDisplay(bool unconditionally)
 {
     nugu_info("got received to clear display template");
+
+    // clear display unconditionally
+    if (unconditionally) {
+        return true;
+    }
+
+    // It need to decide whether clear display immediately or not.
+    // If you decide to clear immediately, return true, or return false
+
+    return false;
 }

--- a/examples/standalone/display_listener.hh
+++ b/examples/standalone/display_listener.hh
@@ -25,7 +25,7 @@ class DisplayListener : public IDisplayListener {
 public:
     virtual ~DisplayListener() = default;
     void renderDisplay(const std::string& type, const std::string& json) override;
-    void clearDisplay() override;
+    bool clearDisplay(bool unconditionally) override;
 };
 
 #endif /* __DISPLAY_LISTENER_H__ */

--- a/include/interface/capability/audio_player_interface.hh
+++ b/include/interface/capability/audio_player_interface.hh
@@ -67,9 +67,11 @@ public:
 
     /**
      * @brief The SDK will ask you to delete the rendered display on the display according to the service context maintenance policy.
+     * @param[in] unconditionally whether clear display unconditionally or not
+     * @return true if display is cleared
      * @see IDisplayListener::clearDisplay()
      */
-    virtual void clearDisplay() = 0;
+    virtual bool clearDisplay(bool unconditionally) = 0;
 
     /**
      * @brief Report this to the user when the state of the audio player changes.

--- a/include/interface/capability/delegation_interface.hh
+++ b/include/interface/capability/delegation_interface.hh
@@ -54,6 +54,7 @@ public:
      * @brief Request context information from the external application.
      * @param[in] ps_id identifier for request play service
      * @param[in] data context information
+     * @return true if request succeed
      */
     virtual bool requestContext(std::string& ps_id, std::string& data) = 0;
 };

--- a/include/interface/capability/display_interface.hh
+++ b/include/interface/capability/display_interface.hh
@@ -54,9 +54,11 @@ public:
 
     /**
      * @brief The SDK will ask you to delete the rendered display on the display according to the service context maintenance policy.
+     * @param[in] unconditionally whether clear display unconditionally or not
+     * @return true if display is cleared
      * @see IAudioPlayerListener::clearDisplay()
      */
-    virtual void clearDisplay() = 0;
+    virtual bool clearDisplay(bool unconditionally) = 0;
 };
 
 /**

--- a/service/capability/audio_player_agent.cc
+++ b/service/capability/audio_player_agent.cc
@@ -611,12 +611,20 @@ void AudioPlayerAgent::onSyncContext(const std::string& ps_id, std::pair<std::st
         aplayer_listener->renderDisplay(render_info.first, render_info.second);
 }
 
-void AudioPlayerAgent::onReleaseContext(const std::string& ps_id)
+bool AudioPlayerAgent::onReleaseContext(const std::string& ps_id, bool unconditionally)
 {
     nugu_dbg("AudioPlayer release context");
 
+    unsigned int no_clear_count = 0;
+
     for (auto aplayer_listener : aplayer_listeners)
-        aplayer_listener->clearDisplay();
+        if (!aplayer_listener->clearDisplay(unconditionally))
+            no_clear_count++;
+
+    if (unconditionally && no_clear_count)
+        nugu_warn("should clear display if unconditionally is true!!");
+
+    return (no_clear_count == 0);
 }
 
 } // NuguCore

--- a/service/capability/audio_player_agent.hh
+++ b/service/capability/audio_player_agent.hh
@@ -86,7 +86,7 @@ public:
 
     // implement IContextManagerListener
     void onSyncContext(const std::string& ps_id, std::pair<std::string, std::string> render_info) override;
-    void onReleaseContext(const std::string& ps_id) override;
+    bool onReleaseContext(const std::string& ps_id, bool unconditionally) override;
 
 private:
     void sendEventCommon(std::string ename);

--- a/service/capability/display_agent.cc
+++ b/service/capability/display_agent.cc
@@ -105,6 +105,7 @@ void DisplayAgent::displayRendered(const std::string& token)
 void DisplayAgent::displayCleared()
 {
     cur_token = "";
+    playsync_manager->clearPendingContext(ps_id);
 }
 
 void DisplayAgent::elementSelected(const std::string& item_token)
@@ -133,12 +134,12 @@ void DisplayAgent::onSyncContext(const std::string& ps_id, std::pair<std::string
     if (display_listener)
         display_listener->renderDisplay(render_info.first, render_info.second);
 }
-void DisplayAgent::onReleaseContext(const std::string& ps_id)
+
+bool DisplayAgent::onReleaseContext(const std::string& ps_id, bool unconditionally)
 {
     nugu_dbg("Display release context");
 
-    if (display_listener)
-        display_listener->clearDisplay();
+    return display_listener ? display_listener->clearDisplay(unconditionally) : true;
 }
 
 } // NuguCore

--- a/service/capability/display_agent.hh
+++ b/service/capability/display_agent.hh
@@ -41,7 +41,7 @@ public:
 
     // implement IContextManagerListener
     void onSyncContext(const std::string& ps_id, std::pair<std::string, std::string> render_info) override;
-    void onReleaseContext(const std::string& ps_id) override;
+    bool onReleaseContext(const std::string& ps_id, bool unconditionally) override;
 
 private:
     void sendEventElementSelected(const std::string& item_token);

--- a/service/playsync_manager.hh
+++ b/service/playsync_manager.hh
@@ -34,7 +34,7 @@ class IPlaySyncManagerListener {
 public:
     virtual ~IPlaySyncManagerListener() = default;
     virtual void onSyncContext(const std::string& ps_id, std::pair<std::string, std::string> render_info) = 0;
-    virtual void onReleaseContext(const std::string& ps_id) = 0;
+    virtual bool onReleaseContext(const std::string& ps_id, bool unconditionally) = 0;
 };
 
 class PlaySyncManager {
@@ -53,7 +53,8 @@ public:
 
     void addContext(const std::string& ps_id, CapabilityType cap_type);
     void addContext(const std::string& ps_id, CapabilityType cap_type, DisplayRenderer renderer);
-    void removeContext(std::string ps_id, CapabilityType cap_type, bool immediately = false);
+    void removeContext(std::string ps_id, CapabilityType cap_type, bool immediately = true);
+    void clearPendingContext(std::string ps_id);
     std::vector<std::string> getAllPlayStackItems();
     std::string getPlayStackItem(CapabilityType cap_type);
 
@@ -65,7 +66,7 @@ private:
     void addStackElement(std::string ps_id, CapabilityType cap_type);
     bool removeStackElement(std::string ps_id, CapabilityType cap_type);
     void addRenderer(std::string ps_id, DisplayRenderer& renderer);
-    void removeRenderer(std::string ps_id);
+    bool removeRenderer(std::string ps_id, bool unconditionally = true);
     void setTimerInterval(const std::string& ps_id);
 
     static const std::map<std::string, long> DURATION_MAP;
@@ -76,6 +77,7 @@ private:
     using TimerCallbackParam = struct {
         PlaySyncManager* instance;
         std::string ps_id;
+        bool immediately;
         std::function<void()> callback; // temp : for holding function for stack log
     };
 


### PR DESCRIPTION
It change handling display context which is cleared
after checking user application's decision.

If user decided to clear immediately, display context is
cleared in check time. If not, you has to clear manually.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>