### PR TITLE
fix code style

### DIFF
--- a/core/capability/asr_agent.cc
+++ b/core/capability/asr_agent.cc
@@ -547,7 +547,6 @@ void ASRAgent::onListeningState(ListeningState state)
         if (prev_listening_state == ListeningState::READY
             || prev_listening_state == ListeningState::LISTENING
             || prev_listening_state == ListeningState::SPEECH_START) {
-
             releaseASRFocus(true, ASRError::UNKNOWN);
         }
 

--- a/core/capability/capability.hh
+++ b/core/capability/capability.hh
@@ -77,11 +77,11 @@ public:
     void sendEvent(CapabilityEvent* event, const std::string& context, const std::string& payload);
     void sendAttachmentEvent(CapabilityEvent* event, bool is_end, size_t size, unsigned char* data);
 
-    virtual void getProperty(const std::string& property, std::string& value) override;
-    virtual void getProperties(const std::string& property, std::list<std::string>& values) override;
-    virtual void setCapabilityListener(ICapabilityListener* clistener) override;
-    virtual void receiveCommand(CapabilityType from, std::string command, const std::string& param) override;
-    virtual void receiveCommandAll(std::string command, const std::string& param) override;
+    void getProperty(const std::string& property, std::string& value) override;
+    void getProperties(const std::string& property, std::list<std::string>& values) override;
+    void setCapabilityListener(ICapabilityListener* clistener) override;
+    void receiveCommand(CapabilityType from, std::string command, const std::string& param) override;
+    void receiveCommandAll(std::string command, const std::string& param) override;
     virtual void parsingDirective(const char* dname, const char* message);
     virtual std::string getContextInfo();
 

--- a/core/wakeup_handler.hh
+++ b/core/wakeup_handler.hh
@@ -30,7 +30,6 @@ using namespace NuguInterface;
 
 class WakeupHandler : public IWakeupHandler,
                       public IWakeupDetectorListener {
-
 public:
     WakeupHandler();
     ~WakeupHandler();

--- a/examples/standalone/capability/display_listener.hh
+++ b/examples/standalone/capability/display_listener.hh
@@ -26,8 +26,8 @@ public:
     DisplayListener();
     virtual ~DisplayListener() = default;
 
-    virtual void renderDisplay(const std::string& id, const std::string& type, const std::string& json, const std::string& dialog_id) override;
-    virtual bool clearDisplay(const std::string& id, bool unconditionally) override;
+    void renderDisplay(const std::string& id, const std::string& type, const std::string& json, const std::string& dialog_id) override;
+    bool clearDisplay(const std::string& id, bool unconditionally) override;
 
 protected:
     std::string listener_name;

--- a/examples/standalone/capability/speech_operator.hh
+++ b/examples/standalone/capability/speech_operator.hh
@@ -24,7 +24,6 @@ using namespace NuguInterface;
 
 class SpeechOperator : public IWakeupListener,
                        public IASRListener {
-
 public:
     void onWakeupState(WakeupDetectState state) override;
     void onState(ASRState state) override;

--- a/examples/standalone/capability/text_listener.hh
+++ b/examples/standalone/capability/text_listener.hh
@@ -24,9 +24,9 @@ using namespace NuguInterface;
 class TextListener : public ITextListener {
 public:
     virtual ~TextListener() = default;
-    virtual void onState(TextState state) override;
-    virtual void onComplete() override;
-    virtual void onError(TextError error) override;
+    void onState(TextState state) override;
+    void onComplete() override;
+    void onError(TextError error) override;
 };
 
 #endif /* __TEXT_LISTENER_H__ */


### PR DESCRIPTION
It remove redundant blank line in some class.
It remove virtual keyword in some class,
because that methods are already declared as override.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>