### PR TITLE
Apply INuguCoreContainer to CapabilityAgent

### DIFF
--- a/include/capability/capability_interface.hh
+++ b/include/capability/capability_interface.hh
@@ -22,9 +22,12 @@
 
 #include <base/nugu_directive.h>
 #include <capability/capability_observer.hh>
+#include <clientkit/nugu_core_container_interface.hh>
 #include <json/json.h>
 
 namespace NuguCapability {
+
+using namespace NuguClientKit;
 
 /**
  * @file capability_interface.hh
@@ -82,6 +85,12 @@ public:
 class ICapabilityInterface : public ICapabilityObservable {
 public:
     virtual ~ICapabilityInterface() = default;
+
+    /**
+     * @brief Set INuguCoreContainer for using functions in NuguCore.
+     * @param[in] core_container NuguCoreContainer instance
+     */
+    virtual void setNuguCoreContainer(INuguCoreContainer* core_container) = 0;
 
     /**
      * @brief Initialize the current object.

--- a/include/clientkit/nugu_client.hh
+++ b/include/clientkit/nugu_client.hh
@@ -21,10 +21,8 @@
 #include <string>
 
 #include <capability/capability_interface.hh>
-#include <clientkit/media_player_interface.hh>
-#include <clientkit/network_manager_interface.hh>
 #include <clientkit/nugu_client_listener.hh>
-#include <clientkit/wakeup_interface.hh>
+#include <clientkit/nugu_core_container_interface.hh>
 
 namespace NuguClientKit {
 
@@ -103,11 +101,10 @@ public:
     void deInitialize(void);
 
     /**
-     * @brief Get WakeupHandler object
-     * @param[in] model_path path which model file is located
-     * @return IWakeupHandler if a feature agent has been created with the feature builder, otherwise NULL
+     * @brief Get NuguCoreContainer object
+     * @return INuguCoreContainer abstraction object of NuguCoreContainer
      */
-    IWakeupHandler* getWakeupHandler(const std::string& model_path = "");
+    INuguCoreContainer* getNuguCoreContainer();
 
     /**
      * @brief Get CapabilityHandler object
@@ -121,12 +118,6 @@ public:
      * @return INetworkManager if a feature agent has been created with the feature builder, otherwise NULL
      */
     INetworkManager* getNetworkManager();
-
-    /**
-     * @brief Get new media player object
-     * @return IMediaPlayer if media player is created, otherwise nullptr
-     */
-    IMediaPlayer* createMediaPlayer();
 
 private:
     std::unique_ptr<NuguClientImpl> impl;

--- a/include/clientkit/nugu_core_container_interface.hh
+++ b/include/clientkit/nugu_core_container_interface.hh
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NUGU_CORE_CONTAINER_INTERFACE_H__
+#define __NUGU_CORE_CONTAINER_INTERFACE_H__
+
+#include "clientkit/media_player_interface.hh"
+#include "clientkit/network_manager_interface.hh"
+#include "clientkit/speech_recognizer_interface.hh"
+#include "clientkit/wakeup_interface.hh"
+
+namespace NuguClientKit {
+
+/**
+ * @file nugu_core_container_interface.hh
+ * @defgroup NuguCoreContainerInterface NuguCoreContainerInterface
+ * @ingroup SDKNuguClientKit
+ * @brief NuguCoreContainer Interface
+ *
+ * Container which have components factory and methods for manipulating NuguCore
+ *
+ * @{
+ */
+
+/**
+ * @brief NuguCoreContainer interface
+ */
+class INuguCoreContainer {
+public:
+    virtual ~INuguCoreContainer() = default;
+
+    /**
+     * @brief Create WakeupHandler instance
+     * @param[in] model_path required model file path
+     */
+    virtual IWakeupHandler* createWakeupHandler(const std::string& model_path = "") = 0;
+
+    /**
+     * @brief Create SpeechRecognizer instance
+     * @param[in] model_path required model file path
+     */
+    virtual ISpeechRecognizer* createSpeechRecognizer(const std::string& model_path = "") = 0;
+
+    /**
+     * @brief Create MediaPlayer instance
+     */
+    virtual IMediaPlayer* createMediaPlayer() = 0;
+};
+
+/**
+ * @}
+ */
+
+} // NuguClientKit
+
+#endif /* __NUGU_CORE_CONTAINER_INTERFACE_H__ */

--- a/include/clientkit/speech_recognizer_interface.hh
+++ b/include/clientkit/speech_recognizer_interface.hh
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NUGU_SPEECH_RECOGNIZER_INTERFACE_H__
+#define __NUGU_SPEECH_RECOGNIZER_INTERFACE_H__
+
+#include <string>
+
+namespace NuguClientKit {
+
+/**
+ * @file speech_recognizer_interface.hh
+ * @defgroup SpeechRecognizerInterface SpeechRecognizerInterface
+ * @ingroup SDKNuguClientKit
+ * @brief Speech Recognizer Interface
+ *
+ * Start/Stop Speech Recognition and receive current listening state
+ *
+ * @{
+ */
+
+/**
+ * @brief ListeningState
+ */
+enum class ListeningState {
+    READY, /**< Ready to listen speech */
+    LISTENING, /**< Listeing speech */
+    SPEECH_START, /**< Detect speech start point */
+    SPEECH_END, /**< Detect speech end point */
+    TIMEOUT, /**< Listening timeout */
+    FAILED, /**< Listening failed */
+    DONE /**< Listening complete */
+};
+
+/**
+ * @brief SpeechRecognizer listener interface
+ * @see ISpeechRecognizer
+ */
+class ISpeechRecognizerListener {
+public:
+    virtual ~ISpeechRecognizerListener() = default;
+
+    /**
+     * @brief Get current listening state to user.
+     * @param[in] state listening state
+     */
+    virtual void onListeningState(ListeningState state) = 0;
+
+    /**
+     * @brief Get current audio input stream
+     * @param[in] buf audio input data
+     * @param[in] length audio input length
+     */
+    virtual void onRecordData(unsigned char* buf, int length) = 0;
+};
+
+/**
+ * @brief SpeechRecognizer interface
+ * @see ISpeechRecognizerListener
+ */
+class ISpeechRecognizer {
+public:
+    virtual ~ISpeechRecognizer() = default;
+
+    /**
+     * @brief Set SpeechRecognizer listener object
+     * @param[in] listener ISpeechRecognizerListener object
+     */
+    virtual void setListener(ISpeechRecognizerListener* listener) = 0;
+
+    /**
+     * @brief Start listening speech
+     */
+    virtual bool startListening(void) = 0;
+
+    /**
+     * @brief Stop listening speech
+     */
+    virtual void stopListening(void) = 0;
+};
+
+/**
+ * @}
+ */
+
+} //NuguClientKit
+
+#endif /* __NUGU_SPEECH_RECOGNIZER_INTERFACE_H__*/

--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -32,7 +32,7 @@ static const int SERVER_RESPONSE_TIMEOUT_MSEC = 10000;
 
 class ASRFocusListener : public IFocusListener {
 public:
-    explicit ASRFocusListener(ASRAgent* agent, SpeechRecognizer* speech_recognizer);
+    explicit ASRFocusListener(ASRAgent* agent, ISpeechRecognizer* speech_recognizer);
     virtual ~ASRFocusListener();
 
     NuguFocusResult onFocus(void* event) override;
@@ -41,10 +41,10 @@ public:
 
 private:
     ASRAgent* agent;
-    SpeechRecognizer* speech_recognizer;
+    ISpeechRecognizer* speech_recognizer;
 };
 
-ASRFocusListener::ASRFocusListener(ASRAgent* agent, SpeechRecognizer* speech_recognizer)
+ASRFocusListener::ASRFocusListener(ASRAgent* agent, ISpeechRecognizer* speech_recognizer)
     : agent(agent)
     , speech_recognizer(speech_recognizer)
 
@@ -189,10 +189,7 @@ void ASRAgent::initialize()
         return;
     }
 
-    SpeechRecognizer::Attribute sr_attribute;
-    sr_attribute.model_path = model_path;
-
-    speech_recognizer = std::unique_ptr<SpeechRecognizer>(new SpeechRecognizer(std::move(sr_attribute)));
+    speech_recognizer = std::unique_ptr<ISpeechRecognizer>(core_container->createSpeechRecognizer(model_path));
     speech_recognizer->setListener(this);
 
     timer = nugu_timer_new(response_timeout, 1);

--- a/src/capability/asr_agent.hh
+++ b/src/capability/asr_agent.hh
@@ -92,7 +92,7 @@ private:
     ExpectSpeechAttr es_attr;
     CapabilityEvent* rec_event;
     NuguTimer* timer;
-    std::unique_ptr<SpeechRecognizer> speech_recognizer;
+    std::unique_ptr<ISpeechRecognizer> speech_recognizer;
     std::string all_context_info;
     std::string dialog_id;
     IFocusListener* asr_focus_listener;

--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -61,7 +61,7 @@ void AudioPlayerAgent::initialize()
         return;
     }
 
-    player = dynamic_cast<IMediaPlayer*>(new MediaPlayer());
+    player = core_container->createMediaPlayer();
     player->addListener(this);
 
     CapabilityManager::getInstance()->addFocus("cap_audio", NUGU_FOCUS_TYPE_MEDIA, this);

--- a/src/capability/capability.cc
+++ b/src/capability/capability.cc
@@ -119,6 +119,11 @@ Capability::~Capability()
         observers.clear();
 }
 
+void Capability::setNuguCoreContainer(INuguCoreContainer* core_container)
+{
+    this->core_container = core_container;
+}
+
 void Capability::initialize()
 {
 }

--- a/src/capability/capability.hh
+++ b/src/capability/capability.hh
@@ -54,6 +54,8 @@ class Capability : virtual public ICapabilityInterface {
 public:
     Capability(const std::string& name, const std::string& ver = "1.0");
     virtual ~Capability();
+
+    void setNuguCoreContainer(INuguCoreContainer* core_container) override;
     void initialize() override;
 
     std::string getReferrerDialogRequestId();
@@ -90,6 +92,7 @@ protected:
     bool initialized = false;
     bool has_attachment = false;
     PlaySyncManager* playsync_manager = nullptr;
+    INuguCoreContainer* core_container = nullptr;
 
 private:
     std::string cname;

--- a/src/clientkit/nugu_client.cc
+++ b/src/clientkit/nugu_client.cc
@@ -71,9 +71,9 @@ void NuguClient::deInitialize(void)
     impl->deInitialize();
 }
 
-IWakeupHandler* NuguClient::getWakeupHandler(const std::string& model_path)
+INuguCoreContainer* NuguClient::getNuguCoreContainer()
 {
-    return impl->getWakeupHandler(model_path);
+    return impl->getNuguCoreContainer();
 }
 
 ICapabilityInterface* NuguClient::getCapabilityHandler(const std::string& cname)
@@ -84,11 +84,6 @@ ICapabilityInterface* NuguClient::getCapabilityHandler(const std::string& cname)
 INetworkManager* NuguClient::getNetworkManager()
 {
     return impl->getNetworkManager();
-}
-
-IMediaPlayer* NuguClient::createMediaPlayer()
-{
-    return impl->createMediaPlayer();
 }
 
 } // NuguClientKit

--- a/src/clientkit/nugu_client_impl.hh
+++ b/src/clientkit/nugu_client_impl.hh
@@ -21,12 +21,12 @@
 #include <memory>
 
 #include "capability/capability_interface.hh"
-#include "clientkit/media_player_interface.hh"
-#include "clientkit/network_manager_interface.hh"
 #include "clientkit/nugu_client_listener.hh"
-#include "clientkit/wakeup_interface.hh"
+#include "core/nugu_core_container.hh"
 
 namespace NuguClientKit {
+
+using namespace NuguCore;
 
 class NuguClientImpl : public INetworkManagerListener {
 public:
@@ -41,9 +41,8 @@ public:
     void deInitialize(void);
 
     ICapabilityInterface* getCapabilityHandler(const std::string& cname);
-    IWakeupHandler* getWakeupHandler(const std::string& model_path = "");
+    INuguCoreContainer* getNuguCoreContainer();
     INetworkManager* getNetworkManager();
-    IMediaPlayer* createMediaPlayer();
 
     // overriding INetworkManagerListener
     void onStatusChanged(NetworkStatus status) override;
@@ -55,8 +54,8 @@ private:
 
     CapabilityMap icapability_map;
     INuguClientListener* listener = nullptr;
-    IWakeupHandler* wakeup_handler = nullptr;
     std::unique_ptr<INetworkManager> network_manager = nullptr;
+    std::unique_ptr<NuguCoreContainer> nugu_core_container = nullptr;
     bool initialized = false;
 };
 

--- a/src/core/nugu_core_container.cc
+++ b/src/core/nugu_core_container.cc
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "base/nugu_log.h"
 #include "media_player.hh"
 #include "network_manager.hh"
 #include "speech_recognizer.hh"
@@ -23,18 +24,32 @@
 
 namespace NuguCore {
 
-IWakeupHandler* NuguCoreContainer::createWakeupHandler(const std::string& model_path)
-{
-    return new WakeupHandler(model_path);
-}
-
 INetworkManager* NuguCoreContainer::createNetworkManager()
 {
     return new NetworkManager();
 }
 
+IWakeupHandler* NuguCoreContainer::createWakeupHandler(const std::string& model_path)
+{
+    // TODO : It needs guarantee related plugin is loaded.
+
+    return new WakeupHandler(model_path);
+}
+
+ISpeechRecognizer* NuguCoreContainer::createSpeechRecognizer(const std::string& model_path)
+{
+    // TODO : It needs guarantee related plugin is loaded.
+
+    SpeechRecognizer::Attribute sr_attribute;
+    sr_attribute.model_path = model_path;
+
+    return new SpeechRecognizer(std::move(sr_attribute));
+}
+
 IMediaPlayer* NuguCoreContainer::createMediaPlayer()
 {
+    // TODO : It needs guarantee related plugin is loaded.
+
     return new MediaPlayer();
 }
 

--- a/src/core/nugu_core_container.hh
+++ b/src/core/nugu_core_container.hh
@@ -17,21 +17,22 @@
 #ifndef __NUGU_CORE_CONTAINER_H__
 #define __NUGU_CORE_CONTAINER_H__
 
-#include "clientkit/media_player_interface.hh"
-#include "clientkit/network_manager_interface.hh"
-#include "clientkit/wakeup_interface.hh"
+#include "clientkit/nugu_core_container_interface.hh"
 
 namespace NuguCore {
 
 using namespace NuguClientKit;
 
-class NuguCoreContainer {
+class NuguCoreContainer : public INuguCoreContainer {
 public:
-    NuguCoreContainer() = delete;
+    virtual ~NuguCoreContainer() = default;
 
-    static IWakeupHandler* createWakeupHandler(const std::string& model_path = "");
-    static INetworkManager* createNetworkManager();
-    static IMediaPlayer* createMediaPlayer();
+    INetworkManager* createNetworkManager();
+
+    // implements INuguCoreContainer
+    IWakeupHandler* createWakeupHandler(const std::string& model_path = "") override;
+    ISpeechRecognizer* createSpeechRecognizer(const std::string& model_path = "") override;
+    IMediaPlayer* createMediaPlayer() override;
 };
 
 } // NuguCore

--- a/src/core/speech_recognizer.hh
+++ b/src/core/speech_recognizer.hh
@@ -18,33 +18,16 @@
 #define __NUGU_SPEECH_RECOGNIZER_H__
 
 #include "audio_input_processor.hh"
+#include "clientkit/speech_recognizer_interface.hh"
 
 #define EPD_MODEL_FILE "nugu_model_epd.raw"
 
 namespace NuguCore {
 
-enum class ListeningState {
-    READY,
-    LISTENING,
-    SPEECH_START,
-    SPEECH_END,
-    TIMEOUT,
-    FAILED,
-    DONE
-};
+using namespace NuguClientKit;
 
-class ISpeechRecognizerListener {
-public:
-    virtual ~ISpeechRecognizerListener() = default;
-
-    /* The callback is invoked in the main context. */
-    virtual void onListeningState(ListeningState state) = 0;
-
-    /* The callback is invoked in the thread context. */
-    virtual void onRecordData(unsigned char* buf, int length) = 0;
-};
-
-class SpeechRecognizer : public AudioInputProcessor {
+class SpeechRecognizer : public ISpeechRecognizer,
+                         public AudioInputProcessor {
 public:
     using Attribute = struct {
         std::string sample;
@@ -61,9 +44,10 @@ public:
     SpeechRecognizer(Attribute&& attribute);
     virtual ~SpeechRecognizer() = default;
 
-    void setListener(ISpeechRecognizerListener* listener);
-    bool startListening(void);
-    void stopListening(void);
+    // implements ISpeechRecognizer
+    void setListener(ISpeechRecognizerListener* listener) override;
+    bool startListening(void) override;
+    void stopListening(void) override;
 
 private:
     void initialize(Attribute&& attribute);


### PR DESCRIPTION
It apply INuguCoreContainer interface to ICapabiltyInterface
for using NuguCoreContainer's functions like creating
SpeechRecoginzer or MediaPlayer.

Because each CapabilityAgent inherit ICapbilityInterface,
they has NuguCoreContainer instance basically.
(That instance is added by NuguClient default.)

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>