### PR TITLE
update DisplayRenderAssembly efficiency

### DIFF
--- a/service/capability/audio_player_agent.cc
+++ b/service/capability/audio_player_agent.cc
@@ -17,7 +17,6 @@
 #include <glib.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
 #include <unistd.h>
 
 #include "audio_player_agent.hh"
@@ -354,22 +353,14 @@ void AudioPlayerAgent::parsingPlay(const char* message)
         Json::Value meta = audio_item["metadata"];
 
         if (!meta.empty() && !meta["template"].empty()) {
-            PlaySyncManager::DisplayRenderInfo* info;
             Json::StyledWriter writer;
-            struct timeval tv;
-            std::string id;
 
-            gettimeofday(&tv, NULL);
-            id = std::to_string(tv.tv_sec) + std::to_string(tv.tv_usec);
-
-            info = new PlaySyncManager::DisplayRenderInfo;
-            info->id = id;
-            info->ps_id = ps_id;
-            info->type = meta["template"]["type"].asString();
-            info->payload = writer.write(meta["template"]);
-            info->dialog_id = nugu_directive_peek_dialog_id(getNuguDirective());
-            info->token = root["token"].asString();
-            render_info[id] = info;
+            std::string id = composeRenderInfo(std::make_tuple(
+                ps_id,
+                meta["template"]["type"].asString(),
+                writer.write(meta["template"]),
+                nugu_directive_peek_dialog_id(getNuguDirective()),
+                root["token"].asString()));
 
             renderer.cap_type = getType();
             renderer.listener = this;

--- a/service/capability/display_agent.cc
+++ b/service/capability/display_agent.cc
@@ -17,7 +17,6 @@
 #include <glib.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
 #include <unistd.h>
 
 #include "capability_manager.hh"
@@ -57,19 +56,12 @@ void DisplayAgent::parsingDirective(const char* dname, const char* message)
     std::string playstackctl_ps_id = getPlayServiceIdInStackControl(root["playStackControl"]);
 
     if (!playstackctl_ps_id.empty()) {
-        struct timeval tv;
-
-        gettimeofday(&tv, NULL);
-        std::string id = std::to_string(tv.tv_sec) + std::to_string(tv.tv_usec);
-
-        PlaySyncManager::DisplayRenderInfo* info = new PlaySyncManager::DisplayRenderInfo;
-        info->id = id;
-        info->ps_id = root["playServiceId"].asString();
-        info->type = type;
-        info->payload = message;
-        info->dialog_id = nugu_directive_peek_dialog_id(getNuguDirective());
-        info->token = root["token"].asString();
-        render_info[id] = info;
+        std::string id = composeRenderInfo(std::make_tuple(
+            root["playServiceId"].asString(),
+            type,
+            message,
+            nugu_directive_peek_dialog_id(getNuguDirective()),
+            root["token"].asString()));
 
         // sync display rendering with context
         PlaySyncManager::DisplayRenderer renderer;

--- a/service/display_render_assembly.hh
+++ b/service/display_render_assembly.hh
@@ -27,8 +27,12 @@ template <typename T>
 class DisplayRenderAssembly : virtual public IDisplayHandler,
                               public IPlaySyncManagerListener {
 public:
+    using RenderInfoParam = std::tuple<std::string, std::string, std::string, std::string, std::string>;
+
     DisplayRenderAssembly();
     virtual ~DisplayRenderAssembly();
+
+    std::string composeRenderInfo(const RenderInfoParam& param);
 
     // implement IDisplayHandler
     void displayRendered(const std::string& id);
@@ -48,6 +52,8 @@ protected:
     IDisplayListener* display_listener = nullptr;
     std::string disp_cur_ps_id = "";
     std::string disp_cur_token = "";
+
+private:
     std::map<std::string, PlaySyncManager::DisplayRenderInfo*> render_info;
 };
 }

--- a/service/display_render_assembly.hpp
+++ b/service/display_render_assembly.hpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <sys/time.h>
+
 #include "capability_manager.hh"
 #include "nugu_log.h"
 
@@ -35,6 +37,21 @@ DisplayRenderAssembly<T>::~DisplayRenderAssembly()
     }
 
     render_info.clear();
+}
+
+template <typename T>
+std::string DisplayRenderAssembly<T>::composeRenderInfo(const RenderInfoParam& param)
+{
+    PlaySyncManager::DisplayRenderInfo* info = new PlaySyncManager::DisplayRenderInfo;
+    struct timeval tv;
+
+    gettimeofday(&tv, NULL);
+    info->id = std::to_string(tv.tv_sec) + std::to_string(tv.tv_usec);
+
+    std::tie(info->ps_id, info->type, info->payload, info->dialog_id, info->token) = param;
+    render_info[info->id] = info;
+
+    return info->id;
 }
 
 template <typename T>

--- a/service/playsync_manager.cc
+++ b/service/playsync_manager.cc
@@ -128,7 +128,7 @@ void PlaySyncManager::addContext(const std::string& ps_id, CapabilityType cap_ty
     Test::showAllContents(context_map);
 }
 
-void PlaySyncManager::removeContext(std::string ps_id, CapabilityType cap_type, bool immediately)
+void PlaySyncManager::removeContext(const std::string& ps_id, CapabilityType cap_type, bool immediately)
 {
     if (ps_id.empty()) {
         nugu_error("Invalid PlayServiceId.");
@@ -173,7 +173,7 @@ void PlaySyncManager::removeContext(std::string ps_id, CapabilityType cap_type, 
     is_expect_speech = false;
 }
 
-void PlaySyncManager::clearPendingContext(std::string ps_id)
+void PlaySyncManager::clearPendingContext(const std::string& ps_id)
 {
     renderer_map.erase(ps_id);
     removeContext(ps_id, CapabilityType::Display);
@@ -198,7 +198,7 @@ std::string PlaySyncManager::getPlayStackItem(CapabilityType cap_type)
     return "";
 }
 
-void PlaySyncManager::addStackElement(std::string ps_id, CapabilityType cap_type)
+void PlaySyncManager::addStackElement(const std::string& ps_id, CapabilityType cap_type)
 {
     auto& stack_elements = context_map[ps_id];
 
@@ -206,7 +206,7 @@ void PlaySyncManager::addStackElement(std::string ps_id, CapabilityType cap_type
         stack_elements.push_back(cap_type);
 }
 
-bool PlaySyncManager::removeStackElement(std::string ps_id, CapabilityType cap_type)
+bool PlaySyncManager::removeStackElement(const std::string& ps_id, CapabilityType cap_type)
 {
     auto& stack_elements = context_map[ps_id];
     stack_elements.erase(remove(stack_elements.begin(), stack_elements.end(), cap_type), stack_elements.end());
@@ -214,7 +214,7 @@ bool PlaySyncManager::removeStackElement(std::string ps_id, CapabilityType cap_t
     return stack_elements.empty();
 }
 
-void PlaySyncManager::addRenderer(std::string ps_id, DisplayRenderer& renderer)
+void PlaySyncManager::addRenderer(const std::string& ps_id, DisplayRenderer& renderer)
 {
     // remove previous renderers firstly
     auto renderer_keys = getKeyOfMap(renderer_map);
@@ -227,7 +227,7 @@ void PlaySyncManager::addRenderer(std::string ps_id, DisplayRenderer& renderer)
     renderer.listener->onSyncDisplayContext(renderer.display_id);
 }
 
-bool PlaySyncManager::removeRenderer(std::string ps_id, bool unconditionally)
+bool PlaySyncManager::removeRenderer(const std::string& ps_id, bool unconditionally)
 {
     if (renderer_map.find(ps_id) == renderer_map.end())
         return true;

--- a/service/playsync_manager.hh
+++ b/service/playsync_manager.hh
@@ -61,8 +61,8 @@ public:
 
     void addContext(const std::string& ps_id, CapabilityType cap_type);
     void addContext(const std::string& ps_id, CapabilityType cap_type, DisplayRenderer renderer);
-    void removeContext(std::string ps_id, CapabilityType cap_type, bool immediately = true);
-    void clearPendingContext(std::string ps_id);
+    void removeContext(const std::string& ps_id, CapabilityType cap_type, bool immediately = true);
+    void clearPendingContext(const std::string& ps_id);
     std::vector<std::string> getAllPlayStackItems();
     std::string getPlayStackItem(CapabilityType cap_type);
 
@@ -72,10 +72,10 @@ public:
     void onASRError();
 
 private:
-    void addStackElement(std::string ps_id, CapabilityType cap_type);
-    bool removeStackElement(std::string ps_id, CapabilityType cap_type);
-    void addRenderer(std::string ps_id, DisplayRenderer& renderer);
-    bool removeRenderer(std::string ps_id, bool unconditionally = true);
+    void addStackElement(const std::string& ps_id, CapabilityType cap_type);
+    bool removeStackElement(const std::string& ps_id, CapabilityType cap_type);
+    void addRenderer(const std::string& ps_id, DisplayRenderer& renderer);
+    bool removeRenderer(const std::string& ps_id, bool unconditionally = true);
     void setTimerInterval(const std::string& ps_id);
 
     static const std::map<std::string, long> DURATION_MAP;


### PR DESCRIPTION
It change to compose DisplayRenderInfo in DisplayRenderAssembly.

And it apply const reference parameter on PlaySyncManager.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>