### PR TITLE
optimize CapabilityType management

### DIFF
--- a/include/interface/capability/capability_interface.hh
+++ b/include/interface/capability/capability_interface.hh
@@ -53,6 +53,19 @@ enum class CapabilityType {
     Location /**< the type of Location agent */
 };
 
+static const std::map<CapabilityType, std::string> CAPABILITY_TYPE_MAP {
+    { CapabilityType::AudioPlayer, "AudioPlayer" },
+    { CapabilityType::Display, "Display" },
+    { CapabilityType::System, "System" },
+    { CapabilityType::TTS, "TTS" },
+    { CapabilityType::ASR, "ASR" },
+    { CapabilityType::Text, "Text" },
+    { CapabilityType::Extension, "Extension" },
+    { CapabilityType::Delegation, "Delegation" },
+    { CapabilityType::Permission, "Permission" },
+    { CapabilityType::Location, "Location" }
+};
+
 /**
  * @brief capability handler interface
  * @see ICapabilityListener

--- a/service/capability/capability.cc
+++ b/service/capability/capability.cc
@@ -51,7 +51,7 @@ bool CapabilityEvent::isUserAction(const std::string& name)
     if ((type == CapabilityType::ASR && name == "Recognize")
         || (type == CapabilityType::TTS && name == "SpeechPlay")
         || (type == CapabilityType::AudioPlayer
-               && (name.find("CommandIssued") != std::string::npos))
+            && (name.find("CommandIssued") != std::string::npos))
         || (type == CapabilityType::Text && name == "TextInput")
         || (type == CapabilityType::Display && name == "ElementSelected")
         || (type == CapabilityType::Permission && name == "RequestAccessCompleted"))
@@ -149,42 +149,7 @@ CapabilityType Capability::getType()
 
 std::string Capability::getTypeName(CapabilityType type)
 {
-    std::string _name;
-
-    switch (type) {
-    case CapabilityType::AudioPlayer:
-        _name = "AudioPlayer";
-        break;
-    case CapabilityType::Display:
-        _name = "Display";
-        break;
-    case CapabilityType::System:
-        _name = "System";
-        break;
-    case CapabilityType::TTS:
-        _name = "TTS";
-        break;
-    case CapabilityType::ASR:
-        _name = "ASR";
-        break;
-    case CapabilityType::Text:
-        _name = "Text";
-        break;
-    case CapabilityType::Extension:
-        _name = "Extension";
-        break;
-    case CapabilityType::Delegation:
-        _name = "Delegation";
-        break;
-    case CapabilityType::Permission:
-        _name = "Permission";
-        break;
-    case CapabilityType::Location:
-        _name = "Location";
-        break;
-    }
-
-    return _name;
+    return CAPABILITY_TYPE_MAP.at(type);
 }
 
 void Capability::setVersion(const std::string& ver)

--- a/service/capability_creator.cc
+++ b/service/capability_creator.cc
@@ -32,46 +32,29 @@
 
 namespace NuguCore {
 
-const std::list<std::pair<CapabilityType, bool>> CapabilityCreator::CAPABILITY_LIST {
-    std::make_pair(CapabilityType::ASR, true),
-    std::make_pair(CapabilityType::TTS, true),
-    std::make_pair(CapabilityType::AudioPlayer, true),
-    std::make_pair(CapabilityType::System, true),
-    std::make_pair(CapabilityType::Display, false),
-    std::make_pair(CapabilityType::Extension, false),
-    std::make_pair(CapabilityType::Text, false),
-    std::make_pair(CapabilityType::Delegation, false),
-    std::make_pair(CapabilityType::Permission, false),
-    std::make_pair(CapabilityType::Location, false),
-};
-
-ICapabilityInterface* CapabilityCreator::createCapability(CapabilityType ctype)
-{
-    switch (ctype) {
-    case CapabilityType::ASR:
-        return new ASRAgent();
-    case CapabilityType::TTS:
-        return new TTSAgent();
-    case CapabilityType::AudioPlayer:
-        return new AudioPlayerAgent();
-    case CapabilityType::System:
-        return new SystemAgent();
-    case CapabilityType::Display:
-        return new DisplayAgent();
-    case CapabilityType::Extension:
-        return new ExtensionAgent();
-    case CapabilityType::Text:
-        return new TextAgent();
-    case CapabilityType::Delegation:
-        return new DelegationAgent();
-    case CapabilityType::Permission:
-        return new PermissionAgent();
-    case CapabilityType::Location:
-        return new LocationAgent();
-    default:
-        return nullptr;
+// for restricting access to only this file
+namespace {
+    template <class T>
+    ICapabilityInterface* create()
+    {
+        return new T;
     }
 }
+
+using CapabilityElement = CapabilityCreator::Element;
+
+const std::list<CapabilityElement> CapabilityCreator::CAPABILITY_LIST {
+    CapabilityElement { CapabilityType::ASR, true, &create<ASRAgent> },
+    CapabilityElement { CapabilityType::TTS, true, &create<TTSAgent> },
+    CapabilityElement { CapabilityType::AudioPlayer, true, &create<AudioPlayerAgent> },
+    CapabilityElement { CapabilityType::System, true, &create<SystemAgent> },
+    CapabilityElement { CapabilityType::Display, false, &create<DisplayAgent> },
+    CapabilityElement { CapabilityType::Extension, false, &create<ExtensionAgent> },
+    CapabilityElement { CapabilityType::Text, false, &create<TextAgent> },
+    CapabilityElement { CapabilityType::Delegation, false, &create<DelegationAgent> },
+    CapabilityElement { CapabilityType::Permission, false, &create<PermissionAgent> },
+    CapabilityElement { CapabilityType::Location, false, &create<LocationAgent> }
+};
 
 IWakeupHandler* CapabilityCreator::createWakeupHandler()
 {

--- a/service/capability_creator.hh
+++ b/service/capability_creator.hh
@@ -17,6 +17,7 @@
 #ifndef __CAPABILITY_CREATOR_H__
 #define __CAPABILITY_CREATOR_H__
 
+#include <functional>
 #include <list>
 
 #include <interface/capability/capability_interface.hh>
@@ -30,10 +31,17 @@ using namespace NuguInterface;
 class CapabilityCreator {
 public:
     virtual ~CapabilityCreator() = default;
-    static const std::list<std::pair<CapabilityType, bool>> CAPABILITY_LIST;
-    static ICapabilityInterface* createCapability(CapabilityType ctype);
+
     static IWakeupHandler* createWakeupHandler();
     static INetworkManager* createNetworkManager();
+
+    struct Element {
+        CapabilityType type;
+        bool is_default;
+        std::function<ICapabilityInterface*()> creator;
+    };
+
+    static const std::list<Element> CAPABILITY_LIST;
 };
 
 } // NuguCore


### PR DESCRIPTION
Previously, for adding new CapabilityType and Agent,
it has to change 4 points in 3 sources.

So, As optimizing it, it reduce to change 2 points in 2 sources.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>