### PR TITLE
capability: system agent handoff spec updated

### DIFF
--- a/service/capability/system_agent.cc
+++ b/service/capability/system_agent.cc
@@ -209,25 +209,25 @@ void SystemAgent::parsingHandoffConnection(const char* message)
         return;
     }
 
-    if (root["domain"].isString()) {
-        const char* tmp = root["domain"].asCString();
+    if (root["hostname"].isString()) {
+        const char* tmp = root["hostname"].asCString();
         if (tmp) {
             int len = strlen(tmp);
             memcpy(policy.hostname, tmp, (len > NUGU_NETWORK_MAX_ADDRESS) ? NUGU_NETWORK_MAX_ADDRESS : len);
         }
     } else {
-        nugu_error("can't find 'domain' string attribute");
+        nugu_error("can't find 'hostname' string attribute");
         return;
     }
 
-    if (root["hostname"].isString()) {
-        const char* tmp = root["hostname"].asCString();
+    if (root["address"].isString()) {
+        const char* tmp = root["address"].asCString();
         if (tmp) {
             int len = strlen(tmp);
             memcpy(policy.address, tmp, (len > NUGU_NETWORK_MAX_ADDRESS) ? NUGU_NETWORK_MAX_ADDRESS : len);
         }
     } else {
-        nugu_error("can't find 'hostname' string attribute");
+        nugu_error("can't find 'address' string attribute");
         return;
     }
 

--- a/src/network/dg_server.c
+++ b/src/network/dg_server.c
@@ -133,7 +133,8 @@ int dg_server_connect_async(DGServer *server)
 	if (server->directives)
 		v1_directives_free(server->directives);
 
-	server->directives = v1_directives_new(server->host);
+	server->directives = v1_directives_new(
+		server->host, server->policy.connection_timeout_ms / 1000);
 
 	ret = v1_directives_establish(server->directives, server->net);
 	if (ret < 0) {

--- a/src/network/http2/v1_directives.cc
+++ b/src/network/http2/v1_directives.cc
@@ -50,6 +50,8 @@ struct _v1_directives {
     MultipartParser* parser;
     HTTP2Network* network;
 
+    int connection_timeout_secs;
+
     enum content_type ctype;
     char* parent_msg_id;
     int is_end;
@@ -322,7 +324,7 @@ static void _on_finish(HTTP2Request* req, void* userdata)
     return;
 }
 
-V1Directives* v1_directives_new(const char* host)
+V1Directives* v1_directives_new(const char* host, int connection_timeout_secs)
 {
     struct _v1_directives* dir;
 
@@ -335,6 +337,7 @@ V1Directives* v1_directives_new(const char* host)
     }
 
     dir->url = g_strdup_printf("%s/v1/directives", host);
+    dir->connection_timeout_secs = connection_timeout_secs;
 
     return dir;
 }
@@ -381,7 +384,7 @@ int v1_directives_establish(V1Directives* dir, HTTP2Network* net)
     http2_request_set_header_callback(req, _on_header, dir);
     http2_request_set_body_callback(req, _on_body, dir);
     http2_request_set_finish_callback(req, _on_finish, dir);
-    http2_request_set_connection_timeout(req, 0);
+    http2_request_set_connection_timeout(req, dir->connection_timeout_secs);
     http2_request_enable_curl_log(req);
 
     ret = http2_network_add_request(net, req);

--- a/src/network/http2/v1_directives.h
+++ b/src/network/http2/v1_directives.h
@@ -25,7 +25,7 @@ extern "C" {
 
 typedef struct _v1_directives V1Directives;
 
-V1Directives *v1_directives_new(const char *host);
+V1Directives *v1_directives_new(const char *host, int connection_timeout_secs);
 void v1_directives_free(V1Directives *dir);
 
 int v1_directives_establish(V1Directives *dir, HTTP2Network *net);


### PR DESCRIPTION
    The payload specification of the HandoffConnection directive has
    changed as follow:

      - 'hostname' property changed to 'address'
      - 'domain' property changed to 'hostname'

    Signed-off-by: Inho Oh <inho.oh@sk.com>

----

    network: add connection timeout

    add missing connection timeout to device gateway server to prevent
    unlimit waiting for connection.

    Signed-off-by: Inho Oh <inho.oh@sk.com>