### PR TITLE
Mic

### DIFF
--- a/clientkit/nugu_client.cc
+++ b/clientkit/nugu_client.cc
@@ -121,6 +121,11 @@ ISystemHandler* NuguClient::getSystemHandler()
     return dynamic_cast<ISystemHandler*>(impl->getCapabilityHandler(CapabilityType::System));
 }
 
+IMicHandler* NuguClient::getMicHandler()
+{
+    return dynamic_cast<IMicHandler*>(impl->getCapabilityHandler(CapabilityType::Mic));
+}
+
 INetworkManager* NuguClient::getNetworkManager()
 {
     return impl->getNetworkManager();

--- a/core/audio_input_processor.cc
+++ b/core/audio_input_processor.cc
@@ -74,11 +74,16 @@ void AudioInputProcessor::init(std::string name, std::string& sample, std::strin
     is_initialized = true;
 }
 
-void AudioInputProcessor::start(const std::function<void()>& extra_func)
+bool AudioInputProcessor::start(const std::function<void()>& extra_func)
 {
     if (is_running) {
         nugu_dbg("Thread is already running...");
-        return;
+        return true;
+    }
+
+    if (recorder->isMute()) {
+        nugu_warn("recorder is muted...");
+        return false;
     }
 
     if (extra_func)
@@ -89,6 +94,8 @@ void AudioInputProcessor::start(const std::function<void()>& extra_func)
     mutex.lock();
     cond.notify_all();
     mutex.unlock();
+
+    return true;
 }
 
 void AudioInputProcessor::stop(void)

--- a/core/audio_input_processor.hh
+++ b/core/audio_input_processor.hh
@@ -37,7 +37,7 @@ public:
 
 protected:
     void init(std::string name, std::string& sample, std::string& format, std::string& channel);
-    void start(const std::function<void()>& extra_func = nullptr);
+    bool start(const std::function<void()>& extra_func = nullptr);
     void stop(void);
     void sendSyncEvent(const std::function<void()>& action = nullptr);
 

--- a/core/audio_recorder_interface.hh
+++ b/core/audio_recorder_interface.hh
@@ -32,6 +32,7 @@ public:
     virtual bool start() = 0;
     virtual bool stop() = 0;
     virtual bool isRecording() = 0;
+    virtual bool isMute() = 0;
 
     virtual int getAudioFrameSize() = 0;
     virtual int getAudioFrameCount() = 0;

--- a/core/audio_recorder_manager.hh
+++ b/core/audio_recorder_manager.hh
@@ -40,6 +40,7 @@ public:
     bool start() override;
     bool stop() override;
     bool isRecording() override;
+    bool isMute() override;
 
     int getAudioFrameSize() override;
     int getAudioFrameCount() override;
@@ -64,6 +65,8 @@ public:
     bool start(IAudioRecorder* recorder);
     bool stop(IAudioRecorder* recorder);
     bool isRecording(IAudioRecorder* recorder);
+    bool isMute();
+    bool setMute(bool mute);
 
     int getAudioFrameSize(IAudioRecorder* recorder);
     int getAudioFrameCount(IAudioRecorder* recorder);
@@ -79,6 +82,7 @@ private:
     std::map<std::string, NuguRecorder*> nugu_recorders;
     std::map<NuguRecorder*, std::list<IAudioRecorder*>> recorders;
     std::mutex mutex;
+    bool muted;
 };
 
 } // NuguCore

--- a/core/capability/asr_agent.cc
+++ b/core/capability/asr_agent.cc
@@ -57,7 +57,8 @@ ASRFocusListener::~ASRFocusListener()
 NuguFocusResult ASRFocusListener::onFocus(void* event)
 {
     nugu_dbg("ASRFocusListener::onFocus");
-    speech_recognizer->startListening();
+    if (!speech_recognizer->startListening())
+        return NUGU_FOCUS_REMOVE;
 
     if (agent->isExpectSpeechState()) {
         agent->resetExpectSpeechState();
@@ -200,6 +201,10 @@ void ASRAgent::startRecognition()
 void ASRAgent::stopRecognition()
 {
     nugu_dbg("stopRecognition()");
+
+    if (rec_event)
+        sendEventStopRecognize();
+
     CapabilityManager::getInstance()->releaseFocus("asr");
 }
 

--- a/core/capability/mic_agent.cc
+++ b/core/capability/mic_agent.cc
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string.h>
+
+#include "base/nugu_log.h"
+
+#include "audio_recorder_manager.hh"
+#include "capability_manager.hh"
+#include "mic_agent.hh"
+
+namespace NuguCore {
+
+static const char* capability_version = "1.0";
+
+MicAgent::MicAgent()
+    : Capability(CapabilityType::Mic, capability_version)
+    , mic_listener(nullptr)
+    , cur_status(MicStatus::ON)
+    , pre_status(MicStatus::ON)
+    , ps_id("")
+{
+}
+
+MicAgent::~MicAgent()
+{
+}
+
+void MicAgent::parsingDirective(const char* dname, const char* message)
+{
+    nugu_dbg("message: %s", message);
+
+    // directive name check
+    if (!strcmp(dname, "SetMic"))
+        parsingSetMic(message);
+    else {
+        nugu_warn("%s[%s] is not support %s directive", getName().c_str(), getVersion().c_str(), dname);
+    }
+}
+
+void MicAgent::updateInfoForContext(Json::Value& ctx)
+{
+    Json::Value mic;
+
+    mic["version"] = getVersion();
+    if (pre_status == MicStatus::ON)
+        mic["micStatus"] = "ON";
+    else
+        mic["micStatus"] = "OFF";
+
+    ctx[getName()] = mic;
+}
+
+void MicAgent::setCapabilityListener(ICapabilityListener* clistener)
+{
+    if (clistener)
+        mic_listener = dynamic_cast<IMicListener*>(clistener);
+}
+
+void MicAgent::enable()
+{
+    control(true);
+}
+
+void MicAgent::disable()
+{
+    control(false);
+}
+
+void MicAgent::sendEventSetMicSucceeded()
+{
+    sendEventCommon("SetMicSucceeded");
+}
+
+void MicAgent::sendEventSetMicFailed()
+{
+    sendEventCommon("SetMicFailed");
+}
+
+void MicAgent::sendEventCommon(const std::string& ename)
+{
+    std::string payload = "";
+    Json::Value root;
+    Json::StyledWriter writer;
+
+    root["playServiceId"] = ps_id;
+    if (cur_status == MicStatus::ON)
+        root["micStatus"] = "ON";
+    else
+        root["micStatus"] = "OFF";
+    payload = writer.write(root);
+
+    sendEvent(ename, getContextInfo(), payload);
+}
+
+void MicAgent::parsingSetMic(const char* message)
+{
+    Json::Value root;
+    Json::Reader reader;
+    std::string mic_status;
+
+    if (!reader.parse(message, root)) {
+        nugu_error("parsing error");
+        return;
+    }
+
+    ps_id = root["playServiceId"].asString();
+    mic_status = root["MicStatus"].asString();
+
+    if (ps_id.size() == 0 || mic_status.size() == 0) {
+        nugu_error("There is no mandatory data in directive message");
+        return;
+    }
+
+    control(mic_status == "ON", true);
+}
+
+void MicAgent::control(bool enable, bool send_event)
+{
+    if (enable)
+        cur_status = MicStatus::ON;
+    else
+        cur_status = MicStatus::OFF;
+
+    if (cur_status == pre_status)
+        return;
+
+    AudioRecorderManager::getInstance()->setMute(cur_status == MicStatus::OFF);
+
+    if (send_event)
+        sendEventSetMicSucceeded();
+
+    if (mic_listener)
+        mic_listener->micStatusChanged(cur_status);
+
+    pre_status = cur_status;
+}
+
+} // NuguCore

--- a/core/capability/mic_agent.hh
+++ b/core/capability/mic_agent.hh
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NUGU_MIC_AGENT_H__
+#define __NUGU_MIC_AGENT_H__
+
+#include "interface/capability/mic_interface.hh"
+
+#include "capability.hh"
+
+namespace NuguCore {
+
+using namespace NuguInterface;
+
+class MicAgent : public Capability, public IMicHandler {
+public:
+    MicAgent();
+    virtual ~MicAgent();
+
+    void parsingDirective(const char* dname, const char* message) override;
+    void updateInfoForContext(Json::Value& ctx) override;
+    void setCapabilityListener(ICapabilityListener* clistener) override;
+    void enable() override;
+    void disable() override;
+
+private:
+    void sendEventCommon(const std::string& ename);
+    void sendEventSetMicSucceeded();
+    void sendEventSetMicFailed();
+
+    void control(bool enable, bool send_event = false);
+
+    void parsingSetMic(const char* message);
+
+    IMicListener* mic_listener;
+    MicStatus cur_status;
+    MicStatus pre_status;
+    std::string ps_id;
+};
+
+} // NuguCore
+
+#endif /* __NUGU_MIC_AGENT_H__ */

--- a/core/capability_creator.cc
+++ b/core/capability_creator.cc
@@ -20,6 +20,7 @@
 #include "capability/display_agent.hh"
 #include "capability/extension_agent.hh"
 #include "capability/location_agent.hh"
+#include "capability/mic_agent.hh"
 #include "capability/system_agent.hh"
 #include "capability/text_agent.hh"
 #include "capability/tts_agent.hh"
@@ -44,16 +45,17 @@ using CapabilityElement = CapabilityCreator::Element;
 
 const std::list<CapabilityElement>& CapabilityCreator::getCapabilityList()
 {
-    static std::list<CapabilityElement> CAPABILITY_LIST {
-    CapabilityElement { CapabilityType::ASR, true, &create<ASRAgent> },
-    CapabilityElement { CapabilityType::TTS, true, &create<TTSAgent> },
-    CapabilityElement { CapabilityType::AudioPlayer, true, &create<AudioPlayerAgent> },
-    CapabilityElement { CapabilityType::System, true, &create<SystemAgent> },
-    CapabilityElement { CapabilityType::Display, false, &create<DisplayAgent> },
-    CapabilityElement { CapabilityType::Extension, false, &create<ExtensionAgent> },
-    CapabilityElement { CapabilityType::Text, false, &create<TextAgent> },
-    CapabilityElement { CapabilityType::Delegation, false, &create<DelegationAgent> },
-    CapabilityElement { CapabilityType::Location, false, &create<LocationAgent> }
+    static std::list<CapabilityElement> CAPABILITY_LIST{
+        CapabilityElement{ CapabilityType::ASR, true, &create<ASRAgent> },
+        CapabilityElement{ CapabilityType::TTS, true, &create<TTSAgent> },
+        CapabilityElement{ CapabilityType::AudioPlayer, true, &create<AudioPlayerAgent> },
+        CapabilityElement{ CapabilityType::System, true, &create<SystemAgent> },
+        CapabilityElement{ CapabilityType::Display, false, &create<DisplayAgent> },
+        CapabilityElement{ CapabilityType::Extension, false, &create<ExtensionAgent> },
+        CapabilityElement{ CapabilityType::Text, false, &create<TextAgent> },
+        CapabilityElement{ CapabilityType::Delegation, false, &create<DelegationAgent> },
+        CapabilityElement{ CapabilityType::Location, false, &create<LocationAgent> },
+        CapabilityElement{ CapabilityType::Mic, false, &create<MicAgent> }
     };
 
     return CAPABILITY_LIST;

--- a/core/speech_recognizer.cc
+++ b/core/speech_recognizer.cc
@@ -136,6 +136,12 @@ void SpeechRecognizer::loop(void)
                 continue;
             }
 
+            if (recorder->isMute()) {
+                nugu_error("nugu recorder is mute");
+                sendSyncListeningEvent(ListeningState::FAILED);
+                break;
+            }
+
             if (!recorder->getAudioFrame(pcm_buf, &pcm_size, 0)) {
                 nugu_error("nugu_recorder_get_frame_timeout() failed");
                 sendSyncListeningEvent(ListeningState::FAILED);
@@ -201,9 +207,9 @@ void SpeechRecognizer::loop(void)
     nugu_dbg("Listening Thread: exited");
 }
 
-void SpeechRecognizer::startListening(void)
+bool SpeechRecognizer::startListening(void)
 {
-    AudioInputProcessor::start([&] {
+    return AudioInputProcessor::start([&] {
         if (listener)
             listener->onListeningState(ListeningState::READY);
 
@@ -214,18 +220,6 @@ void SpeechRecognizer::startListening(void)
 void SpeechRecognizer::stopListening(void)
 {
     AudioInputProcessor::stop();
-}
-
-void SpeechRecognizer::startRecorder(void)
-{
-    if (is_running && !recorder->isRecording())
-        recorder->start();
-}
-
-void SpeechRecognizer::stopRecorder(void)
-{
-    if (is_running && recorder->isRecording())
-        recorder->stop();
 }
 
 } // NuguCore

--- a/core/speech_recognizer.hh
+++ b/core/speech_recognizer.hh
@@ -50,10 +50,8 @@ public:
     virtual ~SpeechRecognizer() = default;
 
     void setListener(ISpeechRecognizerListener* listener);
-    void startListening(void);
+    bool startListening(void);
     void stopListening(void);
-    void startRecorder(void);
-    void stopRecorder(void);
 
 private:
     void loop(void) override;

--- a/core/wakeup_detector.cc
+++ b/core/wakeup_detector.cc
@@ -108,6 +108,12 @@ void WakeupDetector::loop(void)
                 continue;
             }
 
+            if (recorder->isMute()) {
+                nugu_error("recorder is mute");
+                sendSyncWakeupEvent(WakeupState::FAIL);
+                break;
+            }
+
             if (!recorder->getAudioFrame(pcm_buf, &pcm_size, 0)) {
                 nugu_error("recorder->getAudioFrame() failed");
                 sendSyncWakeupEvent(WakeupState::FAIL);

--- a/examples/standalone/capability/mic_listener.cc
+++ b/examples/standalone/capability/mic_listener.cc
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+
+#include "mic_listener.hh"
+
+void MicListener::micStatusChanged(MicStatus& status)
+{
+    switch (status) {
+    case MicStatus::ON:
+        std::cout << "[MIC] ON..." << std::endl;
+        break;
+
+    case MicStatus::OFF:
+        std::cout << "[MIC] OFF..." << std::endl;
+        break;
+    }
+}

--- a/examples/standalone/capability/mic_listener.hh
+++ b/examples/standalone/capability/mic_listener.hh
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __MIC_LISTENER_H__
+#define __MIC_LISTENER_H__
+
+#include <interface/capability/mic_interface.hh>
+
+using namespace NuguInterface;
+
+class MicListener : public IMicListener {
+public:
+    virtual ~MicListener() = default;
+    void micStatusChanged(MicStatus& status) override;
+};
+
+#endif /* __MIC_LISTENER_H__ */

--- a/examples/standalone/nugu_sample.cc
+++ b/examples/standalone/nugu_sample.cc
@@ -16,18 +16,19 @@
 
 #include <iostream>
 
-#include <interface/nugu_configuration.hh>
 #include <clientkit/nugu_client.hh>
+#include <interface/nugu_configuration.hh>
 
 #include "audio_player_listener.hh"
 #include "delegation_listener.hh"
 #include "display_listener.hh"
 #include "extension_listener.hh"
 #include "location_listener.hh"
+#include "mic_listener.hh"
+#include "speech_operator.hh"
 #include "system_listener.hh"
 #include "text_listener.hh"
 #include "tts_listener.hh"
-#include "speech_operator.hh"
 
 #include "nugu_sample_manager.hh"
 
@@ -50,6 +51,7 @@ std::unique_ptr<TextListener> text_listener = nullptr;
 std::unique_ptr<ExtensionListener> extension_listener = nullptr;
 std::unique_ptr<DelegationListener> delegation_listener = nullptr;
 std::unique_ptr<LocationListener> location_listener = nullptr;
+std::unique_ptr<MicListener> mic_listener = nullptr;
 
 void msg_error(const std::string& message)
 {
@@ -131,6 +133,7 @@ void registerCapabilities()
         ->add(CapabilityType::Extension, extension_listener.get())
         ->add(CapabilityType::Delegation, delegation_listener.get())
         ->add(CapabilityType::Location, location_listener.get())
+        ->add(CapabilityType::Mic, mic_listener.get())
         ->construct();
 }
 
@@ -156,6 +159,7 @@ int main(int argc, char** argv)
     extension_listener = make_unique<ExtensionListener>();
     delegation_listener = make_unique<DelegationListener>();
     location_listener = make_unique<LocationListener>();
+    mic_listener = make_unique<MicListener>();
 
     auto nugu_client_listener(make_unique<NuguClientListener>());
     auto network_manager_listener(make_unique<NetworkManagerListener>());
@@ -183,9 +187,10 @@ int main(int argc, char** argv)
 
         nugu_sample_manager->setTextHandler(nugu_client->getTextHandler())
             ->setSpeechOperator(speech_operator.get())
-            ->setNetworkCallback(NuguSampleManager::NetworkCallback {
+            ->setNetworkCallback(NuguSampleManager::NetworkCallback{
                 [&]() { return network_manager->connect(); },
                 [&]() { return network_manager->disconnect(); } })
+            ->setMicHandler(nugu_client->getMicHandler())
             ->runLoop();
     }
 

--- a/examples/standalone/nugu_sample_manager.cc
+++ b/examples/standalone/nugu_sample_manager.cc
@@ -136,6 +136,13 @@ NuguSampleManager* NuguSampleManager::setSpeechOperator(SpeechOperator* speech_o
     return this;
 }
 
+NuguSampleManager* NuguSampleManager::setMicHandler(IMicHandler* mic_handler)
+{
+    commander.mic_handler = mic_handler;
+
+    return this;
+}
+
 void NuguSampleManager::handleNetworkResult(bool is_connected, bool is_show_cmd)
 {
     commander.is_connected = is_connected;
@@ -172,7 +179,8 @@ void NuguSampleManager::showPrompt(void)
             std::cout << "w : start wakeup\n"
                       << "l : start listening\n"
                       << "s : stop listening\n"
-                      << "t : text input\n";
+                      << "t : text input\n"
+                      << "m : set mic mute\n";
 
         std::cout << "c : connect\n"
                   << "d : disconnect\n"
@@ -231,6 +239,14 @@ gboolean NuguSampleManager::onKeyInput(GIOChannel* src, GIOCondition con, gpoint
         showPrompt();
     } else if (g_strcmp0(keybuf, "t") == 0) {
         commander.text_input = 1;
+        showPrompt();
+    } else if (g_strcmp0(keybuf, "m") == 0) {
+        static bool mute = false;
+        mute = !mute;
+        if (!mute)
+            commander.mic_handler->enable();
+        else
+            commander.mic_handler->disable();
         showPrompt();
     } else if (g_strcmp0(keybuf, "c") == 0) {
         if (commander.is_connected) {

--- a/examples/standalone/nugu_sample_manager.hh
+++ b/examples/standalone/nugu_sample_manager.hh
@@ -20,6 +20,7 @@
 #include <glib.h>
 
 #include <interface/capability/text_interface.hh>
+#include <interface/capability/mic_interface.hh>
 
 #include "speech_operator.hh"
 
@@ -40,6 +41,7 @@ public:
         NetworkCallback network_callback;
         ITextHandler* text_handler;
         SpeechOperator* speech_operator;
+        IMicHandler* mic_handler;
     };
 
     static void error(const std::string& message);
@@ -54,6 +56,7 @@ public:
     NuguSampleManager* setNetworkCallback(NetworkCallback callback);
     NuguSampleManager* setTextHandler(ITextHandler* text_handler);
     NuguSampleManager* setSpeechOperator(SpeechOperator* speech_operator);
+    NuguSampleManager* setMicHandler(IMicHandler* mic_handler);
     void handleNetworkResult(bool is_connected, bool is_show_cmd = true);
 
 private:

--- a/include/base/nugu_recorder.h
+++ b/include/base/nugu_recorder.h
@@ -141,6 +141,15 @@ int nugu_recorder_start(NuguRecorder *rec);
 int nugu_recorder_stop(NuguRecorder *rec);
 
 /**
+ * @brief Clear recording data
+ * @param[in] rec recorder object
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ */
+int nugu_recorder_clear(NuguRecorder *rec);
+
+/**
  * @brief Get the status of recording
  * @param[in] rec recorder object
  * @return result

--- a/include/clientkit/nugu_client.hh
+++ b/include/clientkit/nugu_client.hh
@@ -26,6 +26,7 @@
 #include <interface/capability/delegation_interface.hh>
 #include <interface/capability/display_interface.hh>
 #include <interface/capability/extension_interface.hh>
+#include <interface/capability/mic_interface.hh>
 #include <interface/capability/system_interface.hh>
 #include <interface/capability/text_interface.hh>
 #include <interface/capability/tts_interface.hh>
@@ -180,6 +181,12 @@ public:
      * @return INetworkManager if a feature agent has been created with the feature builder, otherwise NULL
      */
     INetworkManager* getNetworkManager();
+
+    /**
+     * @brief Get MicHandler object
+     * @return IMicHandler if a feature agent has been created with the feature builder, otherwise NULL
+     */
+    IMicHandler* getMicHandler();
 
     /**
      * @brief Get new media player object

--- a/include/interface/capability/capability_interface.hh
+++ b/include/interface/capability/capability_interface.hh
@@ -49,7 +49,8 @@ enum class CapabilityType {
     Text, /**< the type of Text agent */
     Extension, /**< the type of Extension agent */
     Delegation, /**< the type of Delegation agent */
-    Location /**< the type of Location agent */
+    Location, /**< the type of Location agent */
+    Mic /**< the type of Mic agent */
 };
 
 static const std::map<CapabilityType, std::string> CAPABILITY_TYPE_MAP {
@@ -61,7 +62,8 @@ static const std::map<CapabilityType, std::string> CAPABILITY_TYPE_MAP {
     { CapabilityType::Text, "Text" },
     { CapabilityType::Extension, "Extension" },
     { CapabilityType::Delegation, "Delegation" },
-    { CapabilityType::Location, "Location" }
+    { CapabilityType::Location, "Location" },
+    { CapabilityType::Mic, "Mic" }
 };
 
 /**

--- a/include/interface/capability/mic_interface.hh
+++ b/include/interface/capability/mic_interface.hh
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NUGU_MIC_INTERFACE_H__
+#define __NUGU_MIC_INTERFACE_H__
+
+#include <interface/capability/capability_interface.hh>
+
+namespace NuguInterface {
+
+/**
+ * @file mic_interface.hh
+ * @defgroup MicInterface MicInterface
+ * @ingroup SDKNuguInterface
+ * @brief MIC capability interface
+ *
+ * Control the microphone on or off via button or mobile nugu application.
+ *
+ * @{
+ */
+
+/**
+ * @brief MicStatus
+ */
+enum class MicStatus {
+    ON, /**< MIC ON status */
+    OFF /**< MIC OFF status */
+};
+
+/**
+ * @brief mic listener interface
+ * @see IMicHandler
+ */
+class IMicListener : public ICapabilityListener {
+public:
+    virtual ~IMicListener() = default;
+
+    /**
+     * @brief Report to the user mic status changed.
+     * @param[in] status mic status
+     */
+    virtual void micStatusChanged(MicStatus& status) = 0;
+};
+
+/**
+ * @brief mic handler interface
+ * @see IMicListener
+ */
+class IMicHandler : virtual public ICapabilityInterface {
+public:
+    virtual ~IMicHandler() = default;
+
+    /**
+     * @brief application enables mic.
+     */
+    virtual void enable() = 0;
+
+    /**
+     * @brief if application disables mic, EPD and KWD will not work.
+     */
+    virtual void disable() = 0;
+};
+
+/**
+ * @}
+ */
+
+} // NuguInterface
+
+#endif /* __NUGU_MIC_INTERFACE_H__ */

--- a/src/nugu_recorder.c
+++ b/src/nugu_recorder.c
@@ -292,6 +292,14 @@ EXPORT_API int nugu_recorder_stop(NuguRecorder *rec)
 	return rec->driver->ops->stop(rec->driver, rec);
 }
 
+EXPORT_API int nugu_recorder_clear(NuguRecorder *rec)
+{
+	g_return_val_if_fail(rec != NULL, -1);
+
+	nugu_ring_buffer_clear_items(rec->buf);
+	return 0;
+}
+
 EXPORT_API int nugu_recorder_is_recording(NuguRecorder *rec)
 {
 	g_return_val_if_fail(rec != NULL, -1);


### PR DESCRIPTION
**Add mute test**

The user can test the mute via sample application.

```
=======================================================
NUGU SDK Command (Connected)
=======================================================
w : start wakeup
l : start listening
s : stop listening
t : text input
m : set mic mute
c : connect
d : disconnect
q : quit
-------------------------------------------------------
```

Signed-off-by: Hyojoong Kim <hyojoong.kim@sk.com>

**Mute Action**

Apply the mute process to the Wakeup Detection and
Auto Speech Recognition.

Signed-off-by: Hyojoong Kim <hyojoong.kim@sk.com>

**Capability: Add MIC Agent**

The NUGU SDK support MIC Agent that is to control the microphone
on or off via button or mobile nugu application.

Signed-off-by: Hyojoong Kim <hyojoong.kim@sk.com>

**Add Mute**

AudioRecorderManager support mute control.

Signed-off-by: Hyojoong Kim <hyojoong.kim@sk.com>
