### PR TITLE
config: move UserAgent and RegistryDns to network

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ SET(VERSION_PATCH 0)
 SET(VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 
 SET(NUGU_USERAGENT "OpenSDK/1.0.0 (Linux) Client/${VERSION}")
+SET(NUGU_REGISTRY_URL "https://reg-http.sktnugu.com")
 
 SET(version ${VERSION})
 SET(prefix ${CMAKE_INSTALL_PREFIX})
@@ -123,6 +124,9 @@ ADD_DEFINITIONS(
 
 	# UserAgent information for network request
 	-DNUGU_USERAGENT=\"${NUGU_USERAGENT}\"
+
+	# Device gateway registry default url
+	-DNUGU_REGISTRY_URL=\"${NUGU_REGISTRY_URL}\"
 )
 
 # Global include directories

--- a/include/core/nugu_config.h
+++ b/include/core/nugu_config.h
@@ -31,21 +31,6 @@ extern "C" {
  */
 
 /**
- * @brief Predefined key name for token
- */
-#define NUGU_CONFIG_KEY_TOKEN "token"
-
-/**
- * @brief Predefined key name for user_agent
- */
-#define NUGU_CONFIG_KEY_USER_AGENT "user_agent"
-
-/**
- * @brief Predefined key name for gateway_registry_dns
- */
-#define NUGU_CONFIG_KEY_GATEWAY_REGISTRY_DNS "gateway_registry_dns"
-
-/**
  * @brief Initialize configuration hash table
  */
 void nugu_config_initialize(void);

--- a/include/core/nugu_network_manager.h
+++ b/include/core/nugu_network_manager.h
@@ -248,6 +248,36 @@ int nugu_network_manager_set_token(const char *token);
 const char *nugu_network_manager_peek_token(void);
 
 /**
+ * @brief Set the device gateway registry url.
+ * @param[in] urlname gateway registry url
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ */
+int nugu_network_manager_set_registry_url(const char *urlname);
+
+/**
+ * @brief Get the device gateway registry url.
+ * @return gateway registry url. Please do not modify the data manually.
+ */
+const char *nugu_network_manager_peek_registry_url(void);
+
+/**
+ * @brief Set the HTTP header UserAgent information.
+ * @param[in] uagent UserAgent information
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ */
+int nugu_network_manager_set_useragent(const char *uagent);
+
+/**
+ * @brief Get the UserAgent information.
+ * @return UserAgent information. Please do not modify the data manually.
+ */
+const char *nugu_network_manager_peek_useragent(void);
+
+/**
  * @}
  */
 

--- a/include/interface/network_manager_interface.hh
+++ b/include/interface/network_manager_interface.hh
@@ -97,6 +97,16 @@ public:
      * @brief Set the access token value.
      */
     virtual bool setToken(std::string token) = 0;
+
+    /**
+     * @brief Set the device gateway registry url.
+     */
+    virtual bool setRegistryUrl(std::string url) = 0;
+
+    /**
+     * @brief Set the HTTP header UserAgent information.
+     */
+    virtual bool setUserAgent(std::string uagent) = 0;
 };
 
 /**

--- a/include/interface/nugu_configuration.hh
+++ b/include/interface/nugu_configuration.hh
@@ -48,8 +48,6 @@ namespace NuguConfig {
         const std::string SERVER_RESPONSE_TIMEOUT_MSEC = "server_response_timeout_msec";
         const std::string MODEL_PATH = "model_path";
         const std::string TTS_ENGINE = "tts_engine";
-        const std::string USER_AGENT = NUGU_CONFIG_KEY_USER_AGENT;
-        const std::string GATEWAY_REGISTRY_DNS = NUGU_CONFIG_KEY_GATEWAY_REGISTRY_DNS;
     }
 
     const NuguConfigType getDefaultValues();

--- a/interface/nugu_client_impl.cc
+++ b/interface/nugu_client_impl.cc
@@ -36,7 +36,6 @@ NuguClientImpl::NuguClientImpl()
 {
     nugu_config_initialize();
     nugu_equeue_initialize();
-    readEnviromentVariables();
     setDefaultConfigs();
 
     network_manager = std::unique_ptr<INetworkManager>(CapabilityCreator::createNetworkManager());
@@ -249,17 +248,6 @@ void NuguClientImpl::onStatusChanged(NetworkStatus status)
 INetworkManager* NuguClientImpl::getNetworkManager()
 {
     return network_manager.get();
-}
-
-void NuguClientImpl::readEnviromentVariables()
-{
-    char* registry_override;
-
-    registry_override = getenv("NUGU_REGISTRY_SERVER");
-    if (!registry_override)
-        return;
-
-    config_env_map[NuguConfig::Key::GATEWAY_REGISTRY_DNS] = registry_override;
 }
 
 IMediaPlayer* NuguClientImpl::createMediaPlayer()

--- a/interface/nugu_client_impl.hh
+++ b/interface/nugu_client_impl.hh
@@ -59,7 +59,6 @@ public:
 private:
     int createCapabilities(void);
     void setDefaultConfigs();
-    void readEnviromentVariables();
 
     std::map<CapabilityType, std::pair<ICapabilityInterface*, ICapabilityListener*>> icapability_map;
     std::map<std::string, std::string> config_map;

--- a/interface/nugu_configuration.cc
+++ b/interface/nugu_configuration.cc
@@ -38,9 +38,7 @@ namespace NuguConfig {
             { Key::KWD_CHANNEL, "1"},
             { Key::SERVER_RESPONSE_TIMEOUT_MSEC, "10000" },
             { Key::MODEL_PATH, "./" },
-            { Key::TTS_ENGINE, "skt" },
-            { Key::USER_AGENT, NUGU_USERAGENT },
-            { Key::GATEWAY_REGISTRY_DNS, "https://reg-http.sktnugu.com" }
+            { Key::TTS_ENGINE, "skt" }
         };
     }
 

--- a/service/network_manager.cc
+++ b/service/network_manager.cc
@@ -103,6 +103,26 @@ bool NetworkManager::setToken(std::string token)
     return true;
 }
 
+bool NetworkManager::setRegistryUrl(std::string url)
+{
+    if (nugu_network_manager_set_registry_url(url.c_str()) < 0) {
+        nugu_error("network set registry url failed");
+        return false;
+    }
+
+    return true;
+}
+
+bool NetworkManager::setUserAgent(std::string uagent)
+{
+    if (nugu_network_manager_set_useragent(uagent.c_str()) < 0) {
+        nugu_error("network set useragent failed");
+        return false;
+    }
+
+    return true;
+}
+
 bool NetworkManager::connect()
 {
     if (nugu_network_manager_connect() < 0) {

--- a/service/network_manager.hh
+++ b/service/network_manager.hh
@@ -36,6 +36,8 @@ public:
     bool connect() override;
     bool disconnect() override;
     bool setToken(std::string token) override;
+    bool setRegistryUrl(std::string url) override;
+    bool setUserAgent(std::string uagent) override;
 
 private:
     std::vector<INetworkManagerListener*> listeners;

--- a/src/network/dg_registry.c
+++ b/src/network/dg_registry.c
@@ -17,7 +17,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "nugu_config.h"
 #include "nugu_log.h"
 #include "nugu_network_manager.h"
 
@@ -70,7 +69,7 @@ int dg_registry_request(DGRegistry *registry)
 	g_return_val_if_fail(registry != NULL, -1);
 	g_return_val_if_fail(registry->net != NULL, -1);
 
-	host = nugu_config_get(NUGU_CONFIG_KEY_GATEWAY_REGISTRY_DNS);
+	host = nugu_network_manager_peek_registry_url();
 	if (!host) {
 		nugu_error("Gateway registry host is not set.");
 		return -1;

--- a/src/network/dg_server.c
+++ b/src/network/dg_server.c
@@ -17,7 +17,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "nugu_config.h"
 #include "nugu_log.h"
 #include "nugu_event.h"
 #include "nugu_uuid.h"

--- a/src/network/http2/http2_network.c
+++ b/src/network/http2/http2_network.c
@@ -24,7 +24,8 @@
 #include <errno.h>
 
 #include "nugu_log.h"
-#include "nugu_config.h"
+#include "nugu_network_manager.h"
+
 #include "http2_network.h"
 
 enum request_type {
@@ -288,7 +289,7 @@ HTTP2Network *http2_network_new()
 
 	net->wakeup_fd = eventfd(0, EFD_CLOEXEC);
 	net->requests = g_async_queue_new_full(g_free);
-	net->useragent = nugu_config_get(NUGU_CONFIG_KEY_USER_AGENT);
+	net->useragent = nugu_network_manager_peek_useragent();
 
 	return net;
 }

--- a/src/network/http2/v1_policies.cc
+++ b/src/network/http2/v1_policies.cc
@@ -19,7 +19,6 @@
 #include <string.h>
 
 #include "nugu_buffer.h"
-#include "nugu_config.h"
 #include "nugu_equeue.h"
 #include "nugu_log.h"
 #include "nugu_network_manager.h"

--- a/src/nugu_network_manager.c
+++ b/src/nugu_network_manager.c
@@ -66,8 +66,10 @@ static const char * const _debug_status_strmap[] = {
 struct _nugu_network {
 	enum connection_step step;
 	char *token;
+	char *useragent;
 
 	/* Registry */
+	char *registry_url;
 	DGRegistry *registry;
 	struct dg_health_check_policy policy;
 	GList *server_list;
@@ -520,6 +522,12 @@ static void nugu_network_manager_free(NetworkManager *nm)
 	if (nm->token)
 		free(nm->token);
 
+	if (nm->registry_url)
+		free(nm->registry_url);
+
+	if (nm->useragent)
+		free(nm->useragent);
+
 	memset(nm, 0, sizeof(NetworkManager));
 	free(nm);
 }
@@ -541,6 +549,9 @@ EXPORT_API int nugu_network_manager_initialize(void)
 	_network = nugu_network_manager_new();
 	if (!_network)
 		return -1;
+
+	nugu_network_manager_set_registry_url(NUGU_REGISTRY_URL);
+	nugu_network_manager_set_useragent(NUGU_USERAGENT);
 
 	return 0;
 }
@@ -742,4 +753,76 @@ const char *nugu_network_manager_peek_token(void)
 	}
 
 	return _network->token;
+}
+
+int nugu_network_manager_set_registry_url(const char *urlname)
+{
+	char *override_value;
+
+	if (!_network) {
+		nugu_error("network manager not initialized");
+		return -1;
+	}
+
+	if (!urlname) {
+		nugu_error("urlname is NULL");
+		return -1;
+	}
+
+	if (_network->registry_url)
+		free(_network->registry_url);
+
+	override_value = getenv("NUGU_REGISTRY_SERVER");
+	if (override_value)
+		_network->registry_url = strdup(override_value);
+	else
+		_network->registry_url = strdup(urlname);
+
+	return 0;
+}
+
+const char *nugu_network_manager_peek_registry_url(void)
+{
+	if (!_network) {
+		nugu_error("network manager not initialized");
+		return NULL;
+	}
+
+	return _network->registry_url;
+}
+
+int nugu_network_manager_set_useragent(const char *uagent)
+{
+	char *override_value;
+
+	if (!_network) {
+		nugu_error("network manager not initialized");
+		return -1;
+	}
+
+	if (!uagent) {
+		nugu_error("urlname is NULL");
+		return -1;
+	}
+
+	if (_network->useragent)
+		free(_network->useragent);
+
+	override_value = getenv("NUGU_USERAGENT");
+	if (override_value)
+		_network->useragent = strdup(override_value);
+	else
+		_network->useragent = strdup(uagent);
+
+	return 0;
+}
+
+const char *nugu_network_manager_peek_useragent(void)
+{
+	if (!_network) {
+		nugu_error("network manager not initialized");
+		return NULL;
+	}
+
+	return _network->useragent;
 }


### PR DESCRIPTION
Move the USER_AGENT and REGISTRY_DNS configuration key to network
manager to clarify the role of the APIs.

Signed-off-by: Inho Oh <inho.oh@sk.com>