### PR TITLE
network: add handoff feature

### DIFF
--- a/include/core/nugu_network_manager.h
+++ b/include/core/nugu_network_manager.h
@@ -63,6 +63,31 @@ enum nugu_network_status {
 typedef enum nugu_network_status NuguNetworkStatus;
 
 /**
+ * @brief Callback prototype for receiving network status events
+ */
+typedef void (*NetworkManagerStatusCallback)(NuguNetworkStatus status,
+					     void *userdata);
+
+/**
+ * @brief network handoff status
+ */
+enum nugu_network_handoff_status {
+	NUGU_NETWORK_HANDOFF_FAILED,
+	NUGU_NETWORK_HANDOFF_SUCCESS
+};
+
+/**
+ * @see enum nugu_network_status
+ */
+typedef enum nugu_network_handoff_status NuguNetworkHandoffStatus;
+
+/**
+ * @brief Callback prototype for handoff status events
+ */
+typedef void (*NetworkManagerHandoffStatusCallback)(
+	NuguNetworkHandoffStatus status, void *userdata);
+
+/**
  * @brief network protocols
  */
 enum nugu_network_protocol {
@@ -95,11 +120,6 @@ struct nugu_network_server_policy {
 typedef struct nugu_network_server_policy NuguNetworkServerPolicy;
 
 /**
- * @brief Callback prototype for receiving network status events
- */
-typedef void (*NetworkManagerCallback)(void *userdata);
-
-/**
  * @brief Set network status callback
  * @param[in] callback callback function
  * @param[in] userdata data to pass to the user callback
@@ -107,8 +127,19 @@ typedef void (*NetworkManagerCallback)(void *userdata);
  * @retval 0 success
  * @retval -1 failure
  */
-int nugu_network_manager_set_callback(NetworkManagerCallback callback,
-				      void *userdata);
+int nugu_network_manager_set_status_callback(
+	NetworkManagerStatusCallback callback, void *userdata);
+
+/**
+ * @brief Set handoff status callback
+ * @param[in] callback callback function
+ * @param[in] userdata data to pass to the user callback
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ */
+int nugu_network_manager_set_handoff_status_callback(
+	NetworkManagerHandoffStatusCallback callback, void *userdata);
 
 /**
  * @brief Set the current network status
@@ -182,6 +213,24 @@ int nugu_network_manager_connect(void);
  * @see nugu_network_manager_connect()
  */
 int nugu_network_manager_disconnect(void);
+
+/**
+ * @brief Handoff the current connection to new server
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ *
+ * When a handoff request is received, the client tries to connect to another
+ * server while maintaining the current connection.
+ *
+ *   - If the handoff connection is successful, change the current connection
+ *     to the new server.
+ *   - If the handoff connection fails, disconnect all connections and start
+ *     over from the Registry step.
+ *   - If the handoff connection is lost, start again from the Registry step.
+ *
+ */
+int nugu_network_manager_handoff(const NuguNetworkServerPolicy *policy);
 
 /**
  * @}

--- a/service/network_manager.cc
+++ b/service/network_manager.cc
@@ -22,12 +22,8 @@
 
 namespace NuguCore {
 
-static void _status(void* userdata)
+static void _status(NuguNetworkStatus status, void* userdata)
 {
-    NuguNetworkStatus status;
-
-    status = nugu_network_manager_get_status();
-
     NetworkManager* instance = static_cast<NetworkManager*>(userdata);
     auto listeners = instance->getListener();
 
@@ -67,12 +63,12 @@ static void _status(void* userdata)
 NetworkManager::NetworkManager()
 {
     nugu_network_manager_initialize();
-    nugu_network_manager_set_callback(_status, this);
+    nugu_network_manager_set_status_callback(_status, this);
 }
 
 NetworkManager::~NetworkManager()
 {
-    nugu_network_manager_set_callback(NULL, NULL);
+    nugu_network_manager_set_status_callback(NULL, NULL);
     nugu_network_manager_deinitialize();
 
     listeners.clear();


### PR DESCRIPTION
When a handoff request is received, the client tries to connect to
another server while maintaining the current connection.

- If the handoff connection is successful, change the current
  connection to the new server.
- If the handoff connection fails, disconnect all connections and
  start over from the Registry step.
- If the handoff connection is lost, start again from the Registry
  step.

Signed-off-by: Inho Oh <inho.oh@sk.com>