### PR TITLE
update handling display render

### DIFF
--- a/include/interface/capability/audio_player_interface.hh
+++ b/include/interface/capability/audio_player_interface.hh
@@ -81,7 +81,7 @@ public:
  * @brief audioplayer handler interface
  * @see IAudioPlayerListener
  */
-class IAudioPlayerHandler : public IDisplayHandler {
+class IAudioPlayerHandler : virtual public IDisplayHandler {
 public:
     virtual ~IAudioPlayerHandler() = default;
 

--- a/service/capability/audio_player_agent.cc
+++ b/service/capability/audio_player_agent.cc
@@ -40,19 +40,12 @@ AudioPlayerAgent::AudioPlayerAgent()
     , cur_token("")
     , pre_ref_dialog_id("")
     , is_finished(false)
-    , display_listener(nullptr)
 {
 }
 
 AudioPlayerAgent::~AudioPlayerAgent()
 {
-    display_listener = nullptr;
     aplayer_listeners.clear();
-
-    for (auto info : render_info) {
-        delete info.second;
-    }
-    render_info.clear();
 
     CapabilityManager::getInstance()->removeFocus("cap_audio");
 
@@ -203,41 +196,6 @@ void AudioPlayerAgent::setCapabilityListener(ICapabilityListener* listener)
     }
 }
 
-void AudioPlayerAgent::displayRendered(const std::string& id)
-{
-}
-
-void AudioPlayerAgent::displayCleared(const std::string& id)
-{
-    std::string ps_id = "";
-
-    if (render_info.find(id) != render_info.end()) {
-        auto info = render_info[id];
-        ps_id = info->ps_id;
-        render_info.erase(id);
-        delete info;
-    }
-    playsync_manager->clearPendingContext(ps_id);
-}
-
-void AudioPlayerAgent::elementSelected(const std::string& id, const std::string& item_token)
-{
-}
-
-void AudioPlayerAgent::setListener(IDisplayListener* listener)
-{
-    if (!listener)
-        return;
-
-    display_listener = listener;
-}
-
-void AudioPlayerAgent::removeListener(IDisplayListener* listener)
-{
-    if (display_listener == listener)
-        display_listener = nullptr;
-}
-
 void AudioPlayerAgent::addListener(IAudioPlayerListener* listener)
 {
     auto iterator = std::find(aplayer_listeners.begin(), aplayer_listeners.end(), listener);
@@ -252,11 +210,6 @@ void AudioPlayerAgent::removeListener(IAudioPlayerListener* listener)
 
     if (iterator != aplayer_listeners.end())
         aplayer_listeners.erase(iterator);
-}
-
-void AudioPlayerAgent::stopRenderingTimer(const std::string& id)
-{
-    playsync_manager->clearContextHold();
 }
 
 void AudioPlayerAgent::sendEventPlaybackStarted()
@@ -673,34 +626,6 @@ void AudioPlayerAgent::muteChanged(int mute)
 {
 }
 
-void AudioPlayerAgent::onSyncDisplayContext(const std::string& id)
-{
-    nugu_dbg("AudioPlayer sync context");
-
-    if (render_info.find(id) == render_info.end())
-        return;
-
-    display_listener->renderDisplay(id, render_info[id]->type, render_info[id]->payload, render_info[id]->dialog_id);
-}
-
-bool AudioPlayerAgent::onReleaseDisplayContext(const std::string& id, bool unconditionally)
-{
-    nugu_dbg("AudioPlayer release context");
-
-    if (render_info.find(id) == render_info.end())
-        return true;
-
-    bool ret = display_listener->clearDisplay(id, unconditionally);
-    if (ret || unconditionally) {
-        auto info = render_info[id];
-        render_info.erase(id);
-        delete info;
-    }
-
-    if (unconditionally && !ret)
-        nugu_warn("should clear display if unconditionally is true!!");
-
-    return ret;
-}
+void AudioPlayerAgent::onElementSelected(const std::string& item_token) {}
 
 } // NuguCore

--- a/service/capability/audio_player_agent.hh
+++ b/service/capability/audio_player_agent.hh
@@ -24,6 +24,7 @@
 
 #include "capability.hh"
 #include "capability_manager.hh"
+#include "display_render_assembly.hh"
 
 namespace NuguCore {
 
@@ -33,7 +34,7 @@ class AudioPlayerAgent : public Capability,
                          public IMediaPlayerListener,
                          public IFocusListener,
                          public IAudioPlayerHandler,
-                         public IPlaySyncManagerListener {
+                         public DisplayRenderAssembly<AudioPlayerAgent> {
 public:
     enum PlaybackError {
         MEDIA_ERROR_UNKNOWN,
@@ -52,14 +53,6 @@ public:
     void updateInfoForContext(Json::Value& ctx) override;
     void receiveCommand(CapabilityType from, std::string command, const std::string& param) override;
     void setCapabilityListener(ICapabilityListener* clistener) override;
-
-    // implement handler
-    void displayRendered(const std::string& id) override;
-    void displayCleared(const std::string& id) override;
-    void elementSelected(const std::string& id, const std::string& item_token) override;
-    void setListener(IDisplayListener* listener) override;
-    void removeListener(IDisplayListener* listener) override;
-    void stopRenderingTimer(const std::string& id) override;
 
     void addListener(IAudioPlayerListener* listener) override;
     void removeListener(IAudioPlayerListener* listener) override;
@@ -92,9 +85,8 @@ public:
     void volumeChanged(int volume);
     void muteChanged(int mute);
 
-    // implement IContextManagerListener
-    void onSyncDisplayContext(const std::string& id) override;
-    bool onReleaseDisplayContext(const std::string& id, bool unconditionally) override;
+    // implement DisplayRenderAssembly
+    void onElementSelected(const std::string& item_token);
 
 private:
     void sendEventCommon(std::string ename);
@@ -123,8 +115,6 @@ private:
     std::string pre_ref_dialog_id;
     bool is_finished;
     std::vector<IAudioPlayerListener*> aplayer_listeners;
-    IDisplayListener* display_listener;
-    std::map<std::string, PlaySyncManager::DisplayRenderInfo*> render_info;
 };
 
 } // NuguCore

--- a/service/capability/display_agent.hh
+++ b/service/capability/display_agent.hh
@@ -17,17 +17,15 @@
 #ifndef __NUGU_DISPLAY_AGENT_H__
 #define __NUGU_DISPLAY_AGENT_H__
 
-#include <interface/capability/display_interface.hh>
-
 #include "capability.hh"
+#include "display_render_assembly.hh"
 
 namespace NuguCore {
 
 using namespace NuguInterface;
 
 class DisplayAgent : public Capability,
-                     public IDisplayHandler,
-                     public IPlaySyncManagerListener {
+                     public DisplayRenderAssembly<DisplayAgent> {
 public:
     DisplayAgent();
     virtual ~DisplayAgent();
@@ -36,25 +34,11 @@ public:
     void updateInfoForContext(Json::Value& ctx) override;
     void setCapabilityListener(ICapabilityListener* clistener) override;
 
-    // implement handler
-    void displayRendered(const std::string& id) override;
-    void displayCleared(const std::string& id) override;
-    void elementSelected(const std::string& id, const std::string& item_token) override;
-    void setListener(IDisplayListener* listener) override;
-    void removeListener(IDisplayListener* listener) override;
-    void stopRenderingTimer(const std::string& id) override;
-
-    // implement IContextManagerListener
-    void onSyncDisplayContext(const std::string& id) override;
-    bool onReleaseDisplayContext(const std::string& id, bool unconditionally) override;
+    // implement DisplayRenderAssembly
+    void onElementSelected(const std::string& item_token);
 
 private:
     void sendEventElementSelected(const std::string& item_token);
-
-    IDisplayListener* display_listener;
-    std::map<std::string, PlaySyncManager::DisplayRenderInfo*> render_info;
-    std::string cur_ps_id;
-    std::string cur_token;
 };
 
 } // NuguCore

--- a/service/display_render_assembly.hh
+++ b/service/display_render_assembly.hh
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NUGU_DISPLAY_RENDER_ASSEMBLY_H__
+#define __NUGU_DISPLAY_RENDER_ASSEMBLY_H__
+
+#include <interface/capability/display_interface.hh>
+
+namespace NuguCore {
+
+using namespace NuguInterface;
+
+template <typename T>
+class DisplayRenderAssembly : virtual public IDisplayHandler,
+                              public IPlaySyncManagerListener {
+public:
+    DisplayRenderAssembly();
+    virtual ~DisplayRenderAssembly();
+
+    // implement IDisplayHandler
+    void displayRendered(const std::string& id);
+    void displayCleared(const std::string& id);
+    void elementSelected(const std::string& id, const std::string& item_token);
+    void setListener(IDisplayListener* listener);
+    void removeListener(IDisplayListener* listener);
+    void stopRenderingTimer(const std::string& id);
+
+    // implement IContextManagerListener
+    void onSyncDisplayContext(const std::string& id) override;
+    bool onReleaseDisplayContext(const std::string& id, bool unconditionally) override;
+
+protected:
+    virtual void onElementSelected(const std::string& item_token) = 0;
+
+    IDisplayListener* display_listener = nullptr;
+    std::string disp_cur_ps_id = "";
+    std::string disp_cur_token = "";
+    std::map<std::string, PlaySyncManager::DisplayRenderInfo*> render_info;
+};
+}
+
+#include "display_render_assembly.hpp"
+
+#endif /* __NUGU_DISPLAY_RENDER_ASSEMBLY_H__ */

--- a/service/display_render_assembly.hpp
+++ b/service/display_render_assembly.hpp
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "capability_manager.hh"
+#include "nugu_log.h"
+
+namespace NuguCore {
+
+template <typename T>
+DisplayRenderAssembly<T>::DisplayRenderAssembly()
+{
+}
+
+template <typename T>
+DisplayRenderAssembly<T>::~DisplayRenderAssembly()
+{
+    disp_cur_token = disp_cur_ps_id = "";
+    display_listener = nullptr;
+
+    for (auto info : render_info) {
+        delete info.second;
+    }
+
+    render_info.clear();
+}
+
+template <typename T>
+void DisplayRenderAssembly<T>::displayRendered(const std::string& id)
+{
+    if (static_cast<T*>(this)->getType() == CapabilityType::Display) {
+        if (render_info.find(id) != render_info.end()) {
+            disp_cur_token = render_info[id]->token;
+            disp_cur_ps_id = render_info[id]->ps_id;
+        }
+    }
+}
+
+template <typename T>
+void DisplayRenderAssembly<T>::displayCleared(const std::string& id)
+{
+    std::string ps_id = "";
+
+    if (render_info.find(id) != render_info.end()) {
+        auto info = render_info[id];
+        ps_id = info->ps_id;
+        render_info.erase(id);
+        delete info;
+
+        disp_cur_token = disp_cur_ps_id = "";
+    }
+
+    CapabilityManager::getInstance()->getPlaySyncManager()->clearPendingContext(ps_id);
+}
+
+template <typename T>
+void DisplayRenderAssembly<T>::elementSelected(const std::string& id, const std::string& item_token)
+{
+    auto derived = static_cast<T*>(this);
+
+    if (derived->getType() == CapabilityType::Display) {
+        if (render_info.find(id) == render_info.end()) {
+            nugu_warn("SDK doesn't know or manage the template(%s)", id.c_str());
+            return;
+        }
+
+        disp_cur_token = render_info[id]->token;
+        disp_cur_ps_id = render_info[id]->ps_id;
+
+        derived->onElementSelected(item_token);
+    }
+}
+
+template <typename T>
+void DisplayRenderAssembly<T>::setListener(IDisplayListener* listener)
+{
+    if (!listener)
+        return;
+
+    display_listener = listener;
+}
+
+template <typename T>
+void DisplayRenderAssembly<T>::removeListener(IDisplayListener* listener)
+{
+    if (!display_listener && (display_listener == listener))
+        display_listener = nullptr;
+}
+
+template <typename T>
+void DisplayRenderAssembly<T>::stopRenderingTimer(const std::string& id)
+{
+    CapabilityManager::getInstance()->getPlaySyncManager()->clearContextHold();
+}
+
+template <typename T>
+void DisplayRenderAssembly<T>::onSyncDisplayContext(const std::string& id)
+{
+    nugu_dbg("%s sync context", static_cast<T*>(this)->getName().c_str());
+
+    if (render_info.find(id) == render_info.end())
+        return;
+
+    if (display_listener)
+        display_listener->renderDisplay(id, render_info[id]->type, render_info[id]->payload, render_info[id]->dialog_id);
+}
+
+template <typename T>
+bool DisplayRenderAssembly<T>::onReleaseDisplayContext(const std::string& id, bool unconditionally)
+{
+    nugu_dbg("%s release context", static_cast<T*>(this)->getName().c_str());
+
+    if (render_info.find(id) == render_info.end())
+        return true;
+
+    bool ret = false;
+
+    if (display_listener)
+        ret = display_listener->clearDisplay(id, unconditionally);
+
+    if (unconditionally || ret) {
+        auto info = render_info[id];
+        render_info.erase(id);
+        delete info;
+    }
+
+    if (unconditionally && !ret)
+        nugu_warn("should clear display if unconditionally is true!!");
+
+    return ret;
+}
+
+}


### PR DESCRIPTION
Between DisplayAgent and AudioPlayerAgent, because it needs
to handle display rendering infomation, almost same duplicated
codes exist both DisplayAgent and AudioPlayerAgent.

So, as adding DisplayRenderAssembly for handling display
rendering infomation, it remove duplication.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>