### PR TITLE
move token api to network manager

### DIFF
--- a/examples/standalone/nugu_sample.cc
+++ b/examples/standalone/nugu_sample.cc
@@ -150,7 +150,6 @@ int main(int argc, char** argv)
     auto network_manager_listener(make_unique<NetworkManagerListener>());
 
     nugu_client = make_unique<NuguClient>();
-    nugu_client->setConfig(NuguConfig::Key::ACCESS_TOKEN, getenv("NUGU_TOKEN"));
     nugu_client->setConfig(NuguConfig::Key::MODEL_PATH, nugu_sample_manager->getModelPath());
     nugu_client->setListener(nugu_client_listener.get());
 
@@ -158,6 +157,7 @@ int main(int argc, char** argv)
 
     network_manager = nugu_client->getNetworkManager();
     network_manager->addListener(network_manager_listener.get());
+    network_manager->setToken(getenv("NUGU_TOKEN"));
 
     if (!network_manager->connect()) {
         msg_error("< Cannot connect to NUGU Platform.");

--- a/include/core/nugu_network_manager.h
+++ b/include/core/nugu_network_manager.h
@@ -233,6 +233,21 @@ int nugu_network_manager_disconnect(void);
 int nugu_network_manager_handoff(const NuguNetworkServerPolicy *policy);
 
 /**
+ * @brief Set the access token value.
+ * @param[in] token access token
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ */
+int nugu_network_manager_set_token(const char *token);
+
+/**
+ * @brief Get the access token value.
+ * @return access token value. Please do not modify the data manually.
+ */
+const char *nugu_network_manager_peek_token(void);
+
+/**
  * @}
  */
 

--- a/include/interface/network_manager_interface.hh
+++ b/include/interface/network_manager_interface.hh
@@ -17,6 +17,8 @@
 #ifndef __NUGU_INETWORK_MANAGER_INTERFACE_H__
 #define __NUGU_INETWORK_MANAGER_INTERFACE_H__
 
+#include <string>
+
 namespace NuguInterface {
 
 /**
@@ -90,6 +92,11 @@ public:
      * @brief Request a disconnection with the NUGU server.
      */
     virtual bool disconnect() = 0;
+
+    /**
+     * @brief Set the access token value.
+     */
+    virtual bool setToken(std::string token) = 0;
 };
 
 /**

--- a/include/interface/nugu_configuration.hh
+++ b/include/interface/nugu_configuration.hh
@@ -48,7 +48,6 @@ namespace NuguConfig {
         const std::string SERVER_RESPONSE_TIMEOUT_MSEC = "server_response_timeout_msec";
         const std::string MODEL_PATH = "model_path";
         const std::string TTS_ENGINE = "tts_engine";
-        const std::string ACCESS_TOKEN = NUGU_CONFIG_KEY_TOKEN;
         const std::string USER_AGENT = NUGU_CONFIG_KEY_USER_AGENT;
         const std::string GATEWAY_REGISTRY_DNS = NUGU_CONFIG_KEY_GATEWAY_REGISTRY_DNS;
     }

--- a/interface/nugu_configuration.cc
+++ b/interface/nugu_configuration.cc
@@ -39,7 +39,6 @@ namespace NuguConfig {
             { Key::SERVER_RESPONSE_TIMEOUT_MSEC, "10000" },
             { Key::MODEL_PATH, "./" },
             { Key::TTS_ENGINE, "skt" },
-            { Key::ACCESS_TOKEN, "" },
             { Key::USER_AGENT, NUGU_USERAGENT },
             { Key::GATEWAY_REGISTRY_DNS, "https://reg-http.sktnugu.com" }
         };

--- a/service/network_manager.cc
+++ b/service/network_manager.cc
@@ -93,6 +93,16 @@ std::vector<INetworkManagerListener*> NetworkManager::getListener()
     return listeners;
 }
 
+bool NetworkManager::setToken(std::string token)
+{
+    if (nugu_network_manager_set_token(token.c_str()) < 0) {
+        nugu_error("network set token failed");
+        return false;
+    }
+
+    return true;
+}
+
 bool NetworkManager::connect()
 {
     if (nugu_network_manager_connect() < 0) {

--- a/service/network_manager.hh
+++ b/service/network_manager.hh
@@ -35,6 +35,7 @@ public:
     std::vector<INetworkManagerListener*> getListener();
     bool connect() override;
     bool disconnect() override;
+    bool setToken(std::string token) override;
 
 private:
     std::vector<INetworkManagerListener*> listeners;

--- a/src/network/dg_registry.c
+++ b/src/network/dg_registry.c
@@ -19,6 +19,7 @@
 
 #include "nugu_config.h"
 #include "nugu_log.h"
+#include "nugu_network_manager.h"
 
 #include "dg_registry.h"
 #include "http2/v1_policies.h"
@@ -44,7 +45,7 @@ DGRegistry *dg_registry_new(void)
 	}
 
 	http2_network_set_token(registry->net,
-				nugu_config_get(NUGU_CONFIG_KEY_TOKEN));
+				nugu_network_manager_peek_token());
 	http2_network_enable_curl_log(registry->net);
 	http2_network_start(registry->net);
 

--- a/src/network/dg_server.c
+++ b/src/network/dg_server.c
@@ -84,8 +84,7 @@ DGServer *dg_server_new(const NuguNetworkServerPolicy *policy)
 	server->type = DG_SERVER_TYPE_NORMAL;
 	server->retry_count = 0;
 
-	http2_network_set_token(server->net,
-				nugu_config_get(NUGU_CONFIG_KEY_TOKEN));
+	http2_network_set_token(server->net, nugu_network_manager_peek_token());
 	http2_network_enable_curl_log(server->net);
 	http2_network_start(server->net);
 

--- a/src/nugu_network_manager.c
+++ b/src/nugu_network_manager.c
@@ -65,6 +65,7 @@ static const char * const _debug_status_strmap[] = {
 
 struct _nugu_network {
 	enum connection_step step;
+	char *token;
 
 	/* Registry */
 	DGRegistry *registry;
@@ -516,6 +517,9 @@ static void nugu_network_manager_free(NetworkManager *nm)
 	if (nm->server_list)
 		g_list_free_full(nm->server_list, free);
 
+	if (nm->token)
+		free(nm->token);
+
 	memset(nm, 0, sizeof(NetworkManager));
 	free(nm);
 }
@@ -708,4 +712,34 @@ nugu_network_manager_handoff(const NuguNetworkServerPolicy *policy)
 	_update_step(_network, STEP_SERVER_HANDOFF);
 
 	return 0;
+}
+
+int nugu_network_manager_set_token(const char *token)
+{
+	if (!_network) {
+		nugu_error("network manager not initialized");
+		return -1;
+	}
+
+	if (!token) {
+		nugu_error("token is NULL");
+		return -1;
+	}
+
+	if (_network->token)
+		free(_network->token);
+
+	_network->token = strdup(token);
+
+	return 0;
+}
+
+const char *nugu_network_manager_peek_token(void)
+{
+	if (!_network) {
+		nugu_error("network manager not initialized");
+		return NULL;
+	}
+
+	return _network->token;
 }

--- a/src/nugu_uuid.c
+++ b/src/nugu_uuid.c
@@ -22,7 +22,7 @@
 
 #include "nugu_uuid.h"
 #include "nugu_log.h"
-#include "nugu_config.h"
+#include "nugu_network_manager.h"
 
 #define BASE_TIMESTAMP 1546300800 /* GMT: 2019/1/1 00:00:00 */
 
@@ -109,7 +109,7 @@ EXPORT_API char *nugu_uuid_generate_time(void)
 	RAND_status();
 	RAND_bytes(buf + 5, 3);
 
-	seed = nugu_config_get(NUGU_CONFIG_KEY_TOKEN);
+	seed = nugu_network_manager_peek_token();
 	if (seed) {
 		unsigned char mdbuf[SHA_DIGEST_LENGTH];
 


### PR DESCRIPTION
To clarify the role of the APIs, move the token API in the
configuration to the network manager.

Signed-off-by: Inho Oh <inho.oh@sk.com>