### PR TITLE
remove CapabilityType

### DIFF
--- a/clientkit/nugu_client.cc
+++ b/clientkit/nugu_client.cc
@@ -29,9 +29,9 @@ NuguClient::CapabilityBuilder::~CapabilityBuilder()
 {
 }
 
-NuguClient::CapabilityBuilder* NuguClient::CapabilityBuilder::add(const CapabilityType ctype, ICapabilityListener* clistener, ICapabilityInterface* cap_instance)
+NuguClient::CapabilityBuilder* NuguClient::CapabilityBuilder::add(const std::string& cname, ICapabilityListener* clistener, ICapabilityInterface* cap_instance)
 {
-    client_impl->registerCapability(ctype, std::make_pair(cap_instance, clistener));
+    client_impl->registerCapability(cname, std::make_pair(cap_instance, clistener));
 
     return this;
 }
@@ -83,47 +83,47 @@ IWakeupHandler* NuguClient::getWakeupHandler()
 
 IASRHandler* NuguClient::getASRHandler()
 {
-    return dynamic_cast<IASRHandler*>(impl->getCapabilityHandler(CapabilityType::ASR));
+    return dynamic_cast<IASRHandler*>(impl->getCapabilityHandler("ASR"));
 }
 
 ITTSHandler* NuguClient::getTTSHandler()
 {
-    return dynamic_cast<ITTSHandler*>(impl->getCapabilityHandler(CapabilityType::TTS));
+    return dynamic_cast<ITTSHandler*>(impl->getCapabilityHandler("TTS"));
 }
 
 IAudioPlayerHandler* NuguClient::getAudioPlayerHandler()
 {
-    return dynamic_cast<IAudioPlayerHandler*>(impl->getCapabilityHandler(CapabilityType::AudioPlayer));
+    return dynamic_cast<IAudioPlayerHandler*>(impl->getCapabilityHandler("AudioPlayer"));
 }
 
 IDisplayHandler* NuguClient::getDisplayHandler()
 {
-    return dynamic_cast<IDisplayHandler*>(impl->getCapabilityHandler(CapabilityType::Display));
+    return dynamic_cast<IDisplayHandler*>(impl->getCapabilityHandler("Display"));
 }
 
 ITextHandler* NuguClient::getTextHandler()
 {
-    return dynamic_cast<ITextHandler*>(impl->getCapabilityHandler(CapabilityType::Text));
+    return dynamic_cast<ITextHandler*>(impl->getCapabilityHandler("Text"));
 }
 
 IExtensionHandler* NuguClient::getExtensionHandler()
 {
-    return dynamic_cast<IExtensionHandler*>(impl->getCapabilityHandler(CapabilityType::Extension));
+    return dynamic_cast<IExtensionHandler*>(impl->getCapabilityHandler("Extension"));
 }
 
 IDelegationHandler* NuguClient::getDelegationHandler()
 {
-    return dynamic_cast<IDelegationHandler*>(impl->getCapabilityHandler(CapabilityType::Delegation));
+    return dynamic_cast<IDelegationHandler*>(impl->getCapabilityHandler("Delegation"));
 }
 
 ISystemHandler* NuguClient::getSystemHandler()
 {
-    return dynamic_cast<ISystemHandler*>(impl->getCapabilityHandler(CapabilityType::System));
+    return dynamic_cast<ISystemHandler*>(impl->getCapabilityHandler("System"));
 }
 
 IMicHandler* NuguClient::getMicHandler()
 {
-    return dynamic_cast<IMicHandler*>(impl->getCapabilityHandler(CapabilityType::Mic));
+    return dynamic_cast<IMicHandler*>(impl->getCapabilityHandler("Mic"));
 }
 
 INetworkManager* NuguClient::getNetworkManager()

--- a/clientkit/nugu_client_impl.hh
+++ b/clientkit/nugu_client_impl.hh
@@ -40,12 +40,12 @@ public:
     void setConfig(NuguConfig::Key key, const std::string& value);
     void setListener(INuguClientListener* listener);
     INuguClientListener* getListener();
-    void registerCapability(const CapabilityType ctype, std::pair<ICapabilityInterface*, ICapabilityListener*> capability);
+    void registerCapability(const std::string& cname, std::pair<ICapabilityInterface*, ICapabilityListener*> capability);
     int create(void);
     bool initialize(void);
     void deInitialize(void);
 
-    ICapabilityInterface* getCapabilityHandler(const CapabilityType ctype);
+    ICapabilityInterface* getCapabilityHandler(const std::string& cname);
     IWakeupHandler* getWakeupHandler();
     INetworkManager* getNetworkManager();
     IMediaPlayer* createMediaPlayer();
@@ -56,7 +56,9 @@ public:
 private:
     int createCapabilities(void);
 
-    std::map<CapabilityType, std::pair<ICapabilityInterface*, ICapabilityListener*>> icapability_map;
+    using CapabilityMap = std::map<std::string, std::pair<ICapabilityInterface*, ICapabilityListener*>>;
+
+    CapabilityMap icapability_map;
     INuguClientListener* listener = nullptr;
     IWakeupHandler* wakeup_handler = nullptr;
     std::unique_ptr<INetworkManager> network_manager = nullptr;

--- a/core/capability/asr_agent.cc
+++ b/core/capability/asr_agent.cc
@@ -25,7 +25,8 @@
 
 namespace NuguCore {
 
-static const char* capability_version = "1.0";
+static const char* CAPABILITY_NAME = "ASR";
+static const char* CAPABILITY_VERSION = "1.0";
 
 class ASRFocusListener : public IFocusListener {
 public:
@@ -135,7 +136,7 @@ NuguFocusStealResult ExpectFocusListener::onStealRequest(void* event, NuguFocusT
 }
 
 ASRAgent::ASRAgent()
-    : Capability(CapabilityType::ASR, capability_version)
+    : Capability(CAPABILITY_NAME, CAPABILITY_VERSION)
     , es_attr({})
     , rec_event(nullptr)
     , timer(nullptr)
@@ -231,17 +232,19 @@ void ASRAgent::saveAllContextInfo()
     all_context_info = CapabilityManager::getInstance()->makeAllContextInfoStack();
 }
 
-void ASRAgent::receiveCommand(CapabilityType from, std::string command, const std::string& param)
+void ASRAgent::receiveCommand(const std::string& from, const std::string& command, const std::string& param)
 {
-    std::transform(command.begin(), command.end(), command.begin(), ::tolower);
+    std::string convert_command;
+    convert_command.resize(command.size());
+    std::transform(command.cbegin(), command.cend(), convert_command.begin(), ::tolower);
 
-    if (!command.compare("wakeup_detected")) {
+    if (!convert_command.compare("wakeup_detected")) {
         if (es_attr.is_handle) {
             CapabilityManager::getInstance()->releaseFocus("expect");
             es_attr = {};
         }
-    } else if (!command.compare("releasefocus")) {
-        if (from == CapabilityType::System) {
+    } else if (!convert_command.compare("releasefocus")) {
+        if (from == "System") {
             if (dialog_id == param)
                 CapabilityManager::getInstance()->releaseFocus("asr");
         } else {

--- a/core/capability/asr_agent.hh
+++ b/core/capability/asr_agent.hh
@@ -56,7 +56,7 @@ public:
     void updateInfoForContext(Json::Value& ctx) override;
     void saveAllContextInfo();
 
-    void receiveCommand(CapabilityType from, std::string command, const std::string& param) override;
+    void receiveCommand(const std::string& from, const std::string& command, const std::string& param) override;
     void getProperty(const std::string& property, std::string& value) override;
     void getProperties(const std::string& property, std::list<std::string>& values) override;
 

--- a/core/capability/audio_player_agent.hh
+++ b/core/capability/audio_player_agent.hh
@@ -51,7 +51,7 @@ public:
 
     void parsingDirective(const char* dname, const char* message) override;
     void updateInfoForContext(Json::Value& ctx) override;
-    void receiveCommand(CapabilityType from, std::string command, const std::string& param) override;
+    void receiveCommand(const std::string& from, const std::string& command, const std::string& param) override;
     void setCapabilityListener(ICapabilityListener* clistener) override;
 
     void addListener(IAudioPlayerListener* listener) override;

--- a/core/capability/capability.cc
+++ b/core/capability/capability.cc
@@ -45,14 +45,13 @@ CapabilityEvent::~CapabilityEvent()
 
 bool CapabilityEvent::isUserAction(const std::string& name)
 {
-    CapabilityType type = capability->getType();
+    const std::string& cname = capability->getName();
 
-    if ((type == CapabilityType::ASR && name == "Recognize")
-        || (type == CapabilityType::TTS && name == "SpeechPlay")
-        || (type == CapabilityType::AudioPlayer
-               && (name.find("CommandIssued") != std::string::npos))
-        || (type == CapabilityType::Text && name == "TextInput")
-        || (type == CapabilityType::Display && name == "ElementSelected"))
+    if ((cname == "ASR" && name == "Recognize")
+        || (cname == "TTS" && name == "SpeechPlay")
+        || (cname == "AudioPlayer" && (name.find("CommandIssued") != std::string::npos))
+        || (cname == "Text" && name == "TextInput")
+        || (cname == "Display" && name == "ElementSelected"))
         return true;
     else
         return false;
@@ -87,7 +86,7 @@ void CapabilityEvent::sendEvent(const std::string& context, const std::string& p
         nugu_event_set_referrer_id(event, ref_dialog_id.c_str());
 
     CapabilityManager* cap_manager = CapabilityManager::getInstance();
-    cap_manager->sendCommand(capability->getType(), CapabilityType::System, "activity", "");
+    cap_manager->sendCommand(capability->getName(), "System", "activity", "");
 
     nugu_network_manager_send_event(event);
     // dialog_request_id is made every time to send event
@@ -105,9 +104,8 @@ void CapabilityEvent::sendAttachmentEvent(bool is_end, size_t size, unsigned cha
         nugu_network_manager_send_event_data(event, is_end, size, data);
 }
 
-Capability::Capability(CapabilityType type, const std::string& ver)
-    : ctype(type)
-    , cname(CAPABILITY_TYPE_MAP.at(type))
+Capability::Capability(const std::string& name, const std::string& ver)
+    : cname(name)
     , version(ver)
     , ref_dialog_id("")
     , cur_ndir(NULL)
@@ -135,24 +133,14 @@ void Capability::setReferrerDialogRequestId(const std::string& id)
     ref_dialog_id = id;
 }
 
-void Capability::setName(CapabilityType type)
+void Capability::setName(const std::string& name)
 {
-    cname = getTypeName(type);
+    cname = name;
 }
 
 std::string Capability::getName()
 {
     return cname;
-}
-
-CapabilityType Capability::getType()
-{
-    return ctype;
-}
-
-std::string Capability::getTypeName(CapabilityType type)
-{
-    return CAPABILITY_TYPE_MAP.at(type);
 }
 
 void Capability::setVersion(const std::string& ver)
@@ -269,11 +257,11 @@ void Capability::setCapabilityListener(ICapabilityListener* clistener)
 {
 }
 
-void Capability::receiveCommand(CapabilityType from, std::string command, const std::string& param)
+void Capability::receiveCommand(const std::string& from, const std::string& command, const std::string& param)
 {
 }
 
-void Capability::receiveCommandAll(std::string command, const std::string& param)
+void Capability::receiveCommandAll(const std::string& command, const std::string& param)
 {
 }
 

--- a/core/capability/capability.hh
+++ b/core/capability/capability.hh
@@ -53,15 +53,13 @@ private:
 
 class Capability : virtual public ICapabilityInterface {
 public:
-    Capability(CapabilityType type, const std::string& ver = "1.0");
+    Capability(const std::string& name, const std::string& ver = "1.0");
     virtual ~Capability();
     virtual void initialize();
 
     std::string getReferrerDialogRequestId();
     void setReferrerDialogRequestId(const std::string& id);
-    std::string getTypeName(CapabilityType type) override;
-    CapabilityType getType() override;
-    void setName(CapabilityType type);
+    void setName(const std::string& name);
     std::string getName() override;
     void setVersion(const std::string& ver);
     std::string getVersion() override;
@@ -79,8 +77,8 @@ public:
     void getProperty(const std::string& property, std::string& value) override;
     void getProperties(const std::string& property, std::list<std::string>& values) override;
     void setCapabilityListener(ICapabilityListener* clistener) override;
-    void receiveCommand(CapabilityType from, std::string command, const std::string& param) override;
-    void receiveCommandAll(std::string command, const std::string& param) override;
+    void receiveCommand(const std::string& from, const std::string& command, const std::string& param) override;
+    void receiveCommandAll(const std::string& command, const std::string& param) override;
     virtual void parsingDirective(const char* dname, const char* message);
     virtual std::string getContextInfo();
 
@@ -95,7 +93,6 @@ protected:
     PlaySyncManager* playsync_manager = nullptr;
 
 private:
-    CapabilityType ctype;
     std::string cname;
     std::string version;
     std::string ref_dialog_id;

--- a/core/capability/delegation_agent.cc
+++ b/core/capability/delegation_agent.cc
@@ -23,10 +23,11 @@
 
 namespace NuguCore {
 
-static const char* capability_version = "1.0";
+static const char* CAPABILITY_NAME = "Delegation";
+static const char* CAPABILITY_VERSION = "1.0";
 
 DelegationAgent::DelegationAgent()
-    : Capability(CapabilityType::Delegation, capability_version)
+    : Capability(CAPABILITY_NAME, CAPABILITY_VERSION)
 {
 }
 

--- a/core/capability/display_agent.cc
+++ b/core/capability/display_agent.cc
@@ -21,10 +21,11 @@
 
 namespace NuguCore {
 
-static const char* capability_version = "1.0";
+static const char* CAPABILITY_NAME = "Display";
+static const char* CAPABILITY_VERSION = "1.0";
 
 DisplayAgent::DisplayAgent()
-    : Capability(CapabilityType::Display, capability_version)
+    : Capability(CAPABILITY_NAME, CAPABILITY_VERSION)
 {
 }
 
@@ -61,13 +62,13 @@ void DisplayAgent::parsingDirective(const char* dname, const char* message)
 
         // sync display rendering with context
         PlaySyncManager::DisplayRenderer renderer;
-        renderer.cap_type = getType();
+        renderer.cap_name = getName();
         renderer.listener = this;
         renderer.only_rendering = true;
         renderer.duration = root["duration"].asString();
         renderer.display_id = id;
 
-        playsync_manager->addContext(playstackctl_ps_id, getType(), std::move(renderer));
+        playsync_manager->addContext(playstackctl_ps_id, getName(), std::move(renderer));
     }
 }
 

--- a/core/capability/extension_agent.cc
+++ b/core/capability/extension_agent.cc
@@ -23,10 +23,11 @@
 
 namespace NuguCore {
 
-static const char* capability_version = "1.1";
+static const char* CAPABILITY_NAME = "Extension";
+static const char* CAPABILITY_VERSION = "1.1";
 
 ExtensionAgent::ExtensionAgent()
-    : Capability(CapabilityType::Extension, capability_version)
+    : Capability(CAPABILITY_NAME, CAPABILITY_VERSION)
     , extension_listener(nullptr)
     , ps_id("")
 {

--- a/core/capability/location_agent.cc
+++ b/core/capability/location_agent.cc
@@ -20,10 +20,11 @@
 
 namespace NuguCore {
 
-static const char* capability_version = "1.0";
+static const char* CAPABILITY_NAME = "Location";
+static const char* CAPABILITY_VERSION = "1.0";
 
 LocationAgent::LocationAgent()
-    : Capability(CapabilityType::Location, capability_version)
+    : Capability(CAPABILITY_NAME, CAPABILITY_VERSION)
 {
 }
 

--- a/core/capability/mic_agent.cc
+++ b/core/capability/mic_agent.cc
@@ -24,10 +24,11 @@
 
 namespace NuguCore {
 
-static const char* capability_version = "1.0";
+static const char* CAPABILITY_NAME = "Mic";
+static const char* CAPABILITY_VERSION = "1.0";
 
 MicAgent::MicAgent()
-    : Capability(CapabilityType::Mic, capability_version)
+    : Capability(CAPABILITY_NAME, CAPABILITY_VERSION)
     , mic_listener(nullptr)
     , cur_status(MicStatus::ON)
     , pre_status(MicStatus::ON)

--- a/core/capability/system_agent.cc
+++ b/core/capability/system_agent.cc
@@ -28,10 +28,11 @@
 
 namespace NuguCore {
 
-static const char* capability_version = "1.1";
+static const char* CAPABILITY_NAME = "System";
+static const char* CAPABILITY_VERSION = "1.1";
 
 SystemAgent::SystemAgent()
-    : Capability(CapabilityType::System, capability_version)
+    : Capability(CAPABILITY_NAME, CAPABILITY_VERSION)
     , system_listener(nullptr)
     , timer(nullptr)
 {
@@ -122,11 +123,13 @@ void SystemAgent::setCapabilityListener(ICapabilityListener* clistener)
         system_listener = dynamic_cast<ISystemListener*>(clistener);
 }
 
-void SystemAgent::receiveCommand(CapabilityType from, std::string command, const std::string& param)
+void SystemAgent::receiveCommand(const std::string& from, const std::string& command, const std::string& param)
 {
-    std::transform(command.begin(), command.end(), command.begin(), ::tolower);
+    std::string convert_command;
+    convert_command.resize(command.size());
+    std::transform(command.cbegin(), command.cend(), convert_command.begin(), ::tolower);
 
-    if (!command.compare("activity")) {
+    if (!convert_command.compare("activity")) {
         nugu_dbg("update timer");
         if (timer)
             nugu_timer_start(timer);
@@ -356,7 +359,7 @@ void SystemAgent::parsingNoDirectives(const char* message)
     }
 
     dialog_id = nugu_directive_peek_dialog_id(getNuguDirective());
-    CapabilityManager::getInstance()->sendCommand(CapabilityType::System, CapabilityType::ASR, "releasefocus", dialog_id);
+    CapabilityManager::getInstance()->sendCommand("System", "ASR", "releasefocus", dialog_id);
 }
 
 void SystemAgent::parsingRevoke(const char* message)

--- a/core/capability/system_agent.hh
+++ b/core/capability/system_agent.hh
@@ -35,7 +35,7 @@ public:
     void updateInfoForContext(Json::Value& ctx) override;
     void setCapabilityListener(ICapabilityListener* clistener) override;
 
-    void receiveCommand(CapabilityType from, std::string command, const std::string& param) override;
+    void receiveCommand(const std::string& from, const std::string& command, const std::string& param) override;
 
     void synchronizeState(void) override;
     void disconnect(void) override;

--- a/core/capability/text_agent.cc
+++ b/core/capability/text_agent.cc
@@ -24,10 +24,11 @@
 
 namespace NuguCore {
 
-static const char* capability_version = "1.0";
+static const char* CAPABILITY_NAME = "Text";
+static const char* CAPABILITY_VERSION = "1.0";
 
 TextAgent::TextAgent()
-    : Capability(CapabilityType::Text, capability_version)
+    : Capability(CAPABILITY_NAME, CAPABILITY_VERSION)
     , text_listener(nullptr)
     , timer(nullptr)
     , cur_state(TextState::IDLE)
@@ -84,11 +85,13 @@ void TextAgent::updateInfoForContext(Json::Value& ctx)
     ctx[getName()] = text;
 }
 
-void TextAgent::receiveCommandAll(std::string command, const std::string& param)
+void TextAgent::receiveCommandAll(const std::string& command, const std::string& param)
 {
-    std::transform(command.begin(), command.end(), command.begin(), ::tolower);
+    std::string convert_command;
+    convert_command.resize(command.size());
+    std::transform(command.cbegin(), command.cend(), convert_command.begin(), ::tolower);
 
-    if (command == "directive_dialog_id" && param == cur_dialog_id) {
+    if (convert_command == "directive_dialog_id" && param == cur_dialog_id) {
         nugu_dbg("process receive command => directive_dialog_id(%s)", param.c_str());
 
         nugu_timer_stop(timer);
@@ -145,10 +148,10 @@ void TextAgent::sendEventTextInput(const std::string& text, const std::string& t
     std::list<std::string> domainTypes;
 
     CapabilityManager* cmanager = CapabilityManager::getInstance();
-    cmanager->getCapabilityProperty(CapabilityType::ASR, "es.playServiceId", ps_id);
-    cmanager->getCapabilityProperty(CapabilityType::ASR, "es.property", property);
-    cmanager->getCapabilityProperty(CapabilityType::ASR, "es.sessionId", session_id);
-    cmanager->getCapabilityProperties(CapabilityType::ASR, "es.domainTypes", domainTypes);
+    cmanager->getCapabilityProperty("ASR", "es.playServiceId", ps_id);
+    cmanager->getCapabilityProperty("ASR", "es.property", property);
+    cmanager->getCapabilityProperty("ASR", "es.sessionId", session_id);
+    cmanager->getCapabilityProperties("ASR", "es.domainTypes", domainTypes);
 
     root["text"] = text;
     if (token.size())

--- a/core/capability/text_agent.hh
+++ b/core/capability/text_agent.hh
@@ -34,7 +34,7 @@ public:
 
     void parsingDirective(const char* dname, const char* message) override;
     void updateInfoForContext(Json::Value& ctx) override;
-    void receiveCommandAll(std::string command, const std::string& param) override;
+    void receiveCommandAll(const std::string& command, const std::string& param) override;
     void setCapabilityListener(ICapabilityListener* clistener) override;
 
     bool requestTextInput(std::string text) override;

--- a/core/capability/tts_agent.cc
+++ b/core/capability/tts_agent.cc
@@ -24,10 +24,11 @@
 
 namespace NuguCore {
 
-static const char* capability_version = "1.0";
+static const char* CAPABILITY_NAME = "TTS";
+static const char* CAPABILITY_VERSION = "1.0";
 
 TTSAgent::TTSAgent()
-    : Capability(CapabilityType::TTS, capability_version)
+    : Capability(CAPABILITY_NAME, CAPABILITY_VERSION)
     , cur_token("")
     , speak_status(-1)
     , finish(false)
@@ -84,7 +85,7 @@ void TTSAgent::initialize()
     nugu_pcm_set_status_callback(pcm, pcmStatusCallback, this);
     nugu_pcm_set_event_callback(pcm, pcmEventCallback, this);
 
-    nugu_pcm_set_property(pcm, (NuguAudioProperty){ AUDIO_SAMPLE_RATE_22K, AUDIO_FORMAT_S16_LE, 1 });
+    nugu_pcm_set_property(pcm, (NuguAudioProperty) { AUDIO_SAMPLE_RATE_22K, AUDIO_FORMAT_S16_LE, 1 });
 
     CapabilityManager::getInstance()->addFocus("cap_tts", NUGU_FOCUS_TYPE_TTS, this);
 
@@ -185,7 +186,7 @@ NuguFocusResult TTSAgent::onUnfocus(void* event)
 
     nugu_pcm_stop(pcm);
 
-    playsync_manager->removeContext(playstackctl_ps_id, getType(), !finish);
+    playsync_manager->removeContext(playstackctl_ps_id, getName(), !finish);
 
     if (tts_listener && cur_status != MEDIA_STATUS_STOPPED)
         tts_listener->onTTSCancel(dialog_id);
@@ -376,7 +377,7 @@ void TTSAgent::parsingSpeak(const char* message)
     playstackctl_ps_id = getPlayServiceIdInStackControl(root["playStackControl"]);
 
     if (!playstackctl_ps_id.empty()) {
-        playsync_manager->addContext(playstackctl_ps_id, getType());
+        playsync_manager->addContext(playstackctl_ps_id, getName());
     }
 
     startTTS(getNuguDirective());

--- a/core/capability_creator.cc
+++ b/core/capability_creator.cc
@@ -45,17 +45,17 @@ using CapabilityElement = CapabilityCreator::Element;
 
 const std::list<CapabilityElement>& CapabilityCreator::getCapabilityList()
 {
-    static std::list<CapabilityElement> CAPABILITY_LIST{
-        CapabilityElement{ CapabilityType::ASR, true, &create<ASRAgent> },
-        CapabilityElement{ CapabilityType::TTS, true, &create<TTSAgent> },
-        CapabilityElement{ CapabilityType::AudioPlayer, true, &create<AudioPlayerAgent> },
-        CapabilityElement{ CapabilityType::System, true, &create<SystemAgent> },
-        CapabilityElement{ CapabilityType::Display, false, &create<DisplayAgent> },
-        CapabilityElement{ CapabilityType::Extension, false, &create<ExtensionAgent> },
-        CapabilityElement{ CapabilityType::Text, false, &create<TextAgent> },
-        CapabilityElement{ CapabilityType::Delegation, false, &create<DelegationAgent> },
-        CapabilityElement{ CapabilityType::Location, false, &create<LocationAgent> },
-        CapabilityElement{ CapabilityType::Mic, false, &create<MicAgent> }
+    static std::list<CapabilityElement> CAPABILITY_LIST {
+        CapabilityElement { "ASR", true, &create<ASRAgent> },
+        CapabilityElement { "TTS", true, &create<TTSAgent> },
+        CapabilityElement { "AudioPlayer", true, &create<AudioPlayerAgent> },
+        CapabilityElement { "System", true, &create<SystemAgent> },
+        CapabilityElement { "Display", false, &create<DisplayAgent> },
+        CapabilityElement { "Extension", false, &create<ExtensionAgent> },
+        CapabilityElement { "Text", false, &create<TextAgent> },
+        CapabilityElement { "Delegation", false, &create<DelegationAgent> },
+        CapabilityElement { "Location", false, &create<LocationAgent> },
+        CapabilityElement { "Mic", false, &create<MicAgent> }
     };
 
     return CAPABILITY_LIST;

--- a/core/capability_creator.hh
+++ b/core/capability_creator.hh
@@ -36,7 +36,7 @@ public:
     static INetworkManager* createNetworkManager();
 
     struct Element {
-        CapabilityType type;
+        std::string name;
         bool is_default;
         std::function<ICapabilityInterface*()> creator;
     };

--- a/core/capability_manager.cc
+++ b/core/capability_manager.cc
@@ -212,31 +212,31 @@ void CapabilityManager::sendCommandAll(const std::string& command, const std::st
     }
 }
 
-void CapabilityManager::sendCommand(CapabilityType from, CapabilityType to,
+void CapabilityManager::sendCommand(const std::string& from, const std::string& to,
     const std::string& command, const std::string& param)
 {
     for (auto iter : caps) {
-        if (iter.second->getType() == to) {
+        if (iter.second->getName() == to) {
             iter.second->receiveCommand(from, command, param);
             break;
         }
     }
 }
 
-void CapabilityManager::getCapabilityProperty(CapabilityType cap, const std::string& property, std::string& value)
+void CapabilityManager::getCapabilityProperty(const std::string& cap, const std::string& property, std::string& value)
 {
     for (auto iter : caps) {
-        if (iter.second->getType() == cap) {
+        if (iter.second->getName() == cap) {
             iter.second->getProperty(property, value);
             break;
         }
     }
 }
 
-void CapabilityManager::getCapabilityProperties(CapabilityType cap, const std::string& property, std::list<std::string>& values)
+void CapabilityManager::getCapabilityProperties(const std::string& cap, const std::string& property, std::list<std::string>& values)
 {
     for (auto iter : caps) {
-        if (iter.second->getType() == cap) {
+        if (iter.second->getName() == cap) {
             iter.second->getProperties(property, values);
             break;
         }

--- a/core/capability_manager.hh
+++ b/core/capability_manager.hh
@@ -60,10 +60,10 @@ public:
     void preprocessDirective(NuguDirective* ndir);
     bool isSupportDirectiveVersion(const std::string& version, ICapabilityInterface* cap);
 
-    void sendCommand(CapabilityType from, CapabilityType to, const std::string& command, const std::string& param);
+    void sendCommand(const std::string& from, const std::string& to, const std::string& command, const std::string& param);
     void sendCommandAll(const std::string& command, const std::string& param);
-    void getCapabilityProperty(CapabilityType cap, const std::string& property, std::string& value);
-    void getCapabilityProperties(CapabilityType cap, const std::string& property, std::list<std::string>& values);
+    void getCapabilityProperty(const std::string& cap, const std::string& property, std::string& value);
+    void getCapabilityProperties(const std::string& cap, const std::string& property, std::list<std::string>& values);
 
     bool isFocusOn(NuguFocusType type);
     int addFocus(const std::string& fname, NuguFocusType type, IFocusListener* listener);

--- a/core/display_render_assembly.hpp
+++ b/core/display_render_assembly.hpp
@@ -58,7 +58,7 @@ std::string DisplayRenderAssembly<T>::composeRenderInfo(const RenderInfoParam& p
 template <typename T>
 void DisplayRenderAssembly<T>::displayRendered(const std::string& id)
 {
-    if (static_cast<T*>(this)->getType() == CapabilityType::Display) {
+    if (static_cast<T*>(this)->getName() == "Display") {
         if (render_info.find(id) != render_info.end()) {
             disp_cur_token = render_info[id]->token;
             disp_cur_ps_id = render_info[id]->ps_id;
@@ -88,7 +88,7 @@ void DisplayRenderAssembly<T>::elementSelected(const std::string& id, const std:
 {
     auto derived = static_cast<T*>(this);
 
-    if (derived->getType() == CapabilityType::Display) {
+    if (derived->getName() == "Display") {
         if (render_info.find(id) == render_info.end()) {
             nugu_warn("SDK doesn't know or manage the template(%s)", id.c_str());
             return;

--- a/core/playsync_manager.hh
+++ b/core/playsync_manager.hh
@@ -48,7 +48,7 @@ public:
     };
     using DisplayRenderer = struct {
         IPlaySyncManagerListener* listener;
-        CapabilityType cap_type;
+        std::string cap_name;
         std::string duration;
         std::string display_id;
         bool only_rendering = false;
@@ -58,21 +58,23 @@ public:
     PlaySyncManager();
     virtual ~PlaySyncManager();
 
-    void addContext(const std::string& ps_id, CapabilityType cap_type);
-    void addContext(const std::string& ps_id, CapabilityType cap_type, DisplayRenderer&& renderer);
-    void removeContext(const std::string& ps_id, CapabilityType cap_type, bool immediately = true);
+    void addContext(const std::string& ps_id, const std::string& cap_name);
+    void addContext(const std::string& ps_id, const std::string& cap_name, DisplayRenderer&& renderer);
+    void removeContext(const std::string& ps_id, const std::string& cap_name, bool immediately = true);
     void clearPendingContext(const std::string& ps_id);
     std::vector<std::string> getAllPlayStackItems();
-    std::string getPlayStackItem(CapabilityType cap_type);
+    std::string getPlayStackItem(const std::string& cap_name);
 
     void setExpectSpeech(bool expect_speech);
     void onMicOn();
     void clearContextHold();
     void onASRError();
 
+    using ContextMap = std::map<std::string, std::vector<std::string>>;
+
 private:
-    void addStackElement(const std::string& ps_id, CapabilityType cap_type);
-    bool removeStackElement(const std::string& ps_id, CapabilityType cap_type);
+    void addStackElement(const std::string& ps_id, const std::string& cap_name);
+    bool removeStackElement(const std::string& ps_id, const std::string& cap_name);
     void addRenderer(const std::string& ps_id, DisplayRenderer& renderer);
     bool removeRenderer(const std::string& ps_id, bool unconditionally = true);
     void setTimerInterval(const std::string& ps_id);
@@ -89,8 +91,8 @@ private:
         std::function<void()> callback; // temp : for holding function for stack log
     };
 
+    ContextMap context_map;
     std::vector<std::string> context_stack;
-    std::map<std::string, std::vector<CapabilityType>> context_map;
     std::map<std::string, DisplayRenderer> renderer_map;
 
     NuguTimer* timer = nullptr;

--- a/core/wakeup_handler.cc
+++ b/core/wakeup_handler.cc
@@ -65,7 +65,7 @@ void WakeupHandler::onWakeupState(WakeupState state)
     case WakeupState::DETECTED:
         nugu_dbg("WakeupState::DETECTED");
 
-        CapabilityManager::getInstance()->sendCommand(CapabilityType::ASR, CapabilityType::ASR, "wakeup_detected", "");
+        CapabilityManager::getInstance()->sendCommand("ASR", "ASR", "wakeup_detected", "");
 
         if (listener)
             listener->onWakeupState(WakeupDetectState::WAKEUP_DETECTED);

--- a/examples/standalone/nugu_sample.cc
+++ b/examples/standalone/nugu_sample.cc
@@ -124,16 +124,16 @@ void registerCapabilities()
 
     // create capability instance. It's possible to set user customized capability using below builder
     nugu_client->getCapabilityBuilder()
-        ->add(CapabilityType::ASR, speech_operator->getASRListener())
-        ->add(CapabilityType::TTS, tts_listener.get())
-        ->add(CapabilityType::AudioPlayer, aplayer_listener.get())
-        ->add(CapabilityType::System, system_listener.get())
-        ->add(CapabilityType::Display, display_listener.get())
-        ->add(CapabilityType::Text, text_listener.get())
-        ->add(CapabilityType::Extension, extension_listener.get())
-        ->add(CapabilityType::Delegation, delegation_listener.get())
-        ->add(CapabilityType::Location, location_listener.get())
-        ->add(CapabilityType::Mic, mic_listener.get())
+        ->add("ASR", speech_operator->getASRListener())
+        ->add("TTS", tts_listener.get())
+        ->add("AudioPlayer", aplayer_listener.get())
+        ->add("System", system_listener.get())
+        ->add("Display", display_listener.get())
+        ->add("Text", text_listener.get())
+        ->add("Extension", extension_listener.get())
+        ->add("Delegation", delegation_listener.get())
+        ->add("Location", location_listener.get())
+        ->add("Mic", mic_listener.get())
         ->construct();
 }
 
@@ -187,7 +187,7 @@ int main(int argc, char** argv)
 
         nugu_sample_manager->setTextHandler(nugu_client->getTextHandler())
             ->setSpeechOperator(speech_operator.get())
-            ->setNetworkCallback(NuguSampleManager::NetworkCallback{
+            ->setNetworkCallback(NuguSampleManager::NetworkCallback {
                 [&]() { return network_manager->connect(); },
                 [&]() { return network_manager->disconnect(); } })
             ->setMicHandler(nugu_client->getMicHandler())

--- a/include/clientkit/nugu_client.hh
+++ b/include/clientkit/nugu_client.hh
@@ -71,12 +71,12 @@ public:
 
         /**
          * @brief Add capabilities to create in the capabilitybuilder. Capabilitybuilder support to insert customized capability agents.
-         * @param[in] ctype access token
+         * @param[in] capability agent name
          * @param[in] clistener capability listener
          * @param[in] cap_instance capability interface
          * @return CapabilityBuilder object
          */
-        CapabilityBuilder* add(const CapabilityType ctype,
+        CapabilityBuilder* add(const std::string& cname,
             ICapabilityListener* clistener = nullptr,
             ICapabilityInterface* cap_instance = nullptr);
 

--- a/include/interface/capability/capability_interface.hh
+++ b/include/interface/capability/capability_interface.hh
@@ -38,35 +38,6 @@ namespace NuguInterface {
  */
 
 /**
- * @brief CapabilityType
- */
-enum class CapabilityType {
-    AudioPlayer, /**< the type of AudioPlayer agent */
-    Display, /**< the type of Display agent */
-    System, /**< the type of System agent */
-    TTS, /**< the type of TTS agent */
-    ASR, /**< the type of ASR agent */
-    Text, /**< the type of Text agent */
-    Extension, /**< the type of Extension agent */
-    Delegation, /**< the type of Delegation agent */
-    Location, /**< the type of Location agent */
-    Mic /**< the type of Mic agent */
-};
-
-static const std::map<CapabilityType, std::string> CAPABILITY_TYPE_MAP {
-    { CapabilityType::AudioPlayer, "AudioPlayer" },
-    { CapabilityType::Display, "Display" },
-    { CapabilityType::System, "System" },
-    { CapabilityType::TTS, "TTS" },
-    { CapabilityType::ASR, "ASR" },
-    { CapabilityType::Text, "Text" },
-    { CapabilityType::Extension, "Extension" },
-    { CapabilityType::Delegation, "Delegation" },
-    { CapabilityType::Location, "Location" },
-    { CapabilityType::Mic, "Mic" }
-};
-
-/**
  * @brief capability listener interface
  * @see ICapabilityHandler
  */
@@ -118,19 +89,6 @@ public:
     virtual void initialize() = 0;
 
     /**
-     * @brief Get the capability type name of the current object.
-     * @param[in] type capability type
-     * @return capability type name
-     */
-    virtual std::string getTypeName(CapabilityType type) = 0;
-
-    /**
-     * @brief Get the capability type of the current object.
-     * @return capability type of the object
-     */
-    virtual CapabilityType getType() = 0;
-
-    /**
      * @brief Get the capability name of the current object.
      * @return capability name of the object
      */
@@ -160,14 +118,14 @@ public:
      * @param[in] command command
      * @param[in] param command parameter
      */
-    virtual void receiveCommand(CapabilityType from, std::string command, const std::string& param) = 0;
+    virtual void receiveCommand(const std::string& from, const std::string& command, const std::string& param) = 0;
 
     /**
      * @brief Processes command received from capability manager.
      * @param[in] command command
      * @param[in] param command parameter
      */
-    virtual void receiveCommandAll(std::string command, const std::string& param) = 0;
+    virtual void receiveCommandAll(const std::string& command, const std::string& param) = 0;
 
     /**
      * @brief It is possible to share own property value among objects.


### PR DESCRIPTION
It remove CapabilityType enum for improving expansibility
of CapabilityAgents. Instead, it recognize each CapabilityAgent
by string.

Be careful. Each Capability Name is case sensitive, so you have
to write spelling correctly as being defined in NDI.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>