### PR TITLE
fix the bug.

### DIFF
--- a/core/capability/asr_agent.cc
+++ b/core/capability/asr_agent.cc
@@ -57,8 +57,6 @@ ASRFocusListener::~ASRFocusListener()
 NuguFocusResult ASRFocusListener::onFocus(void* event)
 {
     nugu_dbg("ASRFocusListener::onFocus");
-    agent->saveAllContextInfo();
-
     speech_recognizer->startListening();
 
     if (agent->isExpectSpeechState()) {
@@ -194,6 +192,8 @@ void ASRAgent::initialize()
 void ASRAgent::startRecognition()
 {
     nugu_dbg("startRecognition()");
+
+    saveAllContextInfo();
     CapabilityManager::getInstance()->requestFocus("asr", NULL);
 }
 


### PR DESCRIPTION
Recognize event sends agent information before wakeup in context.

Signed-off-by: Hyojoong Kim <hyojoong.kim@sk.com>