### PR TITLE
upgrade efficiency

### DIFF
--- a/core/capability/audio_player_agent.cc
+++ b/core/capability/audio_player_agent.cc
@@ -366,7 +366,7 @@ void AudioPlayerAgent::parsingPlay(const char* message)
         }
 
         // sync display rendering with context
-        playsync_manager->addContext(playstackctl_ps_id, getType(), renderer);
+        playsync_manager->addContext(playstackctl_ps_id, getType(), std::move(renderer));
     }
 
     is_finished = false;

--- a/core/capability/display_agent.cc
+++ b/core/capability/display_agent.cc
@@ -67,7 +67,7 @@ void DisplayAgent::parsingDirective(const char* dname, const char* message)
         renderer.duration = root["duration"].asString();
         renderer.display_id = id;
 
-        playsync_manager->addContext(playstackctl_ps_id, getType(), renderer);
+        playsync_manager->addContext(playstackctl_ps_id, getType(), std::move(renderer));
     }
 }
 

--- a/core/playsync_manager.cc
+++ b/core/playsync_manager.cc
@@ -90,7 +90,7 @@ void PlaySyncManager::addContext(const std::string& ps_id, CapabilityType cap_ty
     addContext(ps_id, cap_type, {});
 }
 
-void PlaySyncManager::addContext(const std::string& ps_id, CapabilityType cap_type, DisplayRenderer renderer)
+void PlaySyncManager::addContext(const std::string& ps_id, CapabilityType cap_type, DisplayRenderer&& renderer)
 {
     if (ps_id.empty()) {
         nugu_error("Invalid PlayServiceId.");
@@ -224,7 +224,8 @@ void PlaySyncManager::addRenderer(const std::string& ps_id, DisplayRenderer& ren
         removeRenderer(renderer_key);
     }
 
-    renderer_map[ps_id] = renderer;
+    renderer_map.emplace(ps_id, renderer);
+
     renderer.listener->onSyncDisplayContext(renderer.display_id);
 }
 
@@ -259,7 +260,7 @@ void PlaySyncManager::setTimerInterval(const std::string& ps_id)
 }
 
 template <typename T, typename V>
-std::vector<std::string> PlaySyncManager::getKeyOfMap(std::map<T, V>& map)
+std::vector<std::string> PlaySyncManager::getKeyOfMap(const std::map<T, V>& map)
 {
     std::vector<std::string> keys;
     keys.reserve(map.size());

--- a/core/playsync_manager.hh
+++ b/core/playsync_manager.hh
@@ -59,7 +59,7 @@ public:
     virtual ~PlaySyncManager();
 
     void addContext(const std::string& ps_id, CapabilityType cap_type);
-    void addContext(const std::string& ps_id, CapabilityType cap_type, DisplayRenderer renderer);
+    void addContext(const std::string& ps_id, CapabilityType cap_type, DisplayRenderer&& renderer);
     void removeContext(const std::string& ps_id, CapabilityType cap_type, bool immediately = true);
     void clearPendingContext(const std::string& ps_id);
     std::vector<std::string> getAllPlayStackItems();
@@ -80,7 +80,7 @@ private:
     static const std::map<std::string, long> DURATION_MAP;
 
     template <typename T, typename V>
-    std::vector<std::string> getKeyOfMap(std::map<T, V>& map);
+    std::vector<std::string> getKeyOfMap(const std::map<T, V>& map);
 
     using TimerCallbackParam = struct {
         PlaySyncManager* instance;


### PR DESCRIPTION
It apply move semantics handling DisplayRenderer in PlaySyncManager
for removing temporary instance unnecessarily.