### PR TITLE
Update AudioPlayer v1.1

### DIFF
--- a/core/capability/audio_player_agent.hh
+++ b/core/capability/audio_player_agent.hh
@@ -63,6 +63,9 @@ public:
     void pause() override;
     void resume() override;
     void seek(int msec) override;
+    void setFavorite(bool favorite) override;
+    void setRepeat(RepeatType repeat) override;
+    void setShuffle(bool shuffle) override;
 
     void sendEventPlaybackStarted();
     void sendEventPlaybackFinished();
@@ -73,6 +76,12 @@ public:
     void sendEventProgressReportDelayElapsed();
     void sendEventProgressReportIntervalElapsed();
     void sendEventByDisplayInterface(const std::string& command);
+    void sendEventShowLyricsSucceeded();
+    void sendEventShowLyricsFailed();
+    void sendEventHideLyricsSucceeded();
+    void sendEventHideLyricsFailed();
+    void sendEventControlLyricsPageSucceeded();
+    void sendEventControlLyricsPageFailed();
 
     void mediaStateChanged(MediaPlayerState state);
     void mediaEventReport(MediaPlayerEvent event);
@@ -93,9 +102,14 @@ private:
 
     AudioPlayerState audioPlayerState();
 
+    bool isContentCached(const std::string& key, std::string& playurl);
     void parsingPlay(const char* message);
     void parsingPause(const char* message);
     void parsingStop(const char* message);
+    void parsingUpdateMetadata(const char* message);
+    void parsingShowLyrics(const char* message);
+    void parsingHideLyrics(const char* message);
+    void parsingControlLyricsPage(const char* message);
 
     std::string playbackError(PlaybackError error);
     std::string playerActivity(AudioPlayerState state);

--- a/core/capability/capability.cc
+++ b/core/capability/capability.cc
@@ -204,10 +204,11 @@ void Capability::processDirective(NuguDirective* ndir)
 
         setReferrerDialogRequestId(dref_id);
 
+        has_attachment = false;
         parsingDirective(dname, message);
 
         // the directive with attachment should destroy by agent
-        if (!hasDirectiveAttachment(dname))
+        if (!has_attachment)
             destoryDirective(ndir);
     }
 }
@@ -223,14 +224,6 @@ void Capability::destoryDirective(NuguDirective* ndir)
 NuguDirective* Capability::getNuguDirective()
 {
     return cur_ndir;
-}
-
-bool Capability::hasDirectiveAttachment(const char* dname)
-{
-    if (getType() == CapabilityType::TTS && !strcmp(dname, "Speak"))
-        return true;
-    else
-        return false;
 }
 
 void Capability::parsingDirective(const char* dname, const char* message)

--- a/core/capability/capability.hh
+++ b/core/capability/capability.hh
@@ -71,7 +71,6 @@ public:
     void destoryDirective(NuguDirective* ndir);
 
     NuguDirective* getNuguDirective();
-    bool hasDirectiveAttachment(const char* dname);
 
     void sendEvent(const std::string& name, const std::string& context, const std::string& payload);
     void sendEvent(CapabilityEvent* event, const std::string& context, const std::string& payload);
@@ -92,6 +91,7 @@ public:
 
 protected:
     bool initialized = false;
+    bool has_attachment = false;
     PlaySyncManager* playsync_manager = nullptr;
 
 private:

--- a/core/capability/tts_agent.cc
+++ b/core/capability/tts_agent.cc
@@ -366,6 +366,8 @@ void TTSAgent::parsingSpeak(const char* message)
         return;
     }
 
+    has_attachment = true;
+
     cur_token = token;
     dialog_id = nugu_directive_peek_dialog_id(getNuguDirective());
 

--- a/examples/standalone/capability/audio_player_listener.cc
+++ b/examples/standalone/capability/audio_player_listener.cc
@@ -54,3 +54,29 @@ void AudioPlayerListener::positionChanged(int position)
 {
     std::cout << "[AudioPlayer] - position: " << position << std::endl;
 }
+
+void AudioPlayerListener::favoriteChanged(bool favorite)
+{
+    std::cout << "[AudioPlayer] - favorite: " << favorite << std::endl;
+}
+
+void AudioPlayerListener::shuffleChanged(bool shuffle)
+{
+    std::cout << "[AudioPlayer] - shuffle: " << shuffle << std::endl;
+}
+
+void AudioPlayerListener::repeatChanged(RepeatType repeat)
+{
+    std::cout << "[AudioPlayer] - repeat: " << (int)repeat << std::endl;
+}
+
+void AudioPlayerListener::requestContentCache(const std::string& key, const std::string& playurl)
+{
+    std::cout << "[AudioPlayer] request to cache content - key: " << key << ", playurl: " << playurl << std::endl;
+}
+
+bool AudioPlayerListener::requestToGetCachedContent(const std::string& key, std::string& filepath)
+{
+    std::cout << "[AudioPlayer] request to get cached content - key: " << key << std::endl;
+    return false;
+}

--- a/examples/standalone/capability/audio_player_listener.hh
+++ b/examples/standalone/capability/audio_player_listener.hh
@@ -31,6 +31,11 @@ public:
     void mediaStateChanged(AudioPlayerState state) override;
     void durationChanged(int duration) override;
     void positionChanged(int position) override;
+    void favoriteChanged(bool favorite) override;
+    void shuffleChanged(bool shuffle) override;
+    void repeatChanged(RepeatType repeat) override;
+    void requestContentCache(const std::string& key, const std::string& playurl) override;
+    bool requestToGetCachedContent(const std::string& key, std::string& filepath) override;
 };
 
 #endif /* __AUDIO_PLAYER_LISTENER_H__ */

--- a/examples/standalone/capability/display_listener.cc
+++ b/examples/standalone/capability/display_listener.cc
@@ -26,12 +26,12 @@ DisplayListener::DisplayListener()
 
 void DisplayListener::renderDisplay(const std::string& id, const std::string& type, const std::string& json, const std::string& dialog_id)
 {
-    std::cout << listener_name << " render display template - id: " << id << ", type: " << type << ", dialog_id: " << dialog_id << std::endl;
+    std::cout << "[Display] render display template - id: " << id << ", type: " << type << ", dialog_id: " << dialog_id << std::endl;
 }
 
 bool DisplayListener::clearDisplay(const std::string& id, bool unconditionally)
 {
-    std::cout << listener_name << " clear display template - id: " << id << ", unconditionally: " << unconditionally << std::endl;
+    std::cout << "[Display] clear display template - id: " << id << ", unconditionally: " << unconditionally << std::endl;
 
     // clear display unconditionally
     if (unconditionally) {
@@ -41,5 +41,29 @@ bool DisplayListener::clearDisplay(const std::string& id, bool unconditionally)
     // It need to decide whether clear display immediately or not.
     // If you decide to clear immediately, return true, or return false
 
+    return false;
+}
+
+bool DisplayListener::requestLyricsPageAvailable(bool& visible)
+{
+    std::cout << "[Display] requestLyricsPageAvailable" << std::endl;
+    return false;
+}
+
+bool DisplayListener::showLyrics()
+{
+    std::cout << "[Display] showLyrics" << std::endl;
+    return false;
+}
+
+bool DisplayListener::hideLyrics()
+{
+    std::cout << "[Display] hideLyrics" << std::endl;
+    return false;
+}
+
+bool DisplayListener::controlLyrics(ControlLyricsDirection direction)
+{
+    std::cout << "[Display] controlLyrics - direction: " << (int)direction << std::endl;
     return false;
 }

--- a/examples/standalone/capability/display_listener.hh
+++ b/examples/standalone/capability/display_listener.hh
@@ -28,6 +28,10 @@ public:
 
     void renderDisplay(const std::string& id, const std::string& type, const std::string& json, const std::string& dialog_id) override;
     bool clearDisplay(const std::string& id, bool unconditionally) override;
+    bool requestLyricsPageAvailable(bool& visible) override;
+    bool showLyrics() override;
+    bool hideLyrics() override;
+    bool controlLyrics(ControlLyricsDirection direction) override;
 
 protected:
     std::string listener_name;

--- a/include/interface/capability/audio_player_interface.hh
+++ b/include/interface/capability/audio_player_interface.hh
@@ -46,6 +46,15 @@ enum class AudioPlayerState {
 };
 
 /**
+ * @brief RepeatType
+ */
+enum class RepeatType {
+    NONE,
+    ONE,
+    ALL
+};
+
+/**
  * @brief audioplayer listener interface
  * @see IAudioPlayerHandler
  */
@@ -70,6 +79,39 @@ public:
      * @param[in] position media content's position
      */
     virtual void positionChanged(int position) = 0;
+
+    /**
+     * @brief The audio player reports to the user the current content's favorite setting changed.
+     * @param[in] favorite media content's favorite
+     */
+    virtual void favoriteChanged(bool favorite) = 0;
+
+    /**
+     * @brief The audio player reports to the user the current content's shuffle setting changed.
+     * @param[in] shuffle media content's shuffle
+     */
+    virtual void shuffleChanged(bool shuffle) = 0;
+
+    /**
+     * @brief The audio player reports to the user the current content's repeat setting changed.
+     * @param[in] repeat media content's repeat
+     */
+    virtual void repeatChanged(RepeatType repeat) = 0;
+
+    /**
+     * @brief The audio player request to the user to cache the content if possible
+     * @param[in] key content's unique key
+     * @param[in] playurl content's playurl
+     */
+    virtual void requestContentCache(const std::string& key, const std::string& playurl) = 0;
+
+    /**
+     * @brief The audio player request to the user to get the cached content
+     * @param[in] key content's unique key
+     * @param[out] filepath cached content's filepath
+     * @return return true if cached content, otherwise false
+     */
+    virtual bool requestToGetCachedContent(const std::string& key, std::string& filepath) = 0;
 };
 
 /**
@@ -115,6 +157,24 @@ public:
      * @param[in] sec content's position. It is moved from the current media position.
      */
     virtual void seek(int msec) = 0;
+
+    /**
+     * @brief Request the audio player to set favorite the content.
+     * @param[in] favorite favorite value
+     */
+    virtual void setFavorite(bool favorite) = 0;
+
+    /**
+     * @brief Request the audio player to set repeat the content.
+     * @param[in] repeat repeat value
+     */
+    virtual void setRepeat(RepeatType repeat) = 0;
+
+    /**
+     * @brief Request the audio player to set shuffle the content.
+     * @param[in] shuffle shuffle value
+     */
+    virtual void setShuffle(bool shuffle) = 0;
 
     /**
      * @brief Add the Listener object

--- a/include/interface/capability/display_interface.hh
+++ b/include/interface/capability/display_interface.hh
@@ -33,6 +33,11 @@ namespace NuguInterface {
  * @{
  */
 
+enum class ControlLyricsDirection {
+    PREVIOUS,
+    NEXT
+};
+
 /**
  * @brief display listener interface
  * @see IDisplayHandler
@@ -52,12 +57,38 @@ public:
 
     /**
      * @brief The SDK will ask you to delete the rendered display on the display according to the service context maintenance policy.
-     * @param[in] unconditionally whether clear display unconditionally or not
      * @param[in] id display template id
+     * @param[in] unconditionally whether clear display unconditionally or not
      * @return true if display is cleared
      * @see IAudioPlayerListener::clearDisplay()
      */
     virtual bool clearDisplay(const std::string& id, bool unconditionally) = 0;
+
+    /**
+     * @brief SDK request information about device's lyrics page available
+     * @param[out] visible show lyrics page visible
+     * @return return device's lyrics page available
+     */
+    virtual bool requestLyricsPageAvailable(bool& visible) = 0;
+
+    /**
+     * @brief Request to the user to show the lyrics page. (only use AudioPlayerAgent)
+     * @return return true if show lyrics success, otherwise false.
+     */
+    virtual bool showLyrics() = 0;
+
+    /**
+     * @brief Request to the user to hide the lyrics page. (only use AudioPlayerAgent)
+     * @return return true if hide lyrics success, otherwise false.
+     */
+    virtual bool hideLyrics() = 0;
+
+    /**
+     * @brief Request to the user to control the lyrics page. (only use AudioPlayerAgent)
+     * @param[in] direction move direction in the lyrics page
+     * @return return true if control lyrics success, otherwise false.
+     */
+    virtual bool controlLyrics(ControlLyricsDirection direction) = 0;
 };
 
 /**


### PR DESCRIPTION
The AudioPlayer agent support content's lyrics and cache feature.
Application can control the content as setting shuffle, favorite and repeat.
Added audio chunk content to the specification, but will support it later.

Signed-off-by: Hyojoong Kim <hyojoong.kim@sk.com>