### PR TITLE
Referrer Dialog Request ID

### DIFF
--- a/include/core/nugu_directive.h
+++ b/include/core/nugu_directive.h
@@ -56,13 +56,15 @@ typedef void (*DirectiveDataCallback)(NuguDirective *ndir, void *userdata);
  * @param[in] version version string (e.g. "1.0")
  * @param[in] msg_id unique message-id
  * @param[in] dialog_id unique dialog-request-id
+ * @param[in] referrer_id referrer-dialog-request-id
  * @param[in] json payload
  * @return directive object
  * @see nugu_directive_free()
  */
 NuguDirective *nugu_directive_new(const char *name_space, const char *name,
 				  const char *version, const char *msg_id,
-				  const char *dialog_id, const char *json);
+				  const char *dialog_id,
+				  const char *referrer_id, const char *json);
 
 /**
  * @brief Destroy the directive object
@@ -105,6 +107,13 @@ const char *nugu_directive_peek_msg_id(NuguDirective *ndir);
  * @return dialog-request-id. Please don't free the data manually.
  */
 const char *nugu_directive_peek_dialog_id(NuguDirective *ndir);
+
+/**
+ * @brief Get the referer-dialog-request-id of directive
+ * @param[in] ndir directive object
+ * @return referrer-dialog-request-id. Please don't free the data manually.
+ */
+const char *nugu_directive_peek_referrer_id(NuguDirective *ndir);
 
 /**
  * @brief Get the payload of directive

--- a/service/capability/audio_player_agent.cc
+++ b/service/capability/audio_player_agent.cc
@@ -38,6 +38,7 @@ AudioPlayerAgent::AudioPlayerAgent()
     , report_delay_time(-1)
     , report_interval_time(-1)
     , cur_token("")
+    , pre_ref_dialog_id("")
     , is_finished(false)
     , display_listener(nullptr)
 {
@@ -434,13 +435,19 @@ void AudioPlayerAgent::parsingPlay(const char* message)
     nugu_dbg("= report_delay_time: %d", report_delay_time);
     nugu_dbg("= report_interval_time: %d", report_interval_time);
 
+    std::string id = getReferrerDialoRequestId();
     // stop previous play for handling prev, next media play
     if (token != prev_token) {
+        if (pre_ref_dialog_id.size())
+            setReferrerDialoRequestId(pre_ref_dialog_id);
+
         if (!player->stop()) {
             nugu_error("stop media failed");
             sendEventPlaybackFailed(PlaybackError::MEDIA_ERROR_INTERNAL_DEVICE_ERROR, "player can't stop");
         }
     }
+    setReferrerDialoRequestId(id);
+    pre_ref_dialog_id = id;
     cur_token = token;
 
     if (!player->setSource(url)) {

--- a/service/capability/audio_player_agent.hh
+++ b/service/capability/audio_player_agent.hh
@@ -120,6 +120,7 @@ private:
     long report_delay_time;
     long report_interval_time;
     std::string cur_token;
+    std::string pre_ref_dialog_id;
     bool is_finished;
     std::vector<IAudioPlayerListener*> aplayer_listeners;
     IDisplayListener* display_listener;

--- a/service/capability/capability.hh
+++ b/service/capability/capability.hh
@@ -40,6 +40,8 @@ public:
     CapabilityEvent(const std::string& name, Capability* cap);
     virtual ~CapabilityEvent();
 
+    bool isUserAction(const std::string& name);
+
     std::string getDialogMessageId();
     void setDialogMessageId(const std::string& id);
 
@@ -58,6 +60,8 @@ public:
     virtual ~Capability();
     virtual void initialize();
 
+    std::string getReferrerDialoRequestId();
+    void setReferrerDialoRequestId(const std::string& id);
     std::string getTypeName(CapabilityType type) override;
     CapabilityType getType() override;
     void setName(CapabilityType type);
@@ -97,6 +101,7 @@ private:
     CapabilityType ctype;
     std::string cname;
     std::string version;
+    std::string ref_dialog_id;
     std::vector<ICapabilityObserver*> observers;
     NuguDirective* cur_ndir;
 };

--- a/src/http2/v1_directives.cc
+++ b/src/http2/v1_directives.cc
@@ -178,16 +178,20 @@ static void _body_json(const char* data, size_t length)
         Json::Value dir = dir_list[i];
         Json::Value h;
         NuguDirective* ndir;
+        std::string referrer;
         std::string p;
 
         h = dir["header"];
 
         p = writer.write(dir["payload"]);
 
+        if (!h["referrerDialogRequestId"].empty())
+            referrer = h["referrerDialogRequestId"].asString();
+
         ndir = nugu_directive_new(h["namespace"].asCString(),
             h["name"].asCString(), h["version"].asCString(),
             h["messageId"].asCString(), h["dialogRequestId"].asCString(),
-            p.c_str());
+            referrer.c_str(), p.c_str());
         if (!ndir)
             continue;
 

--- a/src/nugu_directive.c
+++ b/src/nugu_directive.c
@@ -30,6 +30,7 @@ struct _nugu_directive {
 	char *msg_id;
 	char *dialog_id;
 	char *json;
+	char *referrer_id;
 
 	int is_active;
 	int is_end;
@@ -43,7 +44,8 @@ struct _nugu_directive {
 EXPORT_API NuguDirective *
 nugu_directive_new(const char *name_space, const char *name,
 		   const char *version, const char *msg_id,
-		   const char *dialog_id, const char *json)
+		   const char *dialog_id, const char *referrer_id,
+		   const char *json)
 {
 	NuguDirective *ndir;
 
@@ -60,6 +62,7 @@ nugu_directive_new(const char *name_space, const char *name,
 	ndir->version = strdup(version);
 	ndir->msg_id = strdup(msg_id);
 	ndir->dialog_id = strdup(dialog_id);
+	ndir->referrer_id = strdup(referrer_id);
 	ndir->json = strdup(json);
 
 	ndir->is_active = 0;
@@ -90,6 +93,9 @@ EXPORT_API void nugu_directive_free(NuguDirective *ndir)
 
 	free(ndir->dialog_id);
 	ndir->dialog_id = NULL;
+
+	free(ndir->referrer_id);
+	ndir->referrer_id = NULL;
 
 	free(ndir->json);
 	ndir->json = NULL;
@@ -154,6 +160,13 @@ EXPORT_API const char *nugu_directive_peek_dialog_id(NuguDirective *ndir)
 	g_return_val_if_fail(ndir != NULL, NULL);
 
 	return ndir->dialog_id;
+}
+
+EXPORT_API const char *nugu_directive_peek_referrer_id(NuguDirective *ndir)
+{
+	g_return_val_if_fail(ndir != NULL, NULL);
+
+	return ndir->referrer_id;
 }
 
 EXPORT_API const char *nugu_directive_peek_json(NuguDirective *ndir)

--- a/tests/test-nugu-directive.c
+++ b/tests/test-nugu-directive.c
@@ -51,7 +51,7 @@ static void test_nugu_directive_callback(void)
 	NuguDirective *ndir;
 
 	ndir = nugu_directive_new("TTS", "Speak", "1.0", TEST_UUID_1,
-				  TEST_UUID_2, "{}");
+				  TEST_UUID_2, TEST_UUID_1, "{}");
 	g_assert(ndir != NULL);
 
 	g_assert(nugu_directive_set_data_callback(ndir, on_data,
@@ -75,23 +75,23 @@ static void test_nugu_directive_default(void)
 {
 	NuguDirective *ndir;
 
-	g_assert(nugu_directive_new(NULL, NULL, NULL, NULL, NULL, NULL) ==
+	g_assert(nugu_directive_new(NULL, NULL, NULL, NULL, NULL, NULL, NULL) ==
 		 NULL);
-	g_assert(nugu_directive_new("TTS", NULL, NULL, NULL, NULL, NULL) ==
-		 NULL);
-	g_assert(nugu_directive_new(NULL, "Speak", NULL, NULL, NULL, NULL) ==
-		 NULL);
-	g_assert(nugu_directive_new(NULL, NULL, "1.0", NULL, NULL, NULL) ==
-		 NULL);
-	g_assert(nugu_directive_new(NULL, NULL, NULL, TEST_UUID_1, NULL,
+	g_assert(nugu_directive_new("TTS", NULL, NULL, NULL, NULL, NULL,
 				    NULL) == NULL);
-	g_assert(nugu_directive_new(NULL, NULL, NULL, NULL, TEST_UUID_1,
+	g_assert(nugu_directive_new(NULL, "Speak", NULL, NULL, NULL, NULL,
 				    NULL) == NULL);
-	g_assert(nugu_directive_new(NULL, NULL, NULL, NULL, TEST_UUID_1,
+	g_assert(nugu_directive_new(NULL, NULL, "1.0", NULL, NULL, NULL,
+				    NULL) == NULL);
+	g_assert(nugu_directive_new(NULL, NULL, NULL, TEST_UUID_1, NULL, NULL,
+				    NULL) == NULL);
+	g_assert(nugu_directive_new(NULL, NULL, NULL, NULL, TEST_UUID_1, NULL,
+				    NULL) == NULL);
+	g_assert(nugu_directive_new(NULL, NULL, NULL, NULL, TEST_UUID_1, NULL,
 				    "{}") == NULL);
 
 	ndir = nugu_directive_new("TTS", "Speak", "1.0", TEST_UUID_1,
-				  TEST_UUID_2, "{}");
+				  TEST_UUID_2, TEST_UUID_1, "{}");
 	g_assert(ndir != NULL);
 
 	g_assert_cmpstr(nugu_directive_peek_namespace(ndir), ==, "TTS");


### PR DESCRIPTION
1. capability: add refererrer dialog request id

- The refererrer dialog request id binds the user's actions.


2. network: add referrer_dialog_request_id to directive

- The referrer for dialogRequestId is added to directive spec.
   So add related APIs to nugu_directive and network modules.