### PR TITLE
upgrade using vector efficiency

### DIFF
--- a/core/audio_recorder_manager.cc
+++ b/core/audio_recorder_manager.cc
@@ -136,7 +136,7 @@ bool AudioRecorderManager::start(IAudioRecorder* recorder)
     std::list<IAudioRecorder*> recorder_list = recorders[nugu_recorder];
     auto iter = std::find(recorder_list.begin(), recorder_list.end(), recorder);
     if (iter == recorder_list.end()) {
-        recorder_list.push_back(recorder);
+        recorder_list.emplace_back(recorder);
         recorders[nugu_recorder] = recorder_list;
     }
 

--- a/core/capability/asr_agent.cc
+++ b/core/capability/asr_agent.cc
@@ -262,7 +262,7 @@ void ASRAgent::getProperties(const std::string& property, std::list<std::string>
 {
     if (property == "es.domainTypes") {
         for (int i = 0; i < (int)es_attr.domain_types.size(); i++) {
-            values.push_back(es_attr.domain_types[i].asString());
+            values.emplace_back(es_attr.domain_types[i].asString());
         }
     } else {
         values.clear();
@@ -386,7 +386,7 @@ void ASRAgent::setCapabilityListener(ICapabilityListener* clistener)
 void ASRAgent::addListener(IASRListener* listener)
 {
     if (listener && std::find(asr_listeners.begin(), asr_listeners.end(), listener) == asr_listeners.end()) {
-        asr_listeners.push_back(listener);
+        asr_listeners.emplace_back(listener);
     }
 }
 

--- a/core/capability/audio_player_agent.cc
+++ b/core/capability/audio_player_agent.cc
@@ -198,7 +198,7 @@ void AudioPlayerAgent::addListener(IAudioPlayerListener* listener)
     auto iterator = std::find(aplayer_listeners.begin(), aplayer_listeners.end(), listener);
 
     if (iterator == aplayer_listeners.end())
-        aplayer_listeners.push_back(listener);
+        aplayer_listeners.emplace_back(listener);
 }
 
 void AudioPlayerAgent::removeListener(IAudioPlayerListener* listener)

--- a/core/capability/capability.cc
+++ b/core/capability/capability.cc
@@ -16,8 +16,8 @@
 
 #include <string.h>
 
-#include "base/nugu_log.h"
 #include "base/nugu_directive_sequencer.h"
+#include "base/nugu_log.h"
 
 #include "capability.hh"
 #include "capability_manager.hh"
@@ -296,7 +296,7 @@ void Capability::registerObserver(ICapabilityObserver* observer)
     auto iterator = std::find(observers.begin(), observers.end(), observer);
 
     if (iterator == observers.end())
-        observers.push_back(observer);
+        observers.emplace_back(observer);
 }
 
 void Capability::removeObserver(ICapabilityObserver* observer)

--- a/core/capability_creator.hh
+++ b/core/capability_creator.hh
@@ -30,7 +30,7 @@ using namespace NuguInterface;
 
 class CapabilityCreator {
 public:
-    virtual ~CapabilityCreator() = default;
+    CapabilityCreator() = delete;
 
     static IWakeupHandler* createWakeupHandler();
     static INetworkManager* createNetworkManager();

--- a/core/capability_manager_helper.hh
+++ b/core/capability_manager_helper.hh
@@ -25,6 +25,8 @@ using namespace NuguInterface;
 
 class CapabilityManagerHelper {
 public:
+    CapabilityManagerHelper() = delete;
+
     static void addCapability(std::string cname, ICapabilityInterface* cap);
     static void removeCapability(std::string cname);
     static void destroyInstance();

--- a/core/media_player.cc
+++ b/core/media_player.cc
@@ -16,8 +16,8 @@
 
 #include <glib.h>
 
-#include <list>
 #include <algorithm>
+#include <list>
 #include <map>
 
 #include "base/nugu_log.h"
@@ -204,7 +204,7 @@ void MediaPlayer::addListener(IMediaPlayerListener* listener)
 {
     auto iter = std::find(d->listeners.begin(), d->listeners.end(), listener);
     if (iter == d->listeners.end())
-        d->listeners.push_back(listener);
+        d->listeners.emplace_back(listener);
 }
 
 void MediaPlayer::removeListener(IMediaPlayerListener* listener)

--- a/core/network_manager.cc
+++ b/core/network_manager.cc
@@ -78,7 +78,7 @@ NetworkManager::~NetworkManager()
 void NetworkManager::addListener(INetworkManagerListener* listener)
 {
     if (listener && std::find(listeners.begin(), listeners.end(), listener) == listeners.end())
-        listeners.push_back(listener);
+        listeners.emplace_back(listener);
 }
 
 void NetworkManager::removeListener(INetworkManagerListener* listener)

--- a/core/playsync_manager.cc
+++ b/core/playsync_manager.cc
@@ -120,9 +120,9 @@ void PlaySyncManager::addContext(const std::string& ps_id, CapabilityType cap_ty
         nugu_dbg("[context] add context");
 
         std::vector<CapabilityType> stack_elements;
-        stack_elements.push_back(cap_type);
+        stack_elements.emplace_back(cap_type);
         context_map[ps_id] = stack_elements;
-        context_stack.push_back(ps_id);
+        context_stack.emplace_back(ps_id);
     }
 
     // temp: Just debugging & test. Please, maintain in some period.
@@ -204,7 +204,7 @@ void PlaySyncManager::addStackElement(const std::string& ps_id, CapabilityType c
     auto& stack_elements = context_map[ps_id];
 
     if (std::find(stack_elements.begin(), stack_elements.end(), cap_type) == stack_elements.end())
-        stack_elements.push_back(cap_type);
+        stack_elements.emplace_back(cap_type);
 }
 
 bool PlaySyncManager::removeStackElement(const std::string& ps_id, CapabilityType cap_type)


### PR DESCRIPTION
It delete default constructor in CapabilityCreator and
CapabilityManagerHelper for preventing new instance,
because both class are static class.

It replace vector's push_back function to emplace_back
because later function reduce creating temporary instance
for parameter by one.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>