### PR TITLE
add log for initializing step

### DIFF
--- a/interface/nugu_client_impl.cc
+++ b/interface/nugu_client_impl.cc
@@ -190,7 +190,10 @@ bool NuguClientImpl::initialize(void)
 
     // initialize capability
     for (auto const& icapability : icapability_map) {
+        std::string cname = icapability.second.first->getTypeName(icapability.second.first->getType());
+        nugu_dbg("'%s' capability initializing...", cname.c_str());
         icapability.second.first->initialize();
+        nugu_dbg("'%s' capability initialized", cname.c_str());
     }
 
     if (listener)


### PR DESCRIPTION
This patch add following logs to debug initialization step

- Capability initialization
- GStreamer plugin - create ops of player driver

Signed-off-by: Inho Oh <inho.oh@sk.com>