### PR TITLE
Add metadata for multi display handling

### DIFF
--- a/examples/standalone/audio_player_listener.cc
+++ b/examples/standalone/audio_player_listener.cc
@@ -17,29 +17,54 @@
 #include "audio_player_listener.hh"
 #include "nugu_log.h"
 
-void AudioPlayerListener::renderDisplay(const std::string& type, const std::string& json)
+void AudioPlayerListener::renderDisplay(const std::string& id, const std::string& type, const std::string& json, const std::string& dialog_id)
 {
-    nugu_info("got received to render display template");
+    std::cout << "[AudioPlayer] render display template - id: " << id << ", type: " << type << ", dialog_id: " << dialog_id << std::endl;
 }
 
-bool AudioPlayerListener::clearDisplay(bool unconditionally)
+bool AudioPlayerListener::clearDisplay(const std::string& id, bool unconditionally)
 {
-    nugu_info("got received to clear display template");
+    std::cout << "[AudioPlayer] clear display template - id: " << id << ", unconditionally: " << unconditionally << std::endl;
 
-    return true;
+    // clear display unconditionally
+    if (unconditionally) {
+        return true;
+    }
+
+    // It need to decide whether clear display immediately or not.
+    // If you decide to clear immediately, return true, or return false
+
+    return false;
 }
 
 void AudioPlayerListener::mediaStateChanged(AudioPlayerState state)
 {
-    nugu_info("%s - %d", __FUNCTION__, (int)state);
+    std::cout << "[AudioPlayer] ";
+    switch(state) {
+        case AudioPlayerState::IDLE:
+        std::cout << "IDLE\n";
+        break;
+        case AudioPlayerState::PLAYING:
+        std::cout << "PLAYING\n";
+        break;
+        case AudioPlayerState::STOPPED:
+        std::cout << "STOPPED\n";
+        break;
+        case AudioPlayerState::PAUSED:
+        std::cout << "PAUSED\n";
+        break;
+        case AudioPlayerState::FINISHED:
+        std::cout << "FINISHED\n";
+        break;
+    }
 }
 
 void AudioPlayerListener::durationChanged(int duration)
 {
-    nugu_info("%s - %d", __FUNCTION__, duration);
+    nugu_info("[AudioPlayer] - %d", duration);
 }
 
 void AudioPlayerListener::positionChanged(int position)
 {
-    nugu_info("%s - %d", __FUNCTION__, position);
+    nugu_info("[AudioPlayer] - %d", position);
 }

--- a/examples/standalone/audio_player_listener.hh
+++ b/examples/standalone/audio_player_listener.hh
@@ -24,8 +24,8 @@ using namespace NuguInterface;
 class AudioPlayerListener : public IAudioPlayerListener {
 public:
     virtual ~AudioPlayerListener() = default;
-    void renderDisplay(const std::string& type, const std::string& json) override;
-    bool clearDisplay(bool unconditionally) override;
+    void renderDisplay(const std::string& id, const std::string& type, const std::string& json, const std::string& dialog_id) override;
+    bool clearDisplay(const std::string& id, bool unconditionally) override;
     void mediaStateChanged(AudioPlayerState state) override;
     void durationChanged(int duration) override;
     void positionChanged(int position) override;

--- a/examples/standalone/display_listener.cc
+++ b/examples/standalone/display_listener.cc
@@ -19,14 +19,14 @@
 #include "display_listener.hh"
 #include "nugu_log.h"
 
-void DisplayListener::renderDisplay(const std::string& type, const std::string& json)
+void DisplayListener::renderDisplay(const std::string& id, const std::string& type, const std::string& json, const std::string& dialog_id)
 {
-    nugu_info("got received to render display template");
+    std::cout << "[Display] render display template - id: " << id << ", type: " << type << ", dialog_id: " << dialog_id << std::endl;
 }
 
-bool DisplayListener::clearDisplay(bool unconditionally)
+bool DisplayListener::clearDisplay(const std::string& id, bool unconditionally)
 {
-    nugu_info("got received to clear display template");
+    std::cout << "[Display] clear display template - id: " << id << ", unconditionally: " << unconditionally << std::endl;
 
     // clear display unconditionally
     if (unconditionally) {

--- a/examples/standalone/display_listener.hh
+++ b/examples/standalone/display_listener.hh
@@ -24,8 +24,8 @@ using namespace NuguInterface;
 class DisplayListener : public IDisplayListener {
 public:
     virtual ~DisplayListener() = default;
-    void renderDisplay(const std::string& type, const std::string& json) override;
-    bool clearDisplay(bool unconditionally) override;
+    void renderDisplay(const std::string& id, const std::string& type, const std::string& json, const std::string& dialog_id) override;
+    bool clearDisplay(const std::string& id, bool unconditionally) override;
 };
 
 #endif /* __DISPLAY_LISTENER_H__ */

--- a/examples/standalone/extension_listener.cc
+++ b/examples/standalone/extension_listener.cc
@@ -15,6 +15,7 @@
  */
 
 #include "extension_listener.hh"
+#include "nugu_log.h"
 #include <iostream>
 #include <string.h>
 
@@ -22,18 +23,13 @@ ExtensionResult ExtensionListener::receiveAction(std::string& data)
 {
     // TODO : need to handle argument and define method to execute related 3rd party application
 
-    std::cout << "=======================================================\n";
-    std::cout << "Extension data: " << data.c_str() << "\n";
-    std::cout << "=======================================================\n";
+    std::cout << "[Extension] receive action - " << data << std::endl;
 
     return ExtensionResult::SUCCEEDED;
 }
 
 void ExtensionListener::requestContext(std::string& data)
 {
-    std::cout << "=======================================================\n";
-    std::cout << "Extension data: \"\"\n";
-    std::cout << "=======================================================\n";
-
+    nugu_info("[Extension] request context");
     data = "";
 }

--- a/examples/standalone/nugu_sample.cc
+++ b/examples/standalone/nugu_sample.cc
@@ -218,7 +218,7 @@ public:
             break;
         case DIALOG_REQUEST_ID:
             if (data)
-                std::cout << "DIALOG_REQUEST_ID = " << (const char*)data << std::endl;
+                nugu_info("DIALOG_REQUEST_ID = %s", data);
             break;
         }
     }

--- a/examples/standalone/tts_listener.cc
+++ b/examples/standalone/tts_listener.cc
@@ -18,25 +18,26 @@
 
 #include "tts_listener.hh"
 
-void TTSListener::onTTSState(TTSState state)
+void TTSListener::onTTSState(TTSState state, const std::string& dialog_id)
 {
-    std::cout << "[TTS] ";
+    std::cout << "[TTS] - ";
 
     switch (state) {
     case TTSState::TTS_SPEECH_START:
-        std::cout << "tts playing...\n";
+        std::cout << "tts playing...";
         break;
 
     case TTSState::TTS_SPEECH_FINISH:
-        std::cout << "tts playing finished\n";
+        std::cout << "tts playing finished";
         break;
     }
+    std::cout << ", dialog_id: " << dialog_id << std::endl;
 }
 
-void TTSListener::onTTSText(const std::string& text)
+void TTSListener::onTTSText(const std::string& text, const std::string& dialog_id)
 {
-    std::cout << "[TTS] text : ";
-    std::cout << "\033[1;36m" << extractText(text) << "\033[0m" << std::endl;
+    std::cout << "[TTS] - text : ";
+    std::cout << "\033[1;36m" << extractText(text) << "\033[0m, dialog_id: " << dialog_id << std::endl;
 }
 
 std::string TTSListener::extractText(std::string raw_text)

--- a/examples/standalone/tts_listener.hh
+++ b/examples/standalone/tts_listener.hh
@@ -26,8 +26,8 @@ using namespace NuguInterface;
 class TTSListener : public ITTSListener {
 public:
     virtual ~TTSListener() = default;
-    void onTTSState(TTSState state) override;
-    void onTTSText(const std::string& text) override;
+    void onTTSState(TTSState state, const std::string& dialog_id) override;
+    void onTTSText(const std::string& text, const std::string& dialog_id) override;
 
 private:
     std::string extractText(std::string raw_text);

--- a/include/interface/capability/audio_player_interface.hh
+++ b/include/interface/capability/audio_player_interface.hh
@@ -22,6 +22,7 @@
 #include <string>
 
 #include <interface/capability/capability_interface.hh>
+#include <interface/capability/display_interface.hh>
 #include <interface/media_player_interface.hh>
 
 namespace NuguInterface {
@@ -53,25 +54,9 @@ enum class AudioPlayerState {
  * @brief audioplayer listener interface
  * @see IAudioPlayerHandler
  */
-class IAudioPlayerListener : public ICapabilityListener {
+class IAudioPlayerListener : public IDisplayListener {
 public:
     virtual ~IAudioPlayerListener() = default;
-
-    /**
-     * @brief Request rendering by passing metadata so that the device with the display can draw on the screen.
-     * @param[in] type display template type
-     * @param[in] json template in json format for display
-     * @see IDisplayListener::renderDisplay()
-     */
-    virtual void renderDisplay(const std::string& type, const std::string& json) = 0;
-
-    /**
-     * @brief The SDK will ask you to delete the rendered display on the display according to the service context maintenance policy.
-     * @param[in] unconditionally whether clear display unconditionally or not
-     * @return true if display is cleared
-     * @see IDisplayListener::clearDisplay()
-     */
-    virtual bool clearDisplay(bool unconditionally) = 0;
 
     /**
      * @brief Report this to the user when the state of the audio player changes.
@@ -96,7 +81,7 @@ public:
  * @brief audioplayer handler interface
  * @see IAudioPlayerListener
  */
-class IAudioPlayerHandler : public ICapabilityHandler {
+class IAudioPlayerHandler : public IDisplayHandler {
 public:
     virtual ~IAudioPlayerHandler() = default;
 

--- a/include/interface/capability/display_interface.hh
+++ b/include/interface/capability/display_interface.hh
@@ -46,19 +46,22 @@ public:
     virtual ~IDisplayListener() = default;
     /**
      * @brief Request rendering by passing metadata so that the device with the display can draw on the screen.
+     * @param[in] id display template id
      * @param[in] type display template type
      * @param[in] json template in json format for display
+     * @param[in] dialog_id dialog request id
      * @see IAudioPlayerListener::renderDisplay()
      */
-    virtual void renderDisplay(const std::string& type, const std::string& json) = 0;
+    virtual void renderDisplay(const std::string& id, const std::string& type, const std::string& json, const std::string& dialog_id) = 0;
 
     /**
      * @brief The SDK will ask you to delete the rendered display on the display according to the service context maintenance policy.
      * @param[in] unconditionally whether clear display unconditionally or not
+     * @param[in] id display template id
      * @return true if display is cleared
      * @see IAudioPlayerListener::clearDisplay()
      */
-    virtual bool clearDisplay(bool unconditionally) = 0;
+    virtual bool clearDisplay(const std::string& id, bool unconditionally) = 0;
 };
 
 /**
@@ -70,21 +73,35 @@ public:
     virtual ~IDisplayHandler() = default;
 
     /**
-     * @brief The user reports that the display was rendered with the parsed token.
-     * @param[in] token parsed token from metadata
+     * @brief The user reports that the display was rendered.
+     * @param[in] id display template id
      */
-    virtual void displayRendered(const std::string& token) = 0;
+    virtual void displayRendered(const std::string& id) = 0;
 
     /**
      * @brief The user reports that the display is cleared.
+     * @param[in] id display template id
      */
-    virtual void displayCleared() = 0;
+    virtual void displayCleared(const std::string& id) = 0;
 
     /**
      * @brief The user informs the selected item of the list and reports the token information of the item.
+     * @param[in] id display template id
      * @param[in] item_token parsed token from metadata
      */
-    virtual void elementSelected(const std::string& item_token) = 0;
+    virtual void elementSelected(const std::string& id, const std::string& item_token) = 0;
+
+    /**
+     * @brief Set the Listener object
+     * @param[in] listener listener object
+     */
+    virtual void setListener(IDisplayListener* listener) = 0;
+
+    /**
+     * @brief Remove the Listener object
+     * @param[in] listener listener object
+     */
+    virtual void removeListener(IDisplayListener* listener) = 0;
 };
 
 /**

--- a/include/interface/capability/tts_interface.hh
+++ b/include/interface/capability/tts_interface.hh
@@ -51,15 +51,17 @@ public:
     /**
      * @brief Report changes in the speech state to the user.
      * @param[in] state tts state
+     * @param[in] dialog_id dialog request id
      * @see ITTSHandler::requestTTS()
      */
-    virtual void onTTSState(TTSState state) = 0;
+    virtual void onTTSState(TTSState state, const std::string& dialog_id) = 0;
 
     /**
      * @brief Report the speech sentence to the User.
      * @param[in] text sentense
+     * @param[in] dialog_id dialog request id
      */
-    virtual void onTTSText(const std::string& text) = 0;
+    virtual void onTTSText(const std::string& text, const std::string& dialog_id) = 0;
 };
 
 /**

--- a/service/capability/audio_player_agent.hh
+++ b/service/capability/audio_player_agent.hh
@@ -19,6 +19,7 @@
 
 #include <core/nugu_focus.h>
 #include <interface/capability/audio_player_interface.hh>
+#include <interface/capability/display_interface.hh>
 #include <interface/media_player_interface.hh>
 
 #include "capability.hh"
@@ -53,6 +54,12 @@ public:
     void setCapabilityListener(ICapabilityListener* clistener) override;
 
     // implement handler
+    void displayRendered(const std::string& id) override;
+    void displayCleared(const std::string& id) override;
+    void elementSelected(const std::string& id, const std::string& item_token) override;
+    void setListener(IDisplayListener* listener) override;
+    void removeListener(IDisplayListener* listener) override;
+
     void addListener(IAudioPlayerListener* listener) override;
     void removeListener(IAudioPlayerListener* listener) override;
     void play() override;
@@ -85,15 +92,15 @@ public:
     void muteChanged(int mute);
 
     // implement IContextManagerListener
-    void onSyncContext(const std::string& ps_id, std::pair<std::string, std::string> render_info) override;
-    bool onReleaseContext(const std::string& ps_id, bool unconditionally) override;
+    void onSyncDisplayContext(const std::string& id) override;
+    bool onReleaseDisplayContext(const std::string& id, bool unconditionally) override;
 
 private:
     void sendEventCommon(std::string ename);
 
     AudioPlayerState audioPlayerState();
 
-    void parsingPlay(const char* message);
+    void parsingPlay(const char* message, NuguDirective* ndir);
     void parsingPause(const char* message);
     void parsingStop(const char* message);
 
@@ -114,6 +121,8 @@ private:
     std::string cur_token;
     bool is_finished;
     std::vector<IAudioPlayerListener*> aplayer_listeners;
+    IDisplayListener* display_listener;
+    std::map<std::string, PlaySyncManager::DisplayRenderInfo*> render_info;
 };
 
 } // NuguCore

--- a/service/capability/display_agent.hh
+++ b/service/capability/display_agent.hh
@@ -25,7 +25,9 @@ namespace NuguCore {
 
 using namespace NuguInterface;
 
-class DisplayAgent : public Capability, public IDisplayHandler, public IPlaySyncManagerListener {
+class DisplayAgent : public Capability,
+                     public IDisplayHandler,
+                     public IPlaySyncManagerListener {
 public:
     DisplayAgent();
     virtual ~DisplayAgent();
@@ -35,19 +37,22 @@ public:
     void setCapabilityListener(ICapabilityListener* clistener) override;
 
     // implement handler
-    void displayRendered(const std::string& token) override;
-    void displayCleared() override;
-    void elementSelected(const std::string& item_token) override;
+    void displayRendered(const std::string& id) override;
+    void displayCleared(const std::string& id) override;
+    void elementSelected(const std::string& id, const std::string& item_token) override;
+    void setListener(IDisplayListener* listener) override;
+    void removeListener(IDisplayListener* listener) override;
 
     // implement IContextManagerListener
-    void onSyncContext(const std::string& ps_id, std::pair<std::string, std::string> render_info) override;
-    bool onReleaseContext(const std::string& ps_id, bool unconditionally) override;
+    void onSyncDisplayContext(const std::string& id) override;
+    bool onReleaseDisplayContext(const std::string& id, bool unconditionally) override;
 
 private:
     void sendEventElementSelected(const std::string& item_token);
 
     IDisplayListener* display_listener;
-    std::string ps_id;
+    std::map<std::string, PlaySyncManager::DisplayRenderInfo*> render_info;
+    std::string cur_ps_id;
     std::string cur_token;
 };
 

--- a/service/capability/tts_agent.hh
+++ b/service/capability/tts_agent.hh
@@ -75,6 +75,7 @@ private:
     NuguPcm* pcm;
     NuguDecoder* decoder;
 
+    std::string dialog_id;
     std::string ps_id;
     ITTSListener* tts_listener;
 };

--- a/service/playsync_manager.cc
+++ b/service/playsync_manager.cc
@@ -224,21 +224,22 @@ void PlaySyncManager::addRenderer(std::string ps_id, DisplayRenderer& renderer)
     }
 
     renderer_map[ps_id] = renderer;
-    renderer.listener->onSyncContext(ps_id, renderer.render_info);
+    renderer.listener->onSyncDisplayContext(renderer.display_id);
 }
 
 bool PlaySyncManager::removeRenderer(std::string ps_id, bool unconditionally)
 {
-    if (renderer_map.find(ps_id) != renderer_map.end()) {
-        bool result = renderer_map[ps_id].listener->onReleaseContext(ps_id, unconditionally) || unconditionally;
+    if (renderer_map.find(ps_id) == renderer_map.end())
+        return true;
 
-        if (result)
-            renderer_map.erase(ps_id);
+    auto renderer = renderer_map[ps_id];
+    bool result = renderer.listener->onReleaseDisplayContext(renderer.display_id, unconditionally)
+        || unconditionally;
 
-        return result;
-    }
+    if (result)
+        renderer_map.erase(ps_id);
 
-    return true;
+    return result;
 }
 
 void PlaySyncManager::setTimerInterval(const std::string& ps_id)

--- a/service/playsync_manager.hh
+++ b/service/playsync_manager.hh
@@ -33,17 +33,25 @@ using namespace NuguInterface;
 class IPlaySyncManagerListener {
 public:
     virtual ~IPlaySyncManagerListener() = default;
-    virtual void onSyncContext(const std::string& ps_id, std::pair<std::string, std::string> render_info) = 0;
-    virtual bool onReleaseContext(const std::string& ps_id, bool unconditionally) = 0;
+    virtual void onSyncDisplayContext(const std::string& id) = 0;
+    virtual bool onReleaseDisplayContext(const std::string& id, bool unconditionally) = 0;
 };
 
 class PlaySyncManager {
 public:
+    using DisplayRenderInfo = struct {
+        std::string id;
+        std::string type;
+        std::string payload;
+        std::string dialog_id;
+        std::string ps_id;
+        std::string token;
+    };
     using DisplayRenderer = struct {
         IPlaySyncManagerListener* listener;
         CapabilityType cap_type;
         std::string duration;
-        std::pair<std::string, std::string> render_info;
+        std::string display_id;
         bool only_rendering = false;
     };
 


### PR DESCRIPTION
The SDK provides the following additional information to provide
the ability to integrate and manage screens and tts in your application.

```
// added dialog_id to the following functions:
ITTSListener::onTTSState(TTSState state,
			const std::string& dialog_id)
ITTSListener::onTTSText(const std::string& text,
			const std::string& dialog_id)
IDisplayListener::renderDisplay(const std::string& id,
				const std::string& type,
				const std::string& json,
				const std::string& dialog_id)
```

The display interface is separated from the audio player interface.

Signed-off-by: Hyojoong Kim <hyojoong.kim@sk.com>