### PR TITLE
build: fix warnings on clang-tidy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,9 @@ SET(prefix ${CMAKE_INSTALL_PREFIX})
 SET(bindir "${prefix}/${CMAKE_INSTALL_BINDIR}")
 SET(plugindir "${CMAKE_INSTALL_FULL_LIBDIR}/nugu")
 
+# Generate compile_commands.json
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # C++ standard: c++11 (not gnu++11)
 SET(CMAKE_CXX_STANDARD 11)
 SET(CMAKE_CXX_EXTENSIONS OFF)
@@ -52,9 +55,6 @@ ADD_COMPILE_OPTIONS(
 	# Improved version of “-fstack-protector” since gcc 4.9
 	-fstack-protector-strong
 
-	# Non-executable stack
-	-Wa,--execstack
-
 	# Store the stack frame pointer in a register.
 	-fno-omit-frame-pointer
 
@@ -86,8 +86,12 @@ IF (NOT PACKAGING)
 ENDIF()
 
 IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-	# Eliminate unused code and data (with --gc-sections link option)
-	ADD_COMPILE_OPTIONS(-Wl,--gc-sections)
+	ADD_COMPILE_OPTIONS(
+		# Non-executable stack
+		-Wa,--execstack
+
+		# Eliminate unused code and data (with --gc-sections link option)
+		-Wl,--gc-sections)
 
 	IF (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 		# Link only needed libraries

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,8 +12,7 @@ ADD_LIBRARY(objhttp2 OBJECT
 	network/dg_server.c)
 TARGET_INCLUDE_DIRECTORIES(objhttp2 PRIVATE
 	network
-	${CMAKE_BINARY_DIR}/nghttp2/include
-	${CMAKE_BINARY_DIR}/curl/include)
+	${CMAKE_SOURCE_DIR}/externals/curl/include)
 ADD_DEPENDENCIES(objhttp2 CURL)
 
 # NUGU Base
@@ -21,7 +20,7 @@ FILE(GLOB SRCS *.c)
 
 ADD_LIBRARY(objbase OBJECT ${SRCS})
 TARGET_INCLUDE_DIRECTORIES(objbase PRIVATE
-	${CMAKE_BINARY_DIR}/curl/include)
+	${CMAKE_SOURCE_DIR}/externals/curl/include)
 TARGET_COMPILE_DEFINITIONS(objbase PRIVATE
 	# Only symbols that use EXPORT_API are visible, and all other symbols are hidden.
 	-DEXPORT_API=__attribute__\(\(visibility\(\"default\"\)\)\)


### PR DESCRIPTION
Fix build scripts to remove warnings on clang-tidy.

Signed-off-by: Inho Oh <inho.oh@sk.com>