### PR TITLE
base: apply uuid v2 spec

### DIFF
--- a/core/capability/tts_agent.cc
+++ b/core/capability/tts_agent.cc
@@ -234,7 +234,7 @@ void TTSAgent::requestTTS(const std::string& text, const std::string& play_servi
     std::string token;
     char* uuid;
 
-    uuid = nugu_uuid_generate_short();
+    uuid = nugu_uuid_generate_time();
     token = uuid;
     free(uuid);
 

--- a/include/base/nugu_uuid.h
+++ b/include/base/nugu_uuid.h
@@ -17,6 +17,8 @@
 #ifndef __NUGU_UUID_H__
 #define __NUGU_UUID_H__
 
+#include <time.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -31,10 +33,21 @@ extern "C" {
  */
 
 /**
- * @brief Generate short type UUID
- * @return memory allocated UUID string. Developer must free the data manually.
+ * @brief Seconds for base timestamp: 2019/1/1 00:00:00 (GMT)
  */
-char *nugu_uuid_generate_short(void);
+#define NUGU_BASE_TIMESTAMP_SEC 1546300800
+
+/**
+ * @brief Milliseconds for base timestamp: 2019/1/1 00:00:00.000 (GMT)
+ *
+ * This value must be treated as 64 bits.
+ */
+#define NUGU_BASE_TIMESTAMP_MSEC 1546300800000
+
+/**
+ * @brief Maximum UUID size not base16 encoded.
+ */
+#define NUGU_MAX_UUID_SIZE 16
 
 /**
  * @brief Generate time based UUID
@@ -42,6 +55,57 @@ char *nugu_uuid_generate_short(void);
  */
 char *nugu_uuid_generate_time(void);
 
+/**
+ * @brief Convert base16-encoded string to byte array
+ * @param[in] base16 base16-encoded string
+ * @param[in] base16_len length
+ * @param[out] out memory allocated output buffer
+ * @param[in] out_len size of output buffer
+ * @return Result of conversion success or failure
+ * @retval 0 Success
+ * @retval -1 Failure
+ */
+int nugu_uuid_convert_bytes(const char *base16, size_t base16_len,
+			    unsigned char *out, size_t out_len);
+
+/**
+ * @brief Convert byte array to base16-encoded string
+ * @param[in] bytes byte array
+ * @param[in] bytes_len length
+ * @param[out] out memory allocated output buffer
+ * @param[in] out_len size of output buffer
+ * @return Result of conversion success or failure
+ * @retval 0 Success
+ * @retval -1 Failure
+ */
+int nugu_uuid_convert_base16(const unsigned char *bytes, size_t bytes_len,
+			     char *out, size_t out_len);
+
+/**
+ * @brief Convert byte array to base16-encoded string
+ * @param[in] bytes byte array
+ * @param[in] bytes_len length
+ * @param[out] out_time memory allocated structure
+ * @return Result of conversion success or failure
+ * @retval 0 Success
+ * @retval -1 Failure
+ */
+int nugu_uuid_convert_timespec(const unsigned char *bytes, size_t bytes_len,
+			       struct timespec *out_time);
+
+/**
+ * @brief Fill to output buffer with NUGU UUID format using parameters
+ * @param[in] time timestamp information
+ * @param[in] hash hash value(e.g. SHA1(token))
+ * @param[in] hash_len length of hash value
+ * @param[out] out memory allocated output buffer
+ * @param[in] out_len size of output buffer
+ * @return Result of conversion success or failure
+ * @retval 0 Success
+ * @retval -1 Failure
+ */
+int nugu_uuid_fill(const struct timespec *time, const unsigned char *hash,
+		   size_t hash_len, unsigned char *out, size_t out_len);
 /**
  * @}
  */

--- a/src/network/dg_server.c
+++ b/src/network/dg_server.c
@@ -237,7 +237,7 @@ int dg_server_send_attachment(DGServer *server, NuguEvent *nev, int is_end,
 	if (!ea)
 		return -1;
 
-	msg_id = nugu_uuid_generate_short();
+	msg_id = nugu_uuid_generate_time();
 
 	if (data != NULL && length > 0)
 		v1_event_attachment_set_data(ea, data, length);

--- a/src/nugu_event.c
+++ b/src/nugu_event.c
@@ -79,7 +79,7 @@ EXPORT_API NuguEvent *nugu_event_new(const char *name_space, const char *name,
 	nev = calloc(1, sizeof(NuguEvent));
 	nev->name_space = strdup(name_space);
 	nev->name = strdup(name);
-	nev->msg_id = nugu_uuid_generate_short();
+	nev->msg_id = nugu_uuid_generate_time();
 	nev->dialog_id = nugu_uuid_generate_time();
 	nev->referrer_id = NULL;
 	nev->seq = 0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ SET(UNIT_TESTS
 	test-nugu-player
 	test-nugu-timer
 	test-nugu-event
+	test-nugu-uuid
 	test-nugu-directive
 	test-nugu-ringbuffer)
 

--- a/tests/test-nugu-uuid.c
+++ b/tests/test-nugu-uuid.c
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <inttypes.h>
+#include <time.h>
+
+#include <glib.h>
+
+#include "base/nugu_uuid.h"
+#include "base/nugu_log.h"
+
+/* "2020-01-22 01:15:59.039" */
+#define TEST1 "07c41c48bf01cb0eb29b006139b1abbb"
+static unsigned char BYTES1[] = { 0x07, 0xc4, 0x1c, 0x48, 0xbf, 0x01,
+				  0xcb, 0x0e, 0xb2, 0x9b, 0x00, 0x61,
+				  0x39, 0xb1, 0xab, 0xbb };
+
+/* "2020-01-22 01:16:49.627" */
+#define TEST2 "07c41d0e5b01e7f40b3c68ce7da57153"
+static unsigned char BYTES2[] = { 0x07, 0xc4, 0x1d, 0x0e, 0x5b, 0x01,
+				  0xe7, 0xf4, 0x0b, 0x3c, 0x68, 0xce,
+				  0x7d, 0xa5, 0x71, 0x53 };
+
+/* "2020-01-23 00:43:41.516" */
+#define TEST3 "07c925144c014c0f32f1f282026f4e73"
+static unsigned char BYTES3[] = { 0x07, 0xc9, 0x25, 0x14, 0x4c, 0x01,
+				  0x4c, 0x0f, 0x32, 0xf1, 0xf2, 0x82,
+				  0x02, 0x6f, 0x4e, 0x73 };
+
+static void test_nugu_uuid_base16(void)
+{
+	unsigned char buf[NUGU_MAX_UUID_SIZE];
+	char base16_buf[NUGU_MAX_UUID_SIZE * 2 + 1];
+
+	/* Convert base16-encoded 32 bytes to raw 16 bytes */
+	g_assert(nugu_uuid_convert_bytes(TEST1, strlen(TEST1), buf,
+					 sizeof(buf)) == 0);
+	g_assert_cmpmem(buf, sizeof(buf), BYTES1, sizeof(BYTES1));
+
+	g_assert(nugu_uuid_convert_bytes(TEST2, strlen(TEST2), buf,
+					 sizeof(buf)) == 0);
+	g_assert_cmpmem(buf, sizeof(buf), BYTES2, sizeof(BYTES2));
+
+	g_assert(nugu_uuid_convert_bytes(TEST3, strlen(TEST3), buf,
+					 sizeof(buf)) == 0);
+	g_assert_cmpmem(buf, sizeof(buf), BYTES3, sizeof(BYTES3));
+
+	/* Convert raw 16 bytes to base16-encoded 32 bytes */
+	g_assert(nugu_uuid_convert_base16(BYTES1, sizeof(BYTES1), base16_buf,
+					  sizeof(base16_buf)) == 0);
+	g_assert_cmpmem(base16_buf, sizeof(base16_buf), TEST1, sizeof(TEST1));
+
+	g_assert(nugu_uuid_convert_base16(BYTES2, sizeof(BYTES2), base16_buf,
+					  sizeof(base16_buf)) == 0);
+	g_assert_cmpmem(base16_buf, sizeof(base16_buf), TEST2, sizeof(TEST2));
+
+	g_assert(nugu_uuid_convert_base16(BYTES3, sizeof(BYTES3), base16_buf,
+					  sizeof(base16_buf)) == 0);
+	g_assert_cmpmem(base16_buf, sizeof(base16_buf), TEST3, sizeof(TEST3));
+}
+
+static void test_nugu_uuid_time(void)
+{
+	unsigned char buf[NUGU_MAX_UUID_SIZE];
+	unsigned char outbuf[NUGU_MAX_UUID_SIZE];
+	struct tm t_tm;
+	struct timespec t_spec;
+	char timestr[32];
+	unsigned char dummy_hash[6] = { '0', '0', '0', '0', '0', '0' };
+
+	/* Convert 5 bytes to integer from NUGU_BASE_TIMESTAMP_MSEC */
+	g_assert(nugu_uuid_convert_bytes(TEST1, strlen(TEST1), buf,
+					 sizeof(buf)) == 0);
+
+	g_assert(nugu_uuid_convert_timespec(buf, sizeof(buf), &t_spec) == 0);
+	g_assert(t_spec.tv_sec == 1579655759);
+	g_assert(t_spec.tv_nsec == 39000000);
+	gmtime_r(&t_spec.tv_sec, &t_tm);
+	strftime(timestr, sizeof(timestr), "%F %T", &t_tm);
+	g_assert_cmpstr(timestr, ==, "2020-01-22 01:15:59");
+
+	/* Convert timespec to 5 bytes */
+	g_assert(nugu_uuid_fill(&t_spec, dummy_hash, sizeof(dummy_hash) - 5,
+				outbuf, sizeof(outbuf)) == 0);
+	g_assert_cmpmem(buf, 5, outbuf, 5);
+
+	/* Convert 5 bytes to integer from NUGU_BASE_TIMESTAMP_MSEC */
+	g_assert(nugu_uuid_convert_bytes(TEST2, strlen(TEST2), buf,
+					 sizeof(buf)) == 0);
+	g_assert(nugu_uuid_convert_timespec(buf, sizeof(buf), &t_spec) == 0);
+	g_assert(t_spec.tv_sec == 1579655809);
+	g_assert(t_spec.tv_nsec == 627000000);
+	gmtime_r(&t_spec.tv_sec, &t_tm);
+	strftime(timestr, sizeof(timestr), "%F %T", &t_tm);
+	g_assert_cmpstr(timestr, ==, "2020-01-22 01:16:49");
+
+	/* Convert timespec to 5 bytes */
+	g_assert(nugu_uuid_fill(&t_spec, dummy_hash, sizeof(dummy_hash) - 5,
+				outbuf, sizeof(outbuf)) == 0);
+	g_assert_cmpmem(buf, 5, outbuf, 5);
+
+	/* Convert 5 bytes to integer from NUGU_BASE_TIMESTAMP_MSEC */
+	g_assert(nugu_uuid_convert_bytes(TEST3, strlen(TEST3), buf,
+					 sizeof(buf)) == 0);
+	g_assert(nugu_uuid_convert_timespec(buf, sizeof(buf), &t_spec) == 0);
+	g_assert(t_spec.tv_sec == 1579740221);
+	g_assert(t_spec.tv_nsec == 516000000);
+	gmtime_r(&t_spec.tv_sec, &t_tm);
+	strftime(timestr, sizeof(timestr), "%F %T", &t_tm);
+	g_assert_cmpstr(timestr, ==, "2020-01-23 00:43:41");
+
+	/* Convert timespec to 5 bytes */
+	g_assert(nugu_uuid_fill(&t_spec, dummy_hash, sizeof(dummy_hash) - 5,
+				outbuf, sizeof(outbuf)) == 0);
+	g_assert_cmpmem(buf, 5, outbuf, 5);
+}
+
+int main(int argc, char *argv[])
+{
+#if !GLIB_CHECK_VERSION(2, 36, 0)
+	g_type_init();
+#endif
+
+	g_test_init(&argc, &argv, NULL);
+	g_log_set_always_fatal((GLogLevelFlags)G_LOG_FATAL_MASK);
+
+	g_test_add_func("/nugu_uuid/base16", test_nugu_uuid_base16);
+	g_test_add_func("/nugu_uuid/time", test_nugu_uuid_time);
+
+	return g_test_run();
+}


### PR DESCRIPTION
NUGU UUID spec is updated to v2.

```
  /-------------------------------\
  | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |
  |===================+===+=======|
  |      time(5)      | v |       ~
  |---------------+---+---+-------|
  ~  hash(6)      |   random(4)   |
  \---------------+---------------/
```

 * 5 bytes: time(GMT): EPOCH milliseconds - 1546300800000
 * 1 bytes: version: 0x1
 * 6 bytes: hash: cut(sha1(token) 20 bytes, 0, 6 bytes)
 * 4 bytes: random

Signed-off-by: Inho Oh <inho.oh@sk.com>