### PR TITLE
focus: remove MIC focus

### DIFF
--- a/core/capability/asr_agent.hh
+++ b/core/capability/asr_agent.hh
@@ -86,7 +86,7 @@ private:
     void parsingExpectSpeech(const char* message);
     void parsingNotifyResult(const char* message);
 
-    void releaseASRSpeakFocus(bool is_cancel, ASRError error);
+    void releaseASRFocus(bool is_cancel, ASRError error);
 
     ExpectSpeechAttr es_attr;
     CapabilityEvent* rec_event;

--- a/core/capability/audio_player_agent.cc
+++ b/core/capability/audio_player_agent.cc
@@ -68,7 +68,7 @@ void AudioPlayerAgent::initialize()
     initialized = true;
 }
 
-NuguFocusResult AudioPlayerAgent::onFocus(NuguFocusResource rsrc, void* event)
+NuguFocusResult AudioPlayerAgent::onFocus(void* event)
 {
     if (is_paused)
         return NUGU_FOCUS_OK;
@@ -83,7 +83,7 @@ NuguFocusResult AudioPlayerAgent::onFocus(NuguFocusResource rsrc, void* event)
     return NUGU_FOCUS_OK;
 }
 
-NuguFocusResult AudioPlayerAgent::onUnfocus(NuguFocusResource rsrc, void* event)
+NuguFocusResult AudioPlayerAgent::onUnfocus(void* event)
 {
     if (is_finished)
         return NUGU_FOCUS_REMOVE;
@@ -101,7 +101,7 @@ NuguFocusResult AudioPlayerAgent::onUnfocus(NuguFocusResource rsrc, void* event)
     return NUGU_FOCUS_PAUSE;
 }
 
-NuguFocusStealResult AudioPlayerAgent::onStealRequest(NuguFocusResource rsrc, void* event, NuguFocusType target_type)
+NuguFocusStealResult AudioPlayerAgent::onStealRequest(void* event, NuguFocusType target_type)
 {
     return NUGU_FOCUS_STEAL_ALLOW;
 }
@@ -404,7 +404,7 @@ void AudioPlayerAgent::parsingPlay(const char* message)
         return;
     }
 
-    CapabilityManager::getInstance()->requestFocus("cap_audio", NUGU_FOCUS_RESOURCE_SPK, NULL);
+    CapabilityManager::getInstance()->requestFocus("cap_audio", NULL);
 }
 
 void AudioPlayerAgent::parsingPause(const char* message)
@@ -430,7 +430,7 @@ void AudioPlayerAgent::parsingPause(const char* message)
             sendEventPlaybackFailed(PlaybackError::MEDIA_ERROR_INTERNAL_DEVICE_ERROR, "player can't pause");
         }
 
-        CapabilityManager::getInstance()->releaseFocus("cap_audio", NUGU_FOCUS_RESOURCE_SPK);
+        CapabilityManager::getInstance()->releaseFocus("cap_audio");
     }
 }
 
@@ -457,7 +457,7 @@ void AudioPlayerAgent::parsingStop(const char* message)
         if (!stacked_ps_id.empty() && playstackctl_ps_id != stacked_ps_id)
             return;
         else if (stacked_ps_id.empty())
-            CapabilityManager::getInstance()->releaseFocus("cap_audio", NUGU_FOCUS_RESOURCE_SPK);
+            CapabilityManager::getInstance()->releaseFocus("cap_audio");
 
         if (!player->stop()) {
             nugu_error("stop media failed");
@@ -538,7 +538,7 @@ void AudioPlayerAgent::mediaStateChanged(MediaPlayerState state)
         cur_aplayer_state = AudioPlayerState::PAUSED;
         break;
     case MediaPlayerState::STOPPED:
-        CapabilityManager::getInstance()->releaseFocus("cap_audio", NUGU_FOCUS_RESOURCE_SPK);
+        CapabilityManager::getInstance()->releaseFocus("cap_audio");
         if (is_finished) {
             sendEventPlaybackFinished();
             cur_aplayer_state = AudioPlayerState::FINISHED;

--- a/core/capability/audio_player_agent.hh
+++ b/core/capability/audio_player_agent.hh
@@ -100,9 +100,9 @@ private:
     std::string playbackError(PlaybackError error);
     std::string playerActivity(AudioPlayerState state);
 
-    NuguFocusResult onFocus(NuguFocusResource rsrc, void* event) override;
-    NuguFocusResult onUnfocus(NuguFocusResource rsrc, void* event) override;
-    NuguFocusStealResult onStealRequest(NuguFocusResource rsrc, void* event, NuguFocusType target_type) override;
+    NuguFocusResult onFocus(void* event) override;
+    NuguFocusResult onUnfocus(void* event) override;
+    NuguFocusStealResult onStealRequest(void* event, NuguFocusType target_type) override;
 
     IMediaPlayer* player;
     AudioPlayerState cur_aplayer_state;

--- a/core/capability/system_agent.cc
+++ b/core/capability/system_agent.cc
@@ -321,8 +321,7 @@ void SystemAgent::parsingException(const char* message)
     if (exception == SystemException::PLAY_ROUTER_PROCESSING_EXCEPTION) {
         nugu_info("Release ASR focus due to 'not found play' state");
         CapabilityManager* cmanager = CapabilityManager::getInstance();
-        cmanager->releaseFocus("asr", NUGU_FOCUS_RESOURCE_SPK);
-        cmanager->releaseFocus("asr", NUGU_FOCUS_RESOURCE_MIC);
+        cmanager->releaseFocus("asr");
     }
 
     if (system_listener)

--- a/core/capability/tts_agent.cc
+++ b/core/capability/tts_agent.cc
@@ -121,7 +121,7 @@ void TTSAgent::pcmEventCallback(enum nugu_media_event event, void* userdata)
         tts->sendEventSpeechFinished(tts->cur_token);
         tts->finish = true;
         tts->speak_status = MEDIA_STATUS_STOPPED;
-        CapabilityManager::getInstance()->releaseFocus("cap_tts", NUGU_FOCUS_RESOURCE_SPK);
+        CapabilityManager::getInstance()->releaseFocus("cap_tts");
         break;
     default:
         break;
@@ -159,7 +159,7 @@ void TTSAgent::getAttachmentData(NuguDirective* ndir, void* userdata)
     }
 }
 
-NuguFocusResult TTSAgent::onFocus(NuguFocusResource rsrc, void* event)
+NuguFocusResult TTSAgent::onFocus(void* event)
 {
     nugu_info("speak_status: %d", speak_status);
 
@@ -179,7 +179,7 @@ NuguFocusResult TTSAgent::onFocus(NuguFocusResource rsrc, void* event)
     return NUGU_FOCUS_OK;
 }
 
-NuguFocusResult TTSAgent::onUnfocus(NuguFocusResource rsrc, void* event)
+NuguFocusResult TTSAgent::onUnfocus(void* event)
 {
     nugu_pcm_stop(pcm);
 
@@ -188,7 +188,7 @@ NuguFocusResult TTSAgent::onUnfocus(NuguFocusResource rsrc, void* event)
     return NUGU_FOCUS_REMOVE;
 }
 
-NuguFocusStealResult TTSAgent::onStealRequest(NuguFocusResource rsrc, void* event, NuguFocusType target_type)
+NuguFocusStealResult TTSAgent::onStealRequest(void* event, NuguFocusType target_type)
 {
     if (target_type == NUGU_FOCUS_TYPE_ASR)
         return NUGU_FOCUS_STEAL_ALLOW;
@@ -369,7 +369,7 @@ void TTSAgent::parsingSpeak(const char* message)
 
     startTTS(getNuguDirective());
 
-    CapabilityManager::getInstance()->requestFocus("cap_tts", NUGU_FOCUS_RESOURCE_SPK, NULL);
+    CapabilityManager::getInstance()->requestFocus("cap_tts", NULL);
 
     if (tts_listener)
         tts_listener->onTTSText(text, dialog_id);

--- a/core/capability/tts_agent.hh
+++ b/core/capability/tts_agent.hh
@@ -65,9 +65,9 @@ private:
     void parsingStop(const char* message);
 
     void startTTS(NuguDirective* ndir);
-    NuguFocusResult onFocus(NuguFocusResource rsrc, void* event);
-    NuguFocusResult onUnfocus(NuguFocusResource rsrc, void* event);
-    NuguFocusStealResult onStealRequest(NuguFocusResource rsrc, void* event, NuguFocusType target_type);
+    NuguFocusResult onFocus(void* event);
+    NuguFocusResult onUnfocus(void* event);
+    NuguFocusStealResult onStealRequest(void* event, NuguFocusType target_type);
 
     NuguDirective* speak_dir;
     NuguPcm* pcm;

--- a/core/capability_manager.cc
+++ b/core/capability_manager.cc
@@ -27,28 +27,28 @@ using namespace NuguInterface;
 
 CapabilityManager* CapabilityManager::instance = NULL;
 
-static NuguFocusResult on_focus(NuguFocus* focus, NuguFocusResource rsrc,
+static NuguFocusResult on_focus(NuguFocus* focus,
     void* event, void* userdata)
 {
     IFocusListener* listener = static_cast<IFocusListener*>(userdata);
 
-    return listener->onFocus(rsrc, event);
+    return listener->onFocus(event);
 }
 
-static NuguFocusResult on_unfocus(NuguFocus* focus, NuguFocusResource rsrc,
+static NuguFocusResult on_unfocus(NuguFocus* focus,
     void* event, void* userdata)
 {
     IFocusListener* listener = static_cast<IFocusListener*>(userdata);
 
-    return listener->onUnfocus(rsrc, event);
+    return listener->onUnfocus(event);
 }
 
-static NuguFocusStealResult on_steal_request(NuguFocus* focus, NuguFocusResource rsrc,
+static NuguFocusStealResult on_steal_request(NuguFocus* focus,
     void* event, NuguFocus* target, void* userdata)
 {
     IFocusListener* listener = static_cast<IFocusListener*>(userdata);
 
-    return listener->onStealRequest(rsrc, event, nugu_focus_get_type(target));
+    return listener->onStealRequest(event, nugu_focus_get_type(target));
 }
 
 CapabilityManager::CapabilityManager()
@@ -243,9 +243,9 @@ void CapabilityManager::getCapabilityProperties(CapabilityType cap, std::string 
     }
 }
 
-bool CapabilityManager::isFocusOn(NuguFocusResource rsrc)
+bool CapabilityManager::isFocusOn()
 {
-    NuguFocus* focus = nugu_focus_peek_top(rsrc);
+    NuguFocus* focus = nugu_focus_peek_top();
 
     if (focus)
         return true;
@@ -280,7 +280,7 @@ int CapabilityManager::removeFocus(std::string fname)
     return 0;
 }
 
-int CapabilityManager::requestFocus(std::string fname, NuguFocusResource rsrc, void* event)
+int CapabilityManager::requestFocus(std::string fname, void* event)
 {
     NuguFocus* focus;
 
@@ -288,10 +288,10 @@ int CapabilityManager::requestFocus(std::string fname, NuguFocusResource rsrc, v
     if (!focus)
         return -1;
 
-    return nugu_focus_request(focus, rsrc, event);
+    return nugu_focus_request(focus, event);
 }
 
-int CapabilityManager::releaseFocus(std::string fname, NuguFocusResource rsrc)
+int CapabilityManager::releaseFocus(std::string fname)
 {
     NuguFocus* focus;
 
@@ -299,7 +299,7 @@ int CapabilityManager::releaseFocus(std::string fname, NuguFocusResource rsrc)
     if (!focus)
         return -1;
 
-    return nugu_focus_release(focus, rsrc);
+    return nugu_focus_release(focus);
 }
 
 PlaySyncManager* CapabilityManager::getPlaySyncManager()

--- a/core/capability_manager.hh
+++ b/core/capability_manager.hh
@@ -31,9 +31,9 @@ namespace NuguCore {
 class IFocusListener {
 public:
     virtual ~IFocusListener() = default;
-    virtual NuguFocusResult onFocus(NuguFocusResource rsrc, void* event) = 0;
-    virtual NuguFocusResult onUnfocus(NuguFocusResource rsrc, void* event) = 0;
-    virtual NuguFocusStealResult onStealRequest(NuguFocusResource rsrc, void* event, NuguFocusType target_type) = 0;
+    virtual NuguFocusResult onFocus(void* event) = 0;
+    virtual NuguFocusResult onUnfocus(void* event) = 0;
+    virtual NuguFocusStealResult onStealRequest(void* event, NuguFocusType target_type) = 0;
 };
 
 class CapabilityManager {
@@ -65,11 +65,11 @@ public:
     void getCapabilityProperty(CapabilityType cap, std::string property, std::string& value);
     void getCapabilityProperties(CapabilityType cap, std::string property, std::list<std::string>& values);
 
-    bool isFocusOn(NuguFocusResource rsrc);
+    bool isFocusOn();
     int addFocus(std::string fname, NuguFocusType type, IFocusListener* listener);
     int removeFocus(std::string fname);
-    int requestFocus(std::string fname, NuguFocusResource rsrc, void* event);
-    int releaseFocus(std::string fname, NuguFocusResource rsrc);
+    int requestFocus(std::string fname, void* event);
+    int releaseFocus(std::string fname);
 
 private:
     ICapabilityInterface* findCapability(std::string cname);

--- a/core/wakeup_handler.hh
+++ b/core/wakeup_handler.hh
@@ -29,8 +29,7 @@ namespace NuguCore {
 using namespace NuguInterface;
 
 class WakeupHandler : public IWakeupHandler,
-                      public IWakeupDetectorListener,
-                      public IFocusListener {
+                      public IWakeupDetectorListener {
 
 public:
     WakeupHandler();
@@ -38,13 +37,10 @@ public:
 
     void setListener(IWakeupListener* listener) override;
     void startWakeup(void) override;
+    void stopWakeup(void) override;
     void onWakeupState(WakeupState state) override;
 
 private:
-    NuguFocusResult onFocus(NuguFocusResource rsrc, void* event) override;
-    NuguFocusResult onUnfocus(NuguFocusResource rsrc, void* event) override;
-    NuguFocusStealResult onStealRequest(NuguFocusResource rsrc, void* event, NuguFocusType target_type) override;
-
     IWakeupListener* listener = nullptr;
     std::unique_ptr<WakeupDetector> wakeup_detector;
 };

--- a/examples/standalone/capability/speech_operator.cc
+++ b/examples/standalone/capability/speech_operator.cc
@@ -80,6 +80,9 @@ void SpeechOperator::onWakeupState(WakeupDetectState state)
     case WakeupDetectState::WAKEUP_DETECTED:
         msg::wakeup::state("wakeup detected");
 
+        if (wakeup_handler)
+            wakeup_handler->stopWakeup();
+
         if (asr_handler)
             asr_handler->startRecognition();
 
@@ -150,7 +153,12 @@ void SpeechOperator::onState(ASRState state)
         break;
     }
     case ASRState::EXPECTING_SPEECH: {
+        msg::wakeup::state("stop wakeup");
+        if (wakeup_handler)
+            wakeup_handler->stopWakeup();
+
         msg::asr::state("EXPECTING_SPEECH");
+
         break;
     }
     case ASRState::LISTENING: {

--- a/include/base/nugu_focus.h
+++ b/include/base/nugu_focus.h
@@ -35,19 +35,6 @@ extern "C" {
  */
 
 /**
- * @brief Supported resource types
- */
-enum nugu_focus_resource {
-	NUGU_FOCUS_RESOURCE_MIC = 0, /**< Microphone */
-	NUGU_FOCUS_RESOURCE_SPK = 1 /**< Speaker */
-};
-
-/**
- * @see enum nugu_focus_resource
- */
-typedef enum nugu_focus_resource NuguFocusResource;
-
-/**
  * @brief Predefined focus types by priority
  */
 enum nugu_focus_type {
@@ -102,20 +89,17 @@ typedef struct _nugu_focus NuguFocus;
  * @brief Callback prototype for got focus
  */
 typedef NuguFocusResult (*NuguFocusCallback)(NuguFocus *focus,
-					     NuguFocusResource rsrc,
 					     void *event, void *userdata);
 
 /**
  * @brief Callback prototype for lost focus
  */
 typedef NuguFocusResult (*NuguUnfocusCallback)(NuguFocus *focus,
-					       NuguFocusResource rsrc,
 					       void *event, void *userdata);
 /**
  * @brief Callback prototype for steal focus
  */
 typedef NuguFocusStealResult (*NuguStealfocusCallback)(NuguFocus *self,
-						       NuguFocusResource rsrc,
 						       void *event,
 						       NuguFocus *target,
 						       void *userdata);
@@ -162,7 +146,7 @@ NuguFocusType nugu_focus_get_type(NuguFocus *focus);
  * @param[in] focus focus object
  * @return focus object
  */
-NuguFocus *nugu_focus_peek_top(NuguFocusResource rsrc);
+NuguFocus *nugu_focus_peek_top(void);
 
 /**
  * @brief Request to get focus.
@@ -174,7 +158,7 @@ NuguFocus *nugu_focus_peek_top(NuguFocusResource rsrc);
  * @retval -1 failure
  * @see nugu_focus_release()
  */
-int nugu_focus_request(NuguFocus *focus, NuguFocusResource rsrc, void *event);
+int nugu_focus_request(NuguFocus *focus, void *event);
 
 /**
  * @brief Request to release focus.
@@ -185,7 +169,7 @@ int nugu_focus_request(NuguFocus *focus, NuguFocusResource rsrc, void *event);
  * @retval -1 failure
  * @see nugu_focus_request()
  */
-int nugu_focus_release(NuguFocus *focus, NuguFocusResource rsrc);
+int nugu_focus_release(NuguFocus *focus);
 
 /**
  * @}

--- a/include/interface/wakeup_interface.hh
+++ b/include/interface/wakeup_interface.hh
@@ -74,6 +74,11 @@ public:
      * @see IWakeupListener::onWakeupState()
      */
     virtual void startWakeup(void) = 0;
+
+    /**
+     * @brief Stop the wakeup detection
+     */
+    virtual void stopWakeup(void) = 0;
 };
 
 /**


### PR DESCRIPTION
Removes focus processing on unnecessary MIC resources to counteract
external keyword detectors.

When using an external keyword detector, the application must be
responsible for and manage the state of the ASR.

Signed-off-by: Inho Oh <inho.oh@sk.com>