### PR TITLE
apply playStackControl spec

### DIFF
--- a/service/capability/capability.cc
+++ b/service/capability/capability.cc
@@ -161,6 +161,21 @@ std::string Capability::getVersion()
     return version;
 }
 
+std::string Capability::getPlayServiceIdInStackControl(const Json::Value& playstack_control)
+{
+    std::string playstack_ps_id;
+
+    if (!playstack_control.isNull() && !playstack_control.empty()) {
+        std::string playstack_type = playstack_control["type"].asString();
+
+        if (playstack_type.size() > 0 && playstack_type == "PUSH") {
+            playstack_ps_id = playstack_control["playServiceId"].asString();
+        }
+    }
+
+    return playstack_ps_id;
+}
+
 void Capability::destoryDirective(NuguDirective* ndir)
 {
     nugu_dirseq_complete(ndir);

--- a/service/capability/capability.hh
+++ b/service/capability/capability.hh
@@ -64,6 +64,7 @@ public:
     std::string getName() override;
     void setVersion(const std::string& ver);
     std::string getVersion() override;
+    std::string getPlayServiceIdInStackControl(const Json::Value& playstack_control);
 
     void destoryDirective(NuguDirective* ndir);
     void sendEvent(const std::string& name, const std::string& context, const std::string& payload);

--- a/service/capability/tts_agent.cc
+++ b/service/capability/tts_agent.cc
@@ -86,7 +86,7 @@ void TTSAgent::initialize()
     nugu_pcm_set_status_callback(pcm, pcmStatusCallback, this);
     nugu_pcm_set_event_callback(pcm, pcmEventCallback, this);
 
-    nugu_pcm_set_property(pcm, (NuguAudioProperty){ AUDIO_SAMPLE_RATE_22K, AUDIO_FORMAT_S16_LE, 1 });
+    nugu_pcm_set_property(pcm, (NuguAudioProperty) { AUDIO_SAMPLE_RATE_22K, AUDIO_FORMAT_S16_LE, 1 });
 
     CapabilityManager::getInstance()->addFocus("cap_tts", NUGU_FOCUS_TYPE_TTS, this);
 
@@ -185,7 +185,7 @@ NuguFocusResult TTSAgent::onUnfocus(NuguFocusResource rsrc, void* event)
 {
     nugu_pcm_stop(pcm);
 
-    playsync_manager->removeContext(ps_id, getType(), !finish);
+    playsync_manager->removeContext(playstackctl_ps_id, getType(), !finish);
 
     return NUGU_FOCUS_REMOVE;
 }
@@ -377,7 +377,11 @@ void TTSAgent::parsingSpeak(const char* message, NuguDirective* ndir)
 
     stopTTS();
 
-    playsync_manager->addContext(ps_id, getType());
+    playstackctl_ps_id = getPlayServiceIdInStackControl(root["playStackControl"]);
+
+    if (!playstackctl_ps_id.empty()) {
+        playsync_manager->addContext(playstackctl_ps_id, getType());
+    }
 
     startTTS(ndir);
 

--- a/service/capability/tts_agent.hh
+++ b/service/capability/tts_agent.hh
@@ -77,6 +77,7 @@ private:
 
     std::string dialog_id;
     std::string ps_id;
+    std::string playstackctl_ps_id;
     ITTSListener* tts_listener;
 };
 


### PR DESCRIPTION
Because, the policy of managing playServiceId in playStack
is changed to use in playStackControl, it update related agents.
Target Agent : TTSAgent, AudioPlayerAgent, DisplayAgent

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>