### PR TITLE
network: fix long polling re-establish logic

### DIFF
--- a/include/base/nugu_equeue.h
+++ b/include/base/nugu_equeue.h
@@ -58,6 +58,9 @@ enum nugu_equeue_type {
 	NUGU_EQUEUE_TYPE_SERVER_CONNECTED, /**< connected to server */
 	NUGU_EQUEUE_TYPE_SERVER_DISCONNECTED, /**< disconnected from server */
 
+	NUGU_EQUEUE_TYPE_DIRECTIVES_CLOSED,
+	/**< directives stream closed by server */
+
 	NUGU_EQUEUE_TYPE_MAX = 255 /**< maximum value for type id */
 };
 

--- a/src/network/http2/http2_network.c
+++ b/src/network/http2/http2_network.c
@@ -114,6 +114,8 @@ static int _process_remove(HTTP2Network *net, struct request_item *item)
 
 	net->hlist = g_list_remove(net->hlist, req);
 
+	http2_request_unref(item->req);
+
 	return 0;
 }
 
@@ -261,8 +263,9 @@ static void _init_once(void)
 
 	cinfo = curl_version_info(CURLVERSION_NOW);
 	if (cinfo) {
-		nugu_dbg("curl %s (%s), ssl_version=%s", cinfo->version,
-			 cinfo->host, cinfo->ssl_version);
+		nugu_dbg("curl %s (%s), nghttp2_version=%s, ssl_version=%s",
+			 cinfo->version, cinfo->host, cinfo->nghttp2_version,
+			 cinfo->ssl_version);
 
 		if (cinfo->protocols) {
 			const char *const *proto;
@@ -461,7 +464,6 @@ int http2_network_remove_request_sync(HTTP2Network *net, HTTP2Request *req)
 		}
 	}
 
-	http2_request_unref(req);
 	free(item);
 
 	return 0;

--- a/src/network/http2/v1_directives.h
+++ b/src/network/http2/v1_directives.h
@@ -29,7 +29,6 @@ V1Directives *v1_directives_new(const char *host, int connection_timeout_secs);
 void v1_directives_free(V1Directives *dir);
 
 int v1_directives_establish(V1Directives *dir, HTTP2Network *net);
-int v1_directives_establish_sync(V1Directives *dir, HTTP2Network *net);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Change 'g_idle_add' to 'equeue' so that it can be managed by
network_manager as a means to re-establish the long polling.

And, add exception handling for when the connection was finished
immediately on the server. In this case, try to connect to next
server without retrying.

Signed-off-by: Inho Oh <inho.oh@sk.com>