### PR TITLE
add permission interface

### DIFF
--- a/examples/standalone/nugu_sample.cc
+++ b/examples/standalone/nugu_sample.cc
@@ -30,6 +30,7 @@
 #include "extension_listener.hh"
 #include "nugu_client.hh"
 #include "nugu_log.h"
+#include "permission_listener.hh"
 #include "speech_operator.hh"
 #include "system_listener.hh"
 #include "text_listener.hh"
@@ -80,6 +81,7 @@ std::unique_ptr<ISystemListener> system_listener;
 std::unique_ptr<ITextListener> text_listener;
 std::unique_ptr<IExtensionListener> extension_listener;
 std::unique_ptr<IDelegationListener> delegation_listener;
+std::unique_ptr<IPermissionListener> permission_listener;
 ITextHandler* text_handler;
 IDisplayHandler* display_handler;
 IAudioPlayerHandler* aplayer_handler;
@@ -275,6 +277,7 @@ void registerCapabilities()
     text_listener = std::unique_ptr<ITextListener>(new TextListener());
     extension_listener = std::unique_ptr<IExtensionListener>(new ExtensionListener());
     delegation_listener = std::unique_ptr<IDelegationListener>(new DelegationListener());
+    permission_listener = std::unique_ptr<IPermissionListener>(new PermissionListener());
 
     // create capability instance. It's possible to set user customized capability using below builder
     nugu_client->getCapabilityBuilder()
@@ -286,6 +289,7 @@ void registerCapabilities()
         ->add(CapabilityType::Text, text_listener.get())
         ->add(CapabilityType::Extension, extension_listener.get())
         ->add(CapabilityType::Delegation, delegation_listener.get())
+        ->add(CapabilityType::Permission, permission_listener.get())
         ->construct();
 }
 

--- a/examples/standalone/permission_listener.cc
+++ b/examples/standalone/permission_listener.cc
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "permission_listener.hh"
+
+void PermissionListener::requestContext(std::list<PermissionState>& permission_list)
+{
+    permission_list.push_back(location_permission);
+}
+
+void PermissionListener::requestPermission(const std::set<Permission::Type>& permission_set)
+{
+    // TODO: It has to do permission acquirement process in application.
+
+    for (const auto& permission_type : permission_set) {
+        switch (permission_type) {
+        case Permission::Type::LOCATION:
+            location_permission.state = Permission::State::GRANTED;
+            break;
+        }
+    }
+}

--- a/examples/standalone/permission_listener.hh
+++ b/examples/standalone/permission_listener.hh
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __PERMISSION_LISTENER_H__
+#define __PERMISSION_LISTENER_H__
+
+#include <interface/capability/permission_interface.hh>
+
+using namespace NuguInterface;
+
+class PermissionListener : public IPermissionListener {
+
+public:
+    void requestContext(std::list<PermissionState>& permission_list) override;
+    void requestPermission(const std::set<Permission::Type>& permission_set) override;
+
+private:
+    PermissionState location_permission { Permission::Type::LOCATION, Permission::State::UNDETERMINED };
+};
+
+#endif /* __PERMISSION_LISTENER_H__ */

--- a/include/interface/capability/capability_interface.hh
+++ b/include/interface/capability/capability_interface.hh
@@ -48,7 +48,8 @@ enum class CapabilityType {
     ASR, /**< the type of ASR agent */
     Text, /**< the type of Text agent */
     Extension, /**< the type of Extension agent */
-    Delegation /**< the type of Delegation agent */
+    Delegation, /**< the type of Delegation agent */
+    Permission /**< the type of Permission agent */
 };
 
 /**

--- a/include/interface/capability/permission_interface.hh
+++ b/include/interface/capability/permission_interface.hh
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NUGU_PERMISSION_INTERFACE_H__
+#define __NUGU_PERMISSION_INTERFACE_H__
+
+#include <list>
+#include <map>
+#include <set>
+
+#include <interface/capability/capability_interface.hh>
+
+namespace NuguInterface {
+
+/**
+ * @file permission_interface.hh
+ * @defgroup PermissionInterface PermissionInterface
+ * @ingroup SDKNuguInterface
+ * @brief Permission capability interface
+ *
+ * It is used to handle about permission request. If sdk request permission, user application could grant or deny,
+ * then has to send permission states to sdk.
+ *
+ * @{
+ */
+
+namespace Permission {
+    /**
+    * @brief Permission Type
+    */
+    enum class Type {
+        LOCATION /**< Permission about LOCATION */
+    };
+
+    /**
+    * @brief Permission State
+    */
+    enum class State {
+        UNDETERMINED, /**< Not check whether permission granted */
+        GRANTED, /**< permission granted by user */
+        DENIED, /**< permission denied by user */
+        NOT_SUPPORTED /**< not support such permission */
+    };
+
+    const std::map<Type, std::string> TypeMap {
+        { Type::LOCATION, "LOCATION" }
+    };
+
+    const std::map<State, std::string> StateMap {
+        { State::UNDETERMINED, "UNDETERMINED" },
+        { State::GRANTED, "GRANTED" },
+        { State::DENIED, "DENIED" },
+        { State::NOT_SUPPORTED, "NOT_SUPPORTED" }
+    };
+}
+
+typedef struct {
+    Permission::Type type;
+    Permission::State state;
+} PermissionState;
+
+/**
+ * @brief permission listener interface
+ */
+class IPermissionListener : public ICapabilityListener {
+public:
+    virtual ~IPermissionListener() = default;
+
+    /**
+     * @brief Request context information about permission state from user application.
+     * @param[in] permission_list context information about permission state
+     */
+    virtual void requestContext(std::list<PermissionState>& permission_list) = 0;
+
+    /**
+     * @brief Request required permissions which are needed to specific play service.
+     * @param[in] permission_set required permissions
+     */
+    virtual void requestPermission(const std::set<Permission::Type>& permission_set) = 0;
+};
+
+/**
+ * @}
+ */
+
+} // NuguInterface
+
+#endif /* __NUGU_PERMISSION_INTERFACE_H__ */

--- a/service/capability/capability.cc
+++ b/service/capability/capability.cc
@@ -140,6 +140,9 @@ std::string Capability::getTypeName(CapabilityType type)
     case CapabilityType::Delegation:
         _name = "Delegation";
         break;
+    case CapabilityType::Permission:
+        _name = "Permission";
+        break;
     }
 
     return _name;

--- a/service/capability/permission_agent.cc
+++ b/service/capability/permission_agent.cc
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+#include <string.h>
+
+#include "capability_manager.hh"
+#include "nugu_log.h"
+#include "permission_agent.hh"
+
+namespace NuguCore {
+
+static const std::string capability_version = "1.0";
+
+PermissionAgent::PermissionAgent()
+    : Capability(CapabilityType::Permission, capability_version)
+{
+    // set permission type map which is composed by string key and permission::type value
+    std::transform(Permission::TypeMap.cbegin(), Permission::TypeMap.cend(), std::inserter(permission_type_map, permission_type_map.end()),
+        [](const std::pair<Permission::Type, std::string>& element) {
+            return std::make_pair(element.second, element.first);
+        });
+}
+
+PermissionAgent::~PermissionAgent()
+{
+}
+
+void PermissionAgent::setCapabilityListener(ICapabilityListener* clistener)
+{
+    if (clistener)
+        permission_listener = dynamic_cast<IPermissionListener*>(clistener);
+}
+
+void PermissionAgent::updateInfoForContext(Json::Value& ctx)
+{
+    Json::Value permission;
+    Json::Value permissions = Json::Value(Json::arrayValue);
+
+    permission["version"] = getVersion();
+
+    if (permission_listener) {
+        std::string type;
+        std::string state;
+        std::list<PermissionState> permission_list;
+
+        permission_listener->requestContext(permission_list);
+
+        for (const auto& permission_element : permission_list) {
+            try {
+                type = Permission::TypeMap.at(permission_element.type);
+                state = Permission::StateMap.at(permission_element.state);
+            } catch (std::out_of_range& exception) {
+                nugu_warn("Such permission type or state is not exist.");
+            }
+
+            if (!type.empty() && !state.empty()) {
+                Json::Value item;
+                item[type] = state;
+                permissions.append(item);
+            }
+        }
+    }
+
+    if (!permissions.empty())
+        permission["permissions"] = permissions;
+
+    ctx[getName()] = permission;
+}
+
+void PermissionAgent::processDirective(NuguDirective* ndir)
+{
+    const char* dname = nugu_directive_peek_name(ndir);
+    const char* message = nugu_directive_peek_json(ndir);
+
+    if (!message || !dname) {
+        nugu_error("directive message is not correct");
+        destoryDirective(ndir);
+        return;
+    }
+
+    nugu_dbg("message: %s", message);
+
+    if (!strcmp(dname, "RequestAccess"))
+        parsingRequestAccess(message);
+    else {
+        nugu_warn("%s[%s] is not support %s directive", getName().c_str(), getVersion().c_str(), dname);
+    }
+
+    destoryDirective(ndir);
+}
+
+void PermissionAgent::parsingRequestAccess(const char* message)
+{
+    Json::Value root;
+    Json::Reader reader;
+
+    if (!reader.parse(message, root)) {
+        nugu_error("parsing error");
+        return;
+    }
+
+    Json::Value permissions = root["permissions"];
+    ps_id = root["playServiceId"].asString();
+
+    if (!permissions.isArray() || permissions.empty() || ps_id.size() == 0) {
+        nugu_error("The Manatory datas are insufficient to process");
+        return;
+    }
+
+    std::set<Permission::Type> permission_set;
+
+    for (unsigned int i = 0; i < permissions.size(); i++) {
+        try {
+            permission_set.insert(permission_type_map.at(permissions[i].asString()));
+        } catch (std::out_of_range& exception) {
+            nugu_warn("Such permission type is not exist.");
+        }
+    }
+
+    if (permission_set.empty()) {
+        nugu_error("The Required permission_set is empty or not composed correctly.");
+        return;
+    }
+
+    // It has to handle synchronously
+    if (permission_listener) {
+        permission_listener->requestPermission(permission_set);
+        sendEventRequestAccessCompleted();
+    }
+}
+
+void PermissionAgent::sendEventRequestAccessCompleted()
+{
+    std::string payload = "";
+    Json::Value root = ""; // It defined empty in NDI currently
+    Json::StyledWriter writer;
+
+    payload = writer.write(root);
+
+    sendEvent("RequestAccessCompleted", CapabilityManager::getInstance()->makeAllContextInfoStack(), payload);
+}
+
+} // NuguCore

--- a/service/capability/permission_agent.hh
+++ b/service/capability/permission_agent.hh
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NUGU_PERMISSION_AGENT_H__
+#define __NUGU_PERMISSION_AGENT_H__
+
+#include <interface/capability/permission_interface.hh>
+
+#include "capability.hh"
+
+namespace NuguCore {
+
+using namespace NuguInterface;
+
+class PermissionAgent : public Capability {
+public:
+    PermissionAgent();
+    virtual ~PermissionAgent();
+
+    void setCapabilityListener(ICapabilityListener* clistener) override;
+    void updateInfoForContext(Json::Value& ctx) override;
+    void processDirective(NuguDirective* ndir) override;
+
+private:
+    void parsingRequestAccess(const char* message);
+    void sendEventRequestAccessCompleted();
+
+    IPermissionListener* permission_listener = nullptr;
+    std::map<std::string, Permission::Type> permission_type_map;
+    std::string ps_id = "";
+};
+
+} // NuguCore
+
+#endif /* __NUGU_PERMISSION_AGENT_H__ */

--- a/service/capability_creator.cc
+++ b/service/capability_creator.cc
@@ -22,6 +22,7 @@
 #include "display_agent.hh"
 #include "extension_agent.hh"
 #include "network_manager.hh"
+#include "permission_agent.hh"
 #include "speech_recognizer.hh"
 #include "system_agent.hh"
 #include "text_agent.hh"
@@ -38,7 +39,8 @@ const std::list<std::pair<CapabilityType, bool>> CapabilityCreator::CAPABILITY_L
     std::make_pair(CapabilityType::Display, false),
     std::make_pair(CapabilityType::Extension, false),
     std::make_pair(CapabilityType::Text, false),
-    std::make_pair(CapabilityType::Delegation, false)
+    std::make_pair(CapabilityType::Delegation, false),
+    std::make_pair(CapabilityType::Permission, false)
 };
 
 ICapabilityInterface* CapabilityCreator::createCapability(CapabilityType ctype)
@@ -60,6 +62,8 @@ ICapabilityInterface* CapabilityCreator::createCapability(CapabilityType ctype)
         return new TextAgent();
     case CapabilityType::Delegation:
         return new DelegationAgent();
+    case CapabilityType::Permission:
+        return new PermissionAgent();
     default:
         return nullptr;
     }


### PR DESCRIPTION
It add permission interface and agent for handling
directive and event about permission request.

If you receive RequestAccess directive, process permission
flow in application and update permission state.

Current permission states are included in context.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>