### PR TITLE
network: fix status callback

### DIFF
--- a/examples/standalone/nugu_sample.cc
+++ b/examples/standalone/nugu_sample.cc
@@ -84,18 +84,24 @@ public:
 
 class NetworkManagerListener : public INetworkManagerListener {
 public:
-    void onConnected()
+    void onStatusChanged(NetworkStatus status)
     {
-        msg_info("Network connected.");
-
-        nugu_sample_manager->handleNetworkResult(true);
-    }
-
-    void onDisconnected()
-    {
-        msg_info("Network disconnected.");
-
-        nugu_sample_manager->handleNetworkResult(false);
+        switch (status) {
+        case NetworkStatus::DISCONNECTED:
+            msg_info("Network disconnected.");
+            nugu_sample_manager->handleNetworkResult(false);
+            break;
+        case NetworkStatus::CONNECTED:
+            msg_info("Network connected.");
+            nugu_sample_manager->handleNetworkResult(true);
+            break;
+        case NetworkStatus::CONNECTING:
+            msg_info("Network connection in progress.");
+            nugu_sample_manager->handleNetworkResult(false);
+            break;
+        default:
+            break;
+        }
     }
 
     void onError(NetworkError error)

--- a/include/core/nugu_network_manager.h
+++ b/include/core/nugu_network_manager.h
@@ -39,12 +39,21 @@ extern "C" {
 
 /**
  * @brief network status
+ *
+ * Basic connection status flow
+ *   - Normal connection: DISCONNECTED -> CONNECTING -> CONNECTED
+ *   - Connection failed: DISCONNECTED -> CONNECTING -> DISCONNECTED
+ *   - Token error: DISCONNECTED -> CONNECTING -> TOKEN_ERROR -> DISCONNECTED
+ *
+ * Connection recovery flow
+ *   - Connection recovered: CONNECTED -> CONNECTING -> CONNECTED
+ *   - Recovery failed: CONNECTED -> CONNECTING -> DISCONNECTED
+ *   - Token error: CONNECTED -> CONNECTING -> TOKEN_ERROR -> DISCONNECTED
  */
 enum nugu_network_status {
-	NUGU_NETWORK_UNKNOWN, /**< Initial state */
+	NUGU_NETWORK_DISCONNECTED, /**< Network disconnected */
 	NUGU_NETWORK_CONNECTING, /**< Connection in progress */
 	NUGU_NETWORK_CONNECTED, /**< Network connected */
-	NUGU_NETWORK_DISCONNECTED, /**< Network disconnected */
 	NUGU_NETWORK_TOKEN_ERROR /**< Token error */
 };
 

--- a/include/interface/network_manager_interface.hh
+++ b/include/interface/network_manager_interface.hh
@@ -31,9 +31,12 @@ namespace NuguInterface {
  * @{
  */
 
-/**
- * @brief NetworkError
- */
+enum class NetworkStatus {
+    DISCONNECTED, /**< Network disconnected */
+    CONNECTED, /**< Network connected */
+    CONNECTING /**< Connection in progress */
+};
+
 enum class NetworkError {
     TOKEN_ERROR, /**< Occurs when the issued token expires */
     UNKNOWN /**< UNKNOWN */
@@ -48,14 +51,9 @@ public:
     virtual ~INetworkManagerListener() = default;
 
     /**
-     * @brief Report a connection success to the NUGU server.
+     * @brief Report the connection status with the NUGU server.
      */
-    virtual void onConnected();
-
-    /**
-     * @brief Report a connection failure to the NUGU server.
-     */
-    virtual void onDisconnected();
+    virtual void onStatusChanged(NetworkStatus status);
 
     /**
      * @brief Report an error while communicating with the NUGU server.

--- a/interface/network_manager_interface.cc
+++ b/interface/network_manager_interface.cc
@@ -17,8 +17,7 @@
 
 namespace NuguInterface {
 
-void INetworkManagerListener::onConnected() {}
-void INetworkManagerListener::onDisconnected() {}
+void INetworkManagerListener::onStatusChanged(NetworkStatus status) {}
 void INetworkManagerListener::onError(NetworkError error) {}
 
 } //NuguInterface

--- a/interface/nugu_client_impl.cc
+++ b/interface/nugu_client_impl.cc
@@ -235,8 +235,11 @@ void NuguClientImpl::deInitialize(void)
     initialized = false;
 }
 
-void NuguClientImpl::onConnected()
+void NuguClientImpl::onStatusChanged(NetworkStatus status)
 {
+    if (status != NetworkStatus::CONNECTED)
+        return;
+
     ISystemHandler* sys_handler = dynamic_cast<ISystemHandler*>(getCapabilityHandler(CapabilityType::System));
 
     if (sys_handler)

--- a/interface/nugu_client_impl.hh
+++ b/interface/nugu_client_impl.hh
@@ -52,7 +52,7 @@ public:
     INetworkManager* getNetworkManager();
 
     // overriding INetworkManagerListener
-    void onConnected() override;
+    void onStatusChanged(NetworkStatus status) override;
 
 private:
     int createCapabilities(void);

--- a/service/network_manager.cc
+++ b/service/network_manager.cc
@@ -36,13 +36,19 @@ static void _status(void* userdata)
         nugu_info("Network disconnected");
 
         for (auto listener : listeners) {
-            listener->onDisconnected();
+            listener->onStatusChanged(NetworkStatus::DISCONNECTED);
         }
     } else if (status == NUGU_NETWORK_CONNECTED) {
         nugu_info("Network connected");
 
         for (auto listener : listeners) {
-            listener->onConnected();
+            listener->onStatusChanged(NetworkStatus::CONNECTED);
+        }
+    } else if (status == NUGU_NETWORK_CONNECTING) {
+        nugu_info("Network connecting");
+
+        for (auto listener : listeners) {
+            listener->onStatusChanged(NetworkStatus::CONNECTING);
         }
     } else if (status == NUGU_NETWORK_TOKEN_ERROR) {
         nugu_error("Network token error");
@@ -50,11 +56,8 @@ static void _status(void* userdata)
         for (auto listener : listeners) {
             listener->onError(NetworkError::TOKEN_ERROR);
         }
-    } else if (status == NUGU_NETWORK_CONNECTING) {
-        nugu_info("Network connecting");
     } else {
         nugu_error("Network unknown error");
-
         for (auto listener : listeners) {
             listener->onError(NetworkError::UNKNOWN);
         }

--- a/src/nugu_network_manager.c
+++ b/src/nugu_network_manager.c
@@ -55,9 +55,8 @@ static const char * const _debug_connection_step[] = {
 };
 
 static const char * const _debug_status_strmap[] = {
-	[NUGU_NETWORK_UNKNOWN] = "NUGU_NETWORK_UNKNOWN", /**< Unknown */
-	[NUGU_NETWORK_CONNECTING] = "NUGU_NETWORK_CONNECTING",
 	[NUGU_NETWORK_DISCONNECTED] = "NUGU_NETWORK_DISCONNECTED",
+	[NUGU_NETWORK_CONNECTING] = "NUGU_NETWORK_CONNECTING",
 	[NUGU_NETWORK_CONNECTED] = "NUGU_NETWORK_CONNECTED",
 	[NUGU_NETWORK_TOKEN_ERROR] = "NUGU_NETWORK_TOKEN_ERROR",
 };
@@ -241,6 +240,7 @@ static void _process_connecting(NetworkManager *nm,
 	switch (new_step) {
 	case STEP_INVALID_TOKEN:
 		_update_status(nm, NUGU_NETWORK_TOKEN_ERROR);
+		nugu_network_manager_disconnect();
 		break;
 
 	case STEP_REGISTRY_FAILED:
@@ -377,7 +377,7 @@ static NetworkManager *nugu_network_manager_new(void)
 	nugu_equeue_set_handler(NUGU_EQUEUE_TYPE_SERVER_CONNECTED, on_event,
 				NULL, nm);
 
-	nm->cur_status = NUGU_NETWORK_UNKNOWN;
+	nm->cur_status = NUGU_NETWORK_DISCONNECTED;
 	nm->step = STEP_IDLE;
 
 	return nm;
@@ -476,6 +476,8 @@ EXPORT_API int nugu_network_manager_disconnect(void)
 		dg_registry_free(_network->registry);
 		_network->registry = NULL;
 	}
+
+	_update_status(_network, NUGU_NETWORK_DISCONNECTED);
 
 	return 0;
 }


### PR DESCRIPTION
Add a 'connecting' step to eliminate ambiguity in the network state.

Signed-off-by: Inho Oh <inho.oh@sk.com>