### PR TITLE
introduce a event-queue

### DIFF
--- a/include/core/nugu_equeue.h
+++ b/include/core/nugu_equeue.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NUGU_EQUEUE_H__
+#define __NUGU_EQUEUE_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file nugu_equeue.h
+ * @defgroup NuguEventQueue Event Queue
+ * @ingroup SDKCore
+ * @brief Event queue for passing events between threads.
+ *
+ * Queue for raising event callbacks with passing data from another
+ * thread to the thread context in which GMainloop runs.
+ *
+ * Manage the queue thread-safely using GAsyncQueue and wakeup the GMainloop
+ * using eventfd.
+ *
+ * @{
+ */
+
+/**
+ * @brief event types
+ */
+enum nugu_equeue_type {
+	NUGU_EQUEUE_TYPE_NEW_DIRECTIVE = 0, /**< received new directive */
+	NUGU_EQUEUE_TYPE_NEW_ATTACHMENT, /**< received new attachment */
+	NUGU_EQUEUE_TYPE_MAX = 255 /**< maximum value for type id */
+};
+
+/**
+ * @brief Callback prototype for receiving an event
+ */
+typedef void (*NuguEqueueCallback)(enum nugu_equeue_type type, void *data,
+				   void *userdata);
+
+/**
+ * @brief Callback prototype for releasing data after event delivery is done.
+ */
+typedef void (*NuguEqueueDestroyCallback)(void *data);
+
+/**
+ * @brief Initialize the event queue
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ */
+int nugu_equeue_initialize(void);
+
+/**
+ * @brief De-initialize the event queue
+ */
+void nugu_equeue_deinitialize(void);
+
+/**
+ * @brief Set handler for event type
+ * @param[in] type type-id
+ * @param[in] callback callback function
+ * @param[in] destroy_callback destroy notifier function
+ * @param[in] userdata data to pass to the user callback
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ */
+int nugu_equeue_set_handler(enum nugu_equeue_type type,
+			    NuguEqueueCallback callback,
+			    NuguEqueueDestroyCallback destroy_callback,
+			    void *userdata);
+
+/**
+ * @brief Unset handler for event type
+ * @param[in] type type-id
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ */
+int nugu_equeue_unset_handler(enum nugu_equeue_type type);
+
+/**
+ * @brief Push new event with data to queue and trigger event callback
+ * in GMainloop thread context
+ *
+ * @param[in] type type-id
+ * @param[in] data event data
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ */
+int nugu_equeue_push(enum nugu_equeue_type type, void *data);
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/core/nugu_network_manager.h
+++ b/include/core/nugu_network_manager.h
@@ -142,32 +142,6 @@ int nugu_network_manager_connect(void);
 int nugu_network_manager_disconnect(void);
 
 /**
- * @brief Receive a directive. The directive is passed to the sequencer.
- * @param[in] ndir directive object
- * @return result
- * @retval 0 success
- * @retval -1 failure
- * @see nugu_directive_new()
- */
-int nugu_network_manager_recv_directive(NuguDirective *ndir);
-
-/**
- * @brief Append the attachment data to directive object by message-id
- * @param[in] parent_msg_id ID indicating the owner of the data.
- * @param[in] media_type mime info
- * @param[in] is_end data is last(is_end=1) or not(is_end=0)
- * @param[in] length length of data
- * @param[in] data data
- * @return result
- * @retval 0 success
- * @retval -1 failure
- */
-int nugu_network_manager_recv_directive_data(char *parent_msg_id,
-					     char *media_type, int is_end,
-					     size_t length,
-					     unsigned char *data);
-
-/**
  * @}
  */
 

--- a/interface/nugu_client_impl.cc
+++ b/interface/nugu_client_impl.cc
@@ -25,6 +25,7 @@
 #include "nugu_config.h"
 #include "nugu_log.h"
 #include "nugu_plugin.h"
+#include "nugu_equeue.h"
 
 namespace NuguClientKit {
 
@@ -33,6 +34,7 @@ using namespace NuguCore;
 NuguClientImpl::NuguClientImpl()
 {
     nugu_config_initialize();
+    nugu_equeue_initialize();
     readEnviromentVariables();
     setDefaultConfigs();
 
@@ -43,6 +45,7 @@ NuguClientImpl::NuguClientImpl()
 NuguClientImpl::~NuguClientImpl()
 {
     CapabilityManagerHelper::destroyInstance();
+    nugu_equeue_deinitialize();
     nugu_config_deinitialize();
 }
 

--- a/src/http2/http2_manage.h
+++ b/src/http2/http2_manage.h
@@ -30,6 +30,14 @@ enum h2manager_status {
 	H2_STATUS_TOKEN_FAILED
 };
 
+struct equeue_data_attachment {
+	void *data;
+	size_t length;
+	char *parent_msg_id;
+	char *media_type;
+	int is_end;
+};
+
 typedef void (*H2ManagerStatusCallback)(void *userdata);
 
 typedef struct _h2_manager H2Manager;

--- a/src/nugu_equeue.c
+++ b/src/nugu_equeue.c
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/eventfd.h>
+#include <glib.h>
+
+#include "nugu_log.h"
+#include "nugu_equeue.h"
+
+struct _equeue_typemap {
+	NuguEqueueCallback callback;
+	NuguEqueueDestroyCallback destroy_callback;
+	void *userdata;
+};
+
+struct _equeue {
+	int efd;
+	guint source;
+	GAsyncQueue *pendings;
+	struct _equeue_typemap typemap[NUGU_EQUEUE_TYPE_MAX];
+};
+
+struct _econtainer {
+	enum nugu_equeue_type type;
+	void *data;
+};
+
+struct _equeue *_equeue;
+
+static void on_item_destroy(gpointer data)
+{
+	struct _econtainer *item = data;
+	struct _equeue_typemap *handler;
+
+	handler = &_equeue->typemap[item->type];
+
+	if (handler->destroy_callback)
+		handler->destroy_callback(item->data);
+
+	free(item);
+}
+
+static gboolean on_event(GIOChannel *channel, GIOCondition cond,
+			 gpointer userdata)
+{
+	uint64_t ev = 0;
+	ssize_t nread;
+
+	if (!_equeue) {
+		nugu_error("event queue not initialized");
+		return FALSE;
+	}
+
+	nread = read(_equeue->efd, &ev, sizeof(ev));
+	if (nread == -1 || nread != sizeof(ev)) {
+		nugu_error("read failed");
+		return TRUE;
+	}
+
+	while (g_async_queue_length(_equeue->pendings) > 0) {
+		struct _econtainer *item;
+		struct _equeue_typemap *handler;
+
+		item = g_async_queue_try_pop(_equeue->pendings);
+		if (!item)
+			break;
+
+		handler = &_equeue->typemap[item->type];
+		if (handler->callback)
+			handler->callback(item->type, item->data,
+					  handler->userdata);
+
+		if (handler->destroy_callback)
+			handler->destroy_callback(item->data);
+
+		free(item);
+	}
+
+	return TRUE;
+}
+
+int nugu_equeue_initialize(void)
+{
+	GIOChannel *channel;
+
+	g_return_val_if_fail(_equeue == NULL, -1);
+
+	_equeue = calloc(1, sizeof(struct _equeue));
+	if (!_equeue) {
+		error_nomem();
+		return -1;
+	}
+
+	_equeue->efd = eventfd(0, EFD_CLOEXEC);
+	if (_equeue->efd < 0) {
+		nugu_error("eventfd() failed");
+		free(_equeue);
+		return -1;
+	}
+
+	channel = g_io_channel_unix_new(_equeue->efd);
+	_equeue->source = g_io_add_watch(channel, G_IO_IN, on_event, NULL);
+	g_io_channel_unref(channel);
+
+	_equeue->pendings = g_async_queue_new_full(on_item_destroy);
+
+	return 0;
+}
+
+void nugu_equeue_deinitialize(void)
+{
+	g_return_if_fail(_equeue != NULL);
+
+	if (_equeue->efd != -1)
+		close(_equeue->efd);
+
+	if (_equeue->source > 0)
+		g_source_remove(_equeue->source);
+
+	if (_equeue->pendings) {
+		/* Remove pendings */
+		while (g_async_queue_length(_equeue->pendings) > 0) {
+			struct _econtainer *item;
+			struct _equeue_typemap *handler;
+
+			item = g_async_queue_try_pop(_equeue->pendings);
+			if (!item)
+				break;
+
+			handler = &_equeue->typemap[item->type];
+			if (handler->destroy_callback)
+				handler->destroy_callback(item->data);
+
+			free(item);
+		}
+
+		g_async_queue_unref(_equeue->pendings);
+	}
+
+	free(_equeue);
+	_equeue = NULL;
+}
+
+int nugu_equeue_set_handler(enum nugu_equeue_type type,
+			    NuguEqueueCallback callback,
+			    NuguEqueueDestroyCallback destroy_callback,
+			    void *userdata)
+{
+	g_return_val_if_fail(_equeue != NULL, -1);
+	g_return_val_if_fail(type < NUGU_EQUEUE_TYPE_MAX, -1);
+	g_return_val_if_fail(callback != NULL, -1);
+
+	_equeue->typemap[type].callback = callback;
+	_equeue->typemap[type].destroy_callback = destroy_callback;
+	_equeue->typemap[type].userdata = userdata;
+
+	return 0;
+}
+
+int nugu_equeue_unset_handler(enum nugu_equeue_type type)
+{
+	g_return_val_if_fail(_equeue != NULL, -1);
+	g_return_val_if_fail(type < NUGU_EQUEUE_TYPE_MAX, -1);
+
+	_equeue->typemap[type].callback = NULL;
+	_equeue->typemap[type].destroy_callback = NULL;
+	_equeue->typemap[type].userdata = NULL;
+
+	return 0;
+}
+
+int nugu_equeue_push(enum nugu_equeue_type type, void *data)
+{
+	struct _econtainer *item;
+	uint64_t ev = 1;
+	ssize_t written;
+
+	g_return_val_if_fail(_equeue != NULL, -1);
+	g_return_val_if_fail(type < NUGU_EQUEUE_TYPE_MAX, -1);
+
+	if (!_equeue->typemap[type].callback) {
+		nugu_error("Please add handler for %d type first", type);
+		return -1;
+	}
+
+	item = malloc(sizeof(struct _econtainer));
+	if (!item) {
+		error_nomem();
+		return -1;
+	}
+
+	item->data = data;
+	item->type = type;
+
+	g_async_queue_push(_equeue->pendings, item);
+
+	written = write(_equeue->efd, &ev, sizeof(uint64_t));
+	if (written != sizeof(uint64_t)) {
+		nugu_error("write failed");
+		return -1;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
equeue:

Add a queue for raising event callbacks with passing data from another thread to the thread context in which GMainloop runs.

Manage the queue thread-safely using GAsyncQueue and wakeup the GMainloop using eventfd.