### PR TITLE
display:add stopRenderingTimer

### DIFF
--- a/include/interface/capability/display_interface.hh
+++ b/include/interface/capability/display_interface.hh
@@ -102,6 +102,12 @@ public:
      * @param[in] listener listener object
      */
     virtual void removeListener(IDisplayListener* listener) = 0;
+
+    /**
+     * @brief stop display rendering hold timer.
+     * @param[in] id display template id
+     */
+    virtual void stopRenderingTimer(const std::string& id) = 0;
 };
 
 /**

--- a/service/capability/audio_player_agent.cc
+++ b/service/capability/audio_player_agent.cc
@@ -267,6 +267,11 @@ void AudioPlayerAgent::removeListener(IAudioPlayerListener* listener)
         aplayer_listeners.erase(iterator);
 }
 
+void AudioPlayerAgent::stopRenderingTimer(const std::string& id)
+{
+    playsync_manager->clearContextHold();
+}
+
 void AudioPlayerAgent::sendEventPlaybackStarted()
 {
     sendEventCommon("PlaybackStarted");

--- a/service/capability/audio_player_agent.hh
+++ b/service/capability/audio_player_agent.hh
@@ -59,6 +59,7 @@ public:
     void elementSelected(const std::string& id, const std::string& item_token) override;
     void setListener(IDisplayListener* listener) override;
     void removeListener(IDisplayListener* listener) override;
+    void stopRenderingTimer(const std::string& id) override;
 
     void addListener(IAudioPlayerListener* listener) override;
     void removeListener(IAudioPlayerListener* listener) override;

--- a/service/capability/display_agent.cc
+++ b/service/capability/display_agent.cc
@@ -144,6 +144,7 @@ void DisplayAgent::displayCleared(const std::string& id)
         render_info.erase(id);
         delete info;
     }
+
     playsync_manager->clearPendingContext(ps_id);
 }
 
@@ -171,6 +172,11 @@ void DisplayAgent::removeListener(IDisplayListener* listener)
 {
     if (display_listener == listener)
         display_listener = nullptr;
+}
+
+void DisplayAgent::stopRenderingTimer(const std::string& id)
+{
+    playsync_manager->clearContextHold();
 }
 
 void DisplayAgent::sendEventElementSelected(const std::string& item_token)

--- a/service/capability/display_agent.hh
+++ b/service/capability/display_agent.hh
@@ -42,6 +42,7 @@ public:
     void elementSelected(const std::string& id, const std::string& item_token) override;
     void setListener(IDisplayListener* listener) override;
     void removeListener(IDisplayListener* listener) override;
+    void stopRenderingTimer(const std::string& id) override;
 
     // implement IContextManagerListener
     void onSyncDisplayContext(const std::string& id) override;

--- a/service/playsync_manager.cc
+++ b/service/playsync_manager.cc
@@ -281,6 +281,11 @@ void PlaySyncManager::onMicOn()
     nugu_timer_stop(timer);
 }
 
+void PlaySyncManager::clearContextHold()
+{
+    nugu_timer_stop(timer);
+}
+
 void PlaySyncManager::onASRError()
 {
     is_expect_speech = false;

--- a/service/playsync_manager.hh
+++ b/service/playsync_manager.hh
@@ -68,6 +68,7 @@ public:
 
     void setExpectSpeech(bool expect_speech);
     void onMicOn();
+    void clearContextHold();
     void onASRError();
 
 private:


### PR DESCRIPTION
If user want to manage display rendering by self, it needs to
stop related play sync context hold timer. So, it provided
stopRenderingTimer method.

If user call stopRenderingTimer, it has to call displayCleared method
for notifying SDK that there are no more need to display rendering.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>