### PR TITLE
Networkfix

### DIFF
--- a/include/base/nugu_directive.h
+++ b/include/base/nugu_directive.h
@@ -67,11 +67,18 @@ NuguDirective *nugu_directive_new(const char *name_space, const char *name,
 				  const char *referrer_id, const char *json);
 
 /**
- * @brief Destroy the directive object
+ * @brief Increment the reference count of the directive object.
  * @param[in] ndir directive object
  * @see nugu_directive_new()
  */
-void nugu_directive_free(NuguDirective *ndir);
+void nugu_directive_ref(NuguDirective *ndir);
+
+/**
+ * @brief Decrement the reference count of the directive object.
+ * @param[in] ndir directive object
+ * @see nugu_directive_new()
+ */
+void nugu_directive_unref(NuguDirective *ndir);
 
 /**
  * @brief Get the namespace of directive

--- a/src/network/http2/http2_network.c
+++ b/src/network/http2/http2_network.c
@@ -25,6 +25,8 @@
 
 #include <glib.h>
 
+#include "curl/curl.h"
+
 #include "base/nugu_log.h"
 #include "base/nugu_network_manager.h"
 

--- a/src/network/http2/http2_request.h
+++ b/src/network/http2/http2_request.h
@@ -17,8 +17,6 @@
 #ifndef __HTTP2_REQUEST_H__
 #define __HTTP2_REQUEST_H__
 
-#include "curl/curl.h"
-
 #include "base/nugu_buffer.h"
 
 #ifdef __cplusplus
@@ -56,6 +54,8 @@ typedef size_t (*ResponseBodyCallback)(HTTP2Request *req, char *buffer,
 				       void *userdata);
 typedef void (*ResponseFinishCallback)(HTTP2Request *req, void *userdata);
 
+typedef void (*HTTP2DestroyCallback)(HTTP2Request *req, void *userdata);
+
 HTTP2Request *http2_request_new();
 void http2_request_free(HTTP2Request *req);
 
@@ -75,7 +75,7 @@ int http2_request_set_connection_timeout(HTTP2Request *req, int timeout);
 int http2_request_set_timeout(HTTP2Request *req, int timeout_secs);
 int http2_request_set_useragent(HTTP2Request *req, const char *useragent);
 
-CURL *http2_request_get_handle(HTTP2Request *req);
+void *http2_request_get_handle(HTTP2Request *req);
 
 int http2_request_set_header_callback(HTTP2Request *req,
 				      ResponseHeaderCallback cb,
@@ -85,6 +85,8 @@ int http2_request_set_body_callback(HTTP2Request *req, ResponseBodyCallback cb,
 int http2_request_set_finish_callback(HTTP2Request *req,
 				      ResponseFinishCallback cb,
 				      void *userdata);
+int http2_request_set_destroy_callback(HTTP2Request *req,
+				       HTTP2DestroyCallback cb, void *userdata);
 
 NuguBuffer *http2_request_peek_response_body(HTTP2Request *req);
 NuguBuffer *http2_request_peek_response_header(HTTP2Request *req);

--- a/src/network/http2/multipart_parser.c
+++ b/src/network/http2/multipart_parser.c
@@ -54,6 +54,7 @@ struct _multipart_parser {
 	char *boundary;
 	size_t boundary_length;
 	enum bodyparser_step step;
+	void *data;
 };
 
 MultipartParser *multipart_parser_new()
@@ -69,6 +70,7 @@ MultipartParser *multipart_parser_new()
 	parser->header = nugu_buffer_new(0);
 	parser->body = nugu_buffer_new(0);
 	parser->step = STEP_READY;
+	parser->data = NULL;
 
 	return parser;
 }
@@ -97,6 +99,20 @@ void multipart_parser_free(MultipartParser *parser)
 
 	memset(parser, 0, sizeof(MultipartParser));
 	free(parser);
+}
+
+void multipart_parser_set_data(MultipartParser *parser, void *data)
+{
+	g_return_if_fail(parser != NULL);
+
+	parser->data = data;
+}
+
+void *multipart_parser_get_data(MultipartParser *parser)
+{
+	g_return_val_if_fail(parser != NULL, NULL);
+
+	return parser->data;
 }
 
 void multipart_parser_set_boundary(MultipartParser *parser, const char *src,

--- a/src/network/http2/multipart_parser.h
+++ b/src/network/http2/multipart_parser.h
@@ -36,6 +36,9 @@ int multipart_parser_parse(MultipartParser *parser, const char *src,
 			   ParserCallback onFoundBody, void *userdata);
 void multipart_parser_reset(MultipartParser *parser);
 
+void multipart_parser_set_data(MultipartParser *parser, void *data);
+void *multipart_parser_get_data(MultipartParser *parser);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/nugu_directive.c
+++ b/src/nugu_directive.c
@@ -40,6 +40,8 @@ struct _nugu_directive {
 	NuguBuffer *buf;
 	DirectiveDataCallback callback;
 	void *callback_userdata;
+
+	int ref_count;
 };
 
 EXPORT_API NuguDirective *
@@ -69,11 +71,12 @@ nugu_directive_new(const char *name_space, const char *name,
 	ndir->is_active = 0;
 	ndir->buf = nugu_buffer_new(0);
 	ndir->media_type = NULL;
+	ndir->ref_count = 1;
 
 	return ndir;
 }
 
-EXPORT_API void nugu_directive_free(NuguDirective *ndir)
+static void nugu_directive_free(NuguDirective *ndir)
 {
 	g_return_if_fail(ndir != NULL);
 
@@ -109,6 +112,24 @@ EXPORT_API void nugu_directive_free(NuguDirective *ndir)
 
 	memset(ndir, 0, sizeof(NuguDirective));
 	free(ndir);
+}
+
+EXPORT_API void nugu_directive_ref(NuguDirective *ndir)
+{
+	g_return_if_fail(ndir != NULL);
+
+	ndir->ref_count++;
+}
+
+EXPORT_API void nugu_directive_unref(NuguDirective *ndir)
+{
+	g_return_if_fail(ndir != NULL);
+
+	ndir->ref_count--;
+	if (ndir->ref_count > 0)
+		return;
+
+	nugu_directive_free(ndir);
 }
 
 EXPORT_API int nugu_directive_is_active(NuguDirective *ndir)

--- a/src/nugu_directive_sequencer.c
+++ b/src/nugu_directive_sequencer.c
@@ -137,7 +137,7 @@ EXPORT_API int nugu_dirseq_complete(NuguDirective *ndir)
 
 	list_dir = g_list_delete_link(list_dir, l);
 
-	nugu_directive_free(ndir);
+	nugu_directive_unref(ndir);
 
 	nugu_dbg("remain directives: %d", g_list_length(list_dir));
 

--- a/src/nugu_network_manager.c
+++ b/src/nugu_network_manager.c
@@ -96,7 +96,13 @@ typedef struct _nugu_network NetworkManager;
 
 static void on_directive(enum nugu_equeue_type type, void *data, void *userdata)
 {
+	nugu_directive_ref(data);
 	nugu_dirseq_push(data);
+}
+
+static void on_destroy_directive(void *data)
+{
+	nugu_directive_unref(data);
 }
 
 static void on_attachment(enum nugu_equeue_type type, void *data,
@@ -495,7 +501,7 @@ static NetworkManager *nugu_network_manager_new(void)
 
 	/* Received message from server */
 	nugu_equeue_set_handler(NUGU_EQUEUE_TYPE_NEW_DIRECTIVE, on_directive,
-				NULL, nm);
+				on_destroy_directive, nm);
 	nugu_equeue_set_handler(NUGU_EQUEUE_TYPE_NEW_ATTACHMENT, on_attachment,
 				on_destroy_attachment, nm);
 
@@ -577,6 +583,8 @@ EXPORT_API void nugu_network_manager_deinitialize(void)
 	_network = NULL;
 
 	nugu_dirseq_deinitialize();
+
+	nugu_info("network manager de-initialized");
 }
 
 EXPORT_API int nugu_network_manager_connect(void)

--- a/tests/test-nugu-directive.c
+++ b/tests/test-nugu-directive.c
@@ -69,7 +69,7 @@ static void test_nugu_directive_callback(void)
 	g_assert(nugu_directive_add_data(ndir, sizeof(dummy), dummy) == 0);
 	g_assert(flag == 1);
 
-	nugu_directive_free(ndir);
+	nugu_directive_unref(ndir);
 }
 
 static void test_nugu_directive_default(void)
@@ -115,7 +115,7 @@ static void test_nugu_directive_default(void)
 	g_assert(nugu_directive_close_data(ndir) == 0);
 	g_assert(nugu_directive_is_data_end(ndir) == 1);
 
-	nugu_directive_free(ndir);
+	nugu_directive_unref(ndir);
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
Fix network related code to resolve memory leaks caused by abnormal situations.
- http2: add userdata to multipart parser
- http2: add destroy callback to request
- equeue: fix thread issue
- directive: apply ref count to fix memory leak
