### PR TITLE
Update creating CapabilityAgent Instance Policy

### DIFF
--- a/interface/nugu_client_impl.cc
+++ b/interface/nugu_client_impl.cc
@@ -131,34 +131,40 @@ int NuguClientImpl::create(void)
 
 int NuguClientImpl::createCapabilities(void)
 {
-    // [description]
-    // icapability_map[CAPBILITY].first : ICapabilityInterface instance
-    // icapability_map[CAPBILITY].second : ICapabilityListener instance
-
+    /*
+     * [description]
+     *  - CAPBILITY.first : CapabilityType
+     *  - CAPBILITY.second : whether agent is required
+     *  - icapability_map[CAPBILITY.first].first : ICapabilityInterface instance
+     *  - icapability_map[CAPBILITY.first].second : ICapabilityListener instance
+     */
     for (auto const& CAPBILITY : CapabilityCreator::CAPABILITY_LIST) {
-        if (icapability_map.find(CAPBILITY) == icapability_map.end() || !icapability_map[CAPBILITY].first) {
+        // if user didn't add and it's not a required agent, skip to create
+        if (icapability_map.find(CAPBILITY.first) == icapability_map.end() && !CAPBILITY.second)
+            continue;
+
+        if (!icapability_map[CAPBILITY.first].first)
             try {
-                icapability_map[CAPBILITY].first = CapabilityCreator::createCapability(CAPBILITY);
+                icapability_map[CAPBILITY.first].first = CapabilityCreator::createCapability(CAPBILITY.first);
             } catch (std::exception& exp) {
                 nugu_error(exp.what());
             }
-        }
 
-        if (icapability_map[CAPBILITY].first) {
+        if (icapability_map[CAPBILITY.first].first) {
             // add general observer
             if (listener)
-                icapability_map[CAPBILITY].first->registerObserver(listener);
+                icapability_map[CAPBILITY.first].first->registerObserver(listener);
 
             // set capability listener & handler each other
-            if (icapability_map[CAPBILITY].second) {
-                icapability_map[CAPBILITY].first->setCapabilityListener(icapability_map[CAPBILITY].second);
-                icapability_map[CAPBILITY].second->registerCapabilityHandler(dynamic_cast<ICapabilityHandler*>(icapability_map[CAPBILITY].first));
+            if (icapability_map[CAPBILITY.first].second) {
+                icapability_map[CAPBILITY.first].first->setCapabilityListener(icapability_map[CAPBILITY.first].second);
+                icapability_map[CAPBILITY.first].second->registerCapabilityHandler(dynamic_cast<ICapabilityHandler*>(icapability_map[CAPBILITY.first].first));
             }
 
-            std::string cname = icapability_map[CAPBILITY].first->getTypeName(CAPBILITY);
+            std::string cname = icapability_map[CAPBILITY.first].first->getTypeName(CAPBILITY.first);
 
             if (!cname.empty())
-                CapabilityManagerHelper::addCapability(cname, icapability_map[CAPBILITY].first);
+                CapabilityManagerHelper::addCapability(cname, icapability_map[CAPBILITY.first].first);
         }
     }
 

--- a/service/capability_creator.cc
+++ b/service/capability_creator.cc
@@ -30,15 +30,15 @@
 
 namespace NuguCore {
 
-const std::list<CapabilityType> CapabilityCreator::CAPABILITY_LIST {
-    CapabilityType::ASR,
-    CapabilityType::TTS,
-    CapabilityType::AudioPlayer,
-    CapabilityType::System,
-    CapabilityType::Display,
-    CapabilityType::Extension,
-    CapabilityType::Text,
-    CapabilityType::Delegation
+const std::list<std::pair<CapabilityType, bool>> CapabilityCreator::CAPABILITY_LIST {
+    std::make_pair(CapabilityType::ASR, true),
+    std::make_pair(CapabilityType::TTS, true),
+    std::make_pair(CapabilityType::AudioPlayer, true),
+    std::make_pair(CapabilityType::System, true),
+    std::make_pair(CapabilityType::Display, false),
+    std::make_pair(CapabilityType::Extension, false),
+    std::make_pair(CapabilityType::Text, false),
+    std::make_pair(CapabilityType::Delegation, false)
 };
 
 ICapabilityInterface* CapabilityCreator::createCapability(CapabilityType ctype)

--- a/service/capability_creator.hh
+++ b/service/capability_creator.hh
@@ -20,8 +20,8 @@
 #include <list>
 
 #include <interface/capability/capability_interface.hh>
-#include <interface/wakeup_interface.hh>
 #include <interface/network_manager_interface.hh>
+#include <interface/wakeup_interface.hh>
 
 namespace NuguCore {
 
@@ -30,7 +30,7 @@ using namespace NuguInterface;
 class CapabilityCreator {
 public:
     virtual ~CapabilityCreator() = default;
-    static const std::list<CapabilityType> CAPABILITY_LIST;
+    static const std::list<std::pair<CapabilityType, bool>> CAPABILITY_LIST;
     static ICapabilityInterface* createCapability(CapabilityType ctype);
     static IWakeupHandler* createWakeupHandler();
     static INetworkManager* createNetworkManager();


### PR DESCRIPTION
It change policy about creating Capability Agent instance.
It defined required agents for operating SDK and
if user app did not add that agents, sdk create it automatically.

It needs to define what required agents are.
It currently, ASR,TTS,AudioPlayer,System Agents are included.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>