### PR TITLE
network: split the handoff event

### DIFF
--- a/core/capability/system_agent.cc
+++ b/core/capability/system_agent.cc
@@ -36,13 +36,24 @@ SystemAgent::SystemAgent()
 {
     nugu_network_manager_set_handoff_status_callback(
         [](NuguNetworkHandoffStatus status, void* userdata) {
-            if (status != NUGU_NETWORK_HANDOFF_SUCCESS)
-                return;
-
             SystemAgent* sa = static_cast<SystemAgent*>(userdata);
 
-            nugu_info("handoff ok. send synchronizeState() event");
-            sa->synchronizeState();
+            switch (status) {
+            case NUGU_NETWORK_HANDOFF_FAILED:
+                nugu_error("handoff failed");
+                break;
+            case NUGU_NETWORK_HANDOFF_READY:
+                nugu_dbg("handoff ready. send 'Disconnect' event");
+                sa->sendEventDisconnect();
+                break;
+            case NUGU_NETWORK_HANDOFF_COMPLETED:
+                nugu_dbg("handoff completed. send 'SynchronizeState' event");
+                sa->synchronizeState();
+                break;
+            default:
+                nugu_error("invalid status: %d", status);
+                break;
+            }
         },
         this);
 }

--- a/include/base/nugu_network_manager.h
+++ b/include/base/nugu_network_manager.h
@@ -71,7 +71,13 @@ typedef void (*NetworkManagerStatusCallback)(NuguNetworkStatus status,
  */
 enum nugu_network_handoff_status {
 	NUGU_NETWORK_HANDOFF_FAILED,
-	NUGU_NETWORK_HANDOFF_SUCCESS
+	/**< Handoff failed */
+
+	NUGU_NETWORK_HANDOFF_READY,
+	/**< The handoff connection is ready but not yet switched. */
+
+	NUGU_NETWORK_HANDOFF_COMPLETED
+	/**< The transition to the handoff connection is complete. */
 };
 
 /**


### PR DESCRIPTION
To manage the 'Disconnect' event during handoff connection, split
the HANDOFF_SUCCESS event to HANDOFF_READY and HANDOFF_COMPLETED.

Signed-off-by: Inho Oh <inho.oh@sk.com>