### PR TITLE
remove each capability handler getter

### DIFF
--- a/include/clientkit/nugu_client.hh
+++ b/include/clientkit/nugu_client.hh
@@ -20,16 +20,7 @@
 #include <memory>
 #include <string>
 
-#include <interface/capability/asr_interface.hh>
-#include <interface/capability/audio_player_interface.hh>
 #include <interface/capability/capability_interface.hh>
-#include <interface/capability/delegation_interface.hh>
-#include <interface/capability/display_interface.hh>
-#include <interface/capability/extension_interface.hh>
-#include <interface/capability/mic_interface.hh>
-#include <interface/capability/system_interface.hh>
-#include <interface/capability/text_interface.hh>
-#include <interface/capability/tts_interface.hh>
 #include <interface/media_player_interface.hh>
 #include <interface/network_manager_interface.hh>
 #include <interface/nugu_configuration.hh>
@@ -129,64 +120,16 @@ public:
     IWakeupHandler* getWakeupHandler();
 
     /**
-     * @brief Get ASRHandler object
-     * @return IASRHandler if a feature agent has been created with the feature builder, otherwise NULL
+     * @brief Get CapabilityHandler object
+     * @return ICapabilityInterface if a feature agent has been created with the feature builder, otherwise NULL
      */
-    IASRHandler* getASRHandler();
-
-    /**
-     * @brief Get TTSHandler object
-     * @return ITTSHandler if a feature agent has been created with the feature builder, otherwise NULL
-     */
-    ITTSHandler* getTTSHandler();
-
-    /**
-     * @brief Get AudioPlayerHandler object
-     * @return IAudioPlayerHandler if a feature agent has been created with the feature builder, otherwise NULL
-     */
-    IAudioPlayerHandler* getAudioPlayerHandler();
-
-    /**
-     * @brief Get DisplayHandler object
-     * @return IDisplayHandler if a feature agent has been created with the feature builder, otherwise NULL
-     */
-    IDisplayHandler* getDisplayHandler();
-
-    /**
-     * @brief Get TextHandler object
-     * @return ITextHandler if a feature agent has been created with the feature builder, otherwise NULL
-     */
-    ITextHandler* getTextHandler();
-
-    /**
-     * @brief Get ExtensionHandler object
-     * @return IExtensionHandler if a feature agent has been created with the feature builder, otherwise NULL
-     */
-    IExtensionHandler* getExtensionHandler();
-
-    /**
-     * @brief Get DelegationHandler object
-     * @return IDelegationHandler if a feature agent has been created with the feature builder, otherwise NULL
-     */
-    IDelegationHandler* getDelegationHandler();
-
-    /**
-     * @brief Get SystemHandler object
-     * @return ISystemHandler if a feature agent has been created with the feature builder, otherwise NULL
-     */
-    ISystemHandler* getSystemHandler();
+    ICapabilityInterface* getCapabilityHandler(const std::string& cname);
 
     /**
      * @brief Get NetworkManager object
      * @return INetworkManager if a feature agent has been created with the feature builder, otherwise NULL
      */
     INetworkManager* getNetworkManager();
-
-    /**
-     * @brief Get MicHandler object
-     * @return IMicHandler if a feature agent has been created with the feature builder, otherwise NULL
-     */
-    IMicHandler* getMicHandler();
 
     /**
      * @brief Get new media player object

--- a/include/interface/capability/capability_observer.hh
+++ b/include/interface/capability/capability_observer.hh
@@ -34,9 +34,9 @@ namespace NuguInterface {
 /**
  * @brief CapabilitySignal
  */
-typedef enum {
+enum class CapabilitySignal {
     DIALOG_REQUEST_ID /**< Dialog request id generated when event is forwarded to server */
-} CapabilitySignal;
+};
 
 /**
  * @brief capability observer interface

--- a/src/clientkit/nugu_client.cc
+++ b/src/clientkit/nugu_client.cc
@@ -81,49 +81,9 @@ IWakeupHandler* NuguClient::getWakeupHandler()
     return impl->getWakeupHandler();
 }
 
-IASRHandler* NuguClient::getASRHandler()
+ICapabilityInterface* NuguClient::getCapabilityHandler(const std::string& cname)
 {
-    return dynamic_cast<IASRHandler*>(impl->getCapabilityHandler("ASR"));
-}
-
-ITTSHandler* NuguClient::getTTSHandler()
-{
-    return dynamic_cast<ITTSHandler*>(impl->getCapabilityHandler("TTS"));
-}
-
-IAudioPlayerHandler* NuguClient::getAudioPlayerHandler()
-{
-    return dynamic_cast<IAudioPlayerHandler*>(impl->getCapabilityHandler("AudioPlayer"));
-}
-
-IDisplayHandler* NuguClient::getDisplayHandler()
-{
-    return dynamic_cast<IDisplayHandler*>(impl->getCapabilityHandler("Display"));
-}
-
-ITextHandler* NuguClient::getTextHandler()
-{
-    return dynamic_cast<ITextHandler*>(impl->getCapabilityHandler("Text"));
-}
-
-IExtensionHandler* NuguClient::getExtensionHandler()
-{
-    return dynamic_cast<IExtensionHandler*>(impl->getCapabilityHandler("Extension"));
-}
-
-IDelegationHandler* NuguClient::getDelegationHandler()
-{
-    return dynamic_cast<IDelegationHandler*>(impl->getCapabilityHandler("Delegation"));
-}
-
-ISystemHandler* NuguClient::getSystemHandler()
-{
-    return dynamic_cast<ISystemHandler*>(impl->getCapabilityHandler("System"));
-}
-
-IMicHandler* NuguClient::getMicHandler()
-{
-    return dynamic_cast<IMicHandler*>(impl->getCapabilityHandler("Mic"));
+    return impl->getCapabilityHandler(cname);
 }
 
 INetworkManager* NuguClient::getNetworkManager()

--- a/src/core/capability/capability.cc
+++ b/src/core/capability/capability.cc
@@ -90,7 +90,7 @@ void CapabilityEvent::sendEvent(const std::string& context, const std::string& p
 
     nugu_network_manager_send_event(event);
     // dialog_request_id is made every time to send event
-    capability->notifyObservers(DIALOG_REQUEST_ID, (void*)dialog_id.c_str());
+    capability->notifyObservers(CapabilitySignal::DIALOG_REQUEST_ID, (void*)dialog_id.c_str());
 }
 
 void CapabilityEvent::sendAttachmentEvent(bool is_end, size_t size, unsigned char* data)


### PR DESCRIPTION
It remove each capability handler's getter from NuguClient
for removing depedency.

Instead, it's possible to get capability handler's instance
by calling getCapabilityHandler as argument to handler's instance.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>