### PR TITLE
add CapabilityHelper for handling NuguCore

### DIFF
--- a/include/clientkit/capability_helper_interface.hh
+++ b/include/clientkit/capability_helper_interface.hh
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NUGU_CAPABILITY_HELPER_INTERFACE_H__
+#define __NUGU_CAPABILITY_HELPER_INTERFACE_H__
+
+#include <json/json.h>
+#include <list>
+
+#include "base/nugu_focus.h"
+#include "clientkit/playsync_manager_interface.hh"
+
+namespace NuguClientKit {
+/**
+ * @file capability_helper_interface.hh
+ * @defgroup CapabilityHelperInterface CapabilityHelperInterface
+ * @ingroup SDKNuguClientKit
+ * @brief CapabilityHelper Interface
+ *
+ * Helper for using required functions in CapabilityManager or NuguCore Components
+ *
+ * @{
+ */
+
+/**
+ * @brief FocusListener interface
+ */
+class IFocusListener {
+public:
+    virtual ~IFocusListener() = default;
+
+    /**
+     * @brief Receive callback when request focus is acquired.
+     * @param[in] event focus event
+     */
+    virtual NuguFocusResult onFocus(void* event) = 0;
+
+    /**
+     * @brief Receive callback when request focus is released.
+     * @param[in] event focus event
+     */
+    virtual NuguFocusResult onUnfocus(void* event) = 0;
+
+    /**
+     * @brief Receive callback when another focus try to steal.
+     * @param[in] event focus event
+     * @param[in] target_type focus which request to steal
+     */
+    virtual NuguFocusStealResult onStealRequest(void* event, NuguFocusType target_type) = 0;
+};
+
+/**
+ * @brief CapabilityHelper interface
+ */
+class ICapabilityHelper {
+public:
+    virtual ~ICapabilityHelper() = default;
+
+    /**
+     * @brief Get IPlaySyncManager instance
+     */
+    virtual IPlaySyncManager* getPlaySyncManager() = 0;
+
+    /**
+     * @brief Set Audio Recorder mute/unmute
+     * @param[in] mute mute/unmute
+     */
+    virtual bool setMute(bool mute) = 0;
+
+    /**
+     * @brief Send command between CapabilityAgents.
+     * @param[in] from source CapabilityAgent
+     * @param[in] to target CapabilityAgent
+     * @param[in] command command
+     * @param[in] param parameter
+     */
+    virtual void sendCommand(const std::string& from, const std::string& to, const std::string& command, const std::string& param) = 0;
+
+    /**
+     * @brief Get property from CapabilityAgent.
+     * @param[in] cap CapabilityAgent
+     * @param[in] property property key
+     * @param[in] value property value
+     */
+    virtual void getCapabilityProperty(const std::string& cap, const std::string& property, std::string& value) = 0;
+
+    /**
+     * @brief Get properties from CapabilityAgent.
+     * @param[in] cap CapabilityAgent
+     * @param[in] property property key
+     * @param[in] values property values
+     */
+    virtual void getCapabilityProperties(const std::string& cap, const std::string& property, std::list<std::string>& values) = 0;
+
+    /**
+     * @brief Add focus about some focus type.
+     * @param[in] fname focus name
+     * @param[in] type focus type
+     * @param[in] listener focus listener instance
+     */
+    virtual int addFocus(const std::string& fname, NuguFocusType type, IFocusListener* listener) = 0;
+
+    /**
+     * @brief Remove focus.
+     * @param[in] fname focus name
+     */
+    virtual int removeFocus(const std::string& fname) = 0;
+
+    /**
+     * @brief Release focus.
+     * @param[in] fname focus name
+     */
+    virtual int releaseFocus(const std::string& fname) = 0;
+
+    /**
+     * @brief Request focus.
+     * @param[in] fname focus name
+     * @param[in] event focus event
+     */
+    virtual int requestFocus(const std::string& fname, void* event) = 0;
+
+    /**
+     * @brief Check whether param's focus type is focused.
+     * @param[in] type focus type
+     */
+    virtual bool isFocusOn(NuguFocusType type) = 0;
+
+    /**
+     * @brief Get context info.
+     * @param[in] ctx reference object for storing context info
+     */
+    virtual std::string makeContextInfo(Json::Value& ctx) = 0;
+
+    /**
+     * @brief Get context info from All CapabilityAgents.
+     */
+    virtual std::string makeAllContextInfo() = 0;
+
+    /**
+     * @brief Get context info including play stack of All CapabilityAgents.
+     */
+    virtual std::string makeAllContextInfoStack() = 0;
+};
+
+/**
+ * @}
+ */
+
+} // NuguClientKit
+
+#endif /* __NUGU_CAPABILITY_HELPER_INTERFACE_H__ */

--- a/include/clientkit/nugu_core_container_interface.hh
+++ b/include/clientkit/nugu_core_container_interface.hh
@@ -17,6 +17,7 @@
 #ifndef __NUGU_CORE_CONTAINER_INTERFACE_H__
 #define __NUGU_CORE_CONTAINER_INTERFACE_H__
 
+#include "clientkit/capability_helper_interface.hh"
 #include "clientkit/media_player_interface.hh"
 #include "clientkit/network_manager_interface.hh"
 #include "clientkit/speech_recognizer_interface.hh"
@@ -58,6 +59,11 @@ public:
      * @brief Create MediaPlayer instance
      */
     virtual IMediaPlayer* createMediaPlayer() = 0;
+
+    /**
+     * @brief Get CapabilityHelper instance
+     */
+    virtual ICapabilityHelper* getCapabilityHelper() = 0;
 };
 
 /**

--- a/include/clientkit/playsync_manager_interface.hh
+++ b/include/clientkit/playsync_manager_interface.hh
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NUGU_PLAYSYNC_MANAGER_INTERFACE_H__
+#define __NUGU_PLAYSYNC_MANAGER_INTERFACE_H__
+
+#include <string>
+#include <vector>
+
+namespace NuguClientKit {
+
+/**
+ * @file playsync_manager_interface.hh
+ * @defgroup PlaySyncManagerInterface PlaySyncManagerInterface
+ * @ingroup SDKNuguClientKit
+ * @brief PlaySyncManager Interface
+ *
+ * Interface of PlaySyncManager which manage play service context stack.
+ *
+ * @{
+ */
+
+/**
+ * @brief PlayerSyncManagerListener interface
+ * @see IPlaySyncManager
+ */
+class IPlaySyncManagerListener {
+public:
+    virtual ~IPlaySyncManagerListener() = default;
+
+    /**
+     * @brief Receive callback when display context is synced and need to render screen.
+     * @param[in] id rendering display id
+     */
+    virtual void onSyncDisplayContext(const std::string& id) = 0;
+
+    /**
+     * @brief Receive callback when the current display has to be cleared.
+     * @param[in] id rendering display id
+     * @param[in] unconditionally whether clear display unconditionally or not
+     */
+    virtual bool onReleaseDisplayContext(const std::string& id, bool unconditionally) = 0;
+};
+
+/**
+ * @brief PlayerSyncManager interface
+ * @see IPlaySyncManagerListener
+ */
+class IPlaySyncManager {
+public:
+    using DisplayRenderInfo = struct {
+        std::string id;
+        std::string type;
+        std::string payload;
+        std::string dialog_id;
+        std::string ps_id;
+        std::string token;
+    };
+    using DisplayRenderer = struct {
+        IPlaySyncManagerListener* listener = nullptr;
+        std::string cap_name;
+        std::string duration;
+        std::string display_id;
+        bool only_rendering = false;
+    };
+
+public:
+    virtual ~IPlaySyncManager() = default;
+
+    /**
+     * @brief Add current play service id to context stack.
+     * @param[in] ps_id play service id
+     * @param[in] cap_name CapabilityAgent name
+     */
+    virtual void addContext(const std::string& ps_id, const std::string& cap_name) = 0;
+
+    /**
+     * @brief Add current play service id to context stack. It used when display rendering info exist.
+     * @param[in] ps_id play service id
+     * @param[in] cap_name CapabilityAgent name
+     * @param[in] renderer DisplayRenderer object
+     */
+    virtual void addContext(const std::string& ps_id, const std::string& cap_name, DisplayRenderer&& renderer) = 0;
+
+    /**
+     * @brief Remove play service id from context stack.
+     * @param[in] ps_id play service id
+     * @param[in] cap_name CapabilityAgent name
+     * @param[in] immediately whether remove context immediately or not
+     */
+    virtual void removeContext(const std::string& ps_id, const std::string& cap_name, bool immediately = true) = 0;
+
+    /**
+     * @brief Clear pendind play service id from context stack.
+     * @param[in] ps_id play service id
+     */
+    virtual void clearPendingContext(const std::string& ps_id) = 0;
+
+    /**
+     * @brief Get all play service id list which exist in context stack.
+     */
+    virtual std::vector<std::string> getAllPlayStackItems() = 0;
+
+    /**
+     * @brief Get play service id of specific CapabilityAgent.
+     * @param[in] cap_name CapabilityAgent name
+     */
+    virtual std::string getPlayStackItem(const std::string& cap_name) = 0;
+
+    /**
+     * @brief Set whether current ASR is expect speech situation.
+     * @param[in] expect_speech whether expect speech situation or not
+     */
+    virtual void setExpectSpeech(bool expect_speech) = 0;
+
+    /**
+     * @brief Notify mic on as starting listening speech.
+     */
+    virtual void onMicOn() = 0;
+
+    /**
+     * @brief Clear holding context.
+     */
+    virtual void clearContextHold() = 0;
+
+    /**
+     * @brief Notify error occurred when ASR.
+     */
+    virtual void onASRError() = 0;
+};
+
+/**
+ * @}
+ */
+
+} // NuguClientKit
+
+#endif /* __NUGU_PLAYSYNC_MANAGER_INTERFACE_H__ */

--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -49,12 +49,12 @@ ASRFocusListener::ASRFocusListener(ASRAgent* agent, ISpeechRecognizer* speech_re
     , speech_recognizer(speech_recognizer)
 
 {
-    CapabilityManager::getInstance()->addFocus("asr", NUGU_FOCUS_TYPE_ASR, this);
+    agent->getCapabilityHelper()->addFocus("asr", NUGU_FOCUS_TYPE_ASR, this);
 }
 
 ASRFocusListener::~ASRFocusListener()
 {
-    CapabilityManager::getInstance()->removeFocus("asr");
+    agent->getCapabilityHelper()->removeFocus("asr");
 }
 
 NuguFocusResult ASRFocusListener::onFocus(void* event)
@@ -65,7 +65,7 @@ NuguFocusResult ASRFocusListener::onFocus(void* event)
 
     if (agent->isExpectSpeechState()) {
         agent->resetExpectSpeechState();
-        CapabilityManager::getInstance()->releaseFocus("expect");
+        agent->getCapabilityHelper()->releaseFocus("expect");
     }
 
     return NUGU_FOCUS_OK;
@@ -107,12 +107,12 @@ private:
 ExpectFocusListener::ExpectFocusListener(ASRAgent* agent)
     : agent(agent)
 {
-    CapabilityManager::getInstance()->addFocus("expect", NUGU_FOCUS_TYPE_ASR_EXPECT, this);
+    agent->getCapabilityHelper()->addFocus("expect", NUGU_FOCUS_TYPE_ASR_EXPECT, this);
 }
 
 ExpectFocusListener::~ExpectFocusListener()
 {
-    CapabilityManager::getInstance()->removeFocus("expect");
+    agent->getCapabilityHelper()->removeFocus("expect");
 }
 
 NuguFocusResult ExpectFocusListener::onFocus(void* event)
@@ -212,7 +212,7 @@ void ASRAgent::startRecognition()
     nugu_dbg("startRecognition()");
 
     saveAllContextInfo();
-    CapabilityManager::getInstance()->requestFocus("asr", NULL);
+    capa_helper->requestFocus("asr", NULL);
 }
 
 void ASRAgent::stopRecognition()
@@ -222,7 +222,7 @@ void ASRAgent::stopRecognition()
     if (rec_event)
         sendEventStopRecognize();
 
-    CapabilityManager::getInstance()->releaseFocus("asr");
+    capa_helper->releaseFocus("asr");
 }
 
 void ASRAgent::parsingDirective(const char* dname, const char* message)
@@ -245,7 +245,7 @@ void ASRAgent::updateInfoForContext(Json::Value& ctx)
 
 void ASRAgent::saveAllContextInfo()
 {
-    all_context_info = CapabilityManager::getInstance()->makeAllContextInfoStack();
+    all_context_info = capa_helper->makeAllContextInfoStack();
 }
 
 void ASRAgent::receiveCommand(const std::string& from, const std::string& command, const std::string& param)
@@ -256,15 +256,15 @@ void ASRAgent::receiveCommand(const std::string& from, const std::string& comman
 
     if (!convert_command.compare("wakeup_detected")) {
         if (es_attr.is_handle) {
-            CapabilityManager::getInstance()->releaseFocus("expect");
+            capa_helper->releaseFocus("expect");
             es_attr = {};
         }
     } else if (!convert_command.compare("releasefocus")) {
         if (from == "System") {
             if (dialog_id == param)
-                CapabilityManager::getInstance()->releaseFocus("asr");
+                capa_helper->releaseFocus("asr");
         } else {
-            CapabilityManager::getInstance()->releaseFocus("asr");
+            capa_helper->releaseFocus("asr");
         }
     }
 }
@@ -457,7 +457,7 @@ void ASRAgent::parsingExpectSpeech(const char* message)
 
     playsync_manager->setExpectSpeech(true);
 
-    CapabilityManager::getInstance()->requestFocus("expect", NULL);
+    capa_helper->requestFocus("expect", NULL);
 }
 
 void ASRAgent::parsingNotifyResult(const char* message)
@@ -589,7 +589,7 @@ void ASRAgent::releaseASRFocus(bool is_cancel, ASRError error)
             asr_listener->onError(error);
     }
 
-    CapabilityManager::getInstance()->releaseFocus("asr");
+    capa_helper->releaseFocus("asr");
     playsync_manager->onASRError();
 }
 

--- a/src/capability/asr_agent.hh
+++ b/src/capability/asr_agent.hh
@@ -24,12 +24,8 @@
 #include "base/nugu_timer.h"
 #include "capability/asr_interface.hh"
 #include "capability/capability.hh"
-#include "core/capability_manager.hh"
-#include "core/speech_recognizer.hh"
 
 namespace NuguCapability {
-
-using namespace NuguCore;
 
 typedef struct expect_speech_attr {
     bool is_handle;

--- a/src/capability/audio_player_agent.hh
+++ b/src/capability/audio_player_agent.hh
@@ -22,7 +22,6 @@
 #include "capability/audio_player_interface.hh"
 #include "capability/display_interface.hh"
 #include "clientkit/media_player_interface.hh"
-#include "core/capability_manager.hh"
 #include "display_render_assembly.hh"
 
 namespace NuguCapability {
@@ -97,6 +96,7 @@ public:
 
     // implement DisplayRenderAssembly
     void onElementSelected(const std::string& item_token) override;
+    IPlaySyncManager* getPlaySyncManager() override;
 
     using IDisplayHandler::removeListener;
 

--- a/src/capability/capability.cc
+++ b/src/capability/capability.cc
@@ -18,7 +18,6 @@
 
 #include "base/nugu_directive_sequencer.h"
 #include "base/nugu_log.h"
-#include "core/capability_manager.hh"
 
 #include "capability.hh"
 
@@ -85,8 +84,7 @@ void CapabilityEvent::sendEvent(const std::string& context, const std::string& p
     if (ref_dialog_id.size())
         nugu_event_set_referrer_id(event, ref_dialog_id.c_str());
 
-    CapabilityManager* cap_manager = CapabilityManager::getInstance();
-    cap_manager->sendCommand(capability->getName(), "System", "activity", "");
+    capability->getCapabilityHelper()->sendCommand(capability->getName(), "System", "activity", "");
 
     nugu_network_manager_send_event(event);
     // dialog_request_id is made every time to send event
@@ -110,7 +108,6 @@ Capability::Capability(const std::string& name, const std::string& ver)
     , ref_dialog_id("")
     , cur_ndir(NULL)
 {
-    playsync_manager = CapabilityManager::getInstance()->getPlaySyncManager();
 }
 
 Capability::~Capability()
@@ -122,6 +119,8 @@ Capability::~Capability()
 void Capability::setNuguCoreContainer(INuguCoreContainer* core_container)
 {
     this->core_container = core_container;
+    capa_helper = core_container->getCapabilityHelper();
+    playsync_manager = capa_helper->getPlaySyncManager();
 }
 
 void Capability::initialize()
@@ -275,7 +274,12 @@ std::string Capability::getContextInfo()
     Json::Value ctx;
     updateInfoForContext(ctx);
 
-    return CapabilityManager::getInstance()->makeContextInfo(ctx);
+    return capa_helper->makeContextInfo(ctx);
+}
+
+ICapabilityHelper* Capability::getCapabilityHelper()
+{
+    return capa_helper;
 }
 
 /********************************************************************

--- a/src/capability/capability.hh
+++ b/src/capability/capability.hh
@@ -24,11 +24,8 @@
 #include "base/nugu_event.h"
 #include "base/nugu_network_manager.h"
 #include "capability/capability_interface.hh"
-#include "core/playsync_manager.hh"
 
 namespace NuguCapability {
-
-using namespace NuguCore;
 
 class Capability;
 class CapabilityEvent {
@@ -82,6 +79,7 @@ public:
     void receiveCommandAll(const std::string& command, const std::string& param) override;
     virtual void parsingDirective(const char* dname, const char* message);
     virtual std::string getContextInfo();
+    ICapabilityHelper* getCapabilityHelper();
 
     // implements ICapabilityObservable
     void registerObserver(ICapabilityObserver* observer) override;
@@ -91,8 +89,10 @@ public:
 protected:
     bool initialized = false;
     bool has_attachment = false;
-    PlaySyncManager* playsync_manager = nullptr;
+
     INuguCoreContainer* core_container = nullptr;
+    ICapabilityHelper* capa_helper = nullptr;
+    IPlaySyncManager* playsync_manager = nullptr;
 
 private:
     std::string cname;

--- a/src/capability/delegation_agent.cc
+++ b/src/capability/delegation_agent.cc
@@ -17,8 +17,6 @@
 #include <string.h>
 
 #include "base/nugu_log.h"
-#include "core/capability_manager.hh"
-
 #include "delegation_agent.hh"
 
 namespace NuguCapability {
@@ -74,7 +72,7 @@ std::string DelegationAgent::getContextInfo()
     Json::Value ctx;
     updateInfoForContext(ctx);
 
-    return !ctx.empty() ? CapabilityManager::getInstance()->makeContextInfo(ctx) : "";
+    return !ctx.empty() ? capa_helper->makeContextInfo(ctx) : "";
 }
 
 void DelegationAgent::parsingDirective(const char* dname, const char* message)

--- a/src/capability/display_agent.cc
+++ b/src/capability/display_agent.cc
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 
-#include "base/nugu_log.h"
-#include "core/capability_manager.hh"
-
 #include "display_agent.hh"
+#include "base/nugu_log.h"
 
 namespace NuguCapability {
 
@@ -61,7 +59,7 @@ void DisplayAgent::parsingDirective(const char* dname, const char* message)
             root["token"].asString()));
 
         // sync display rendering with context
-        PlaySyncManager::DisplayRenderer renderer;
+        IPlaySyncManager::DisplayRenderer renderer;
         renderer.cap_name = getName();
         renderer.listener = this;
         renderer.only_rendering = true;
@@ -108,6 +106,11 @@ void DisplayAgent::sendEventElementSelected(const std::string& item_token)
 void DisplayAgent::onElementSelected(const std::string& item_token)
 {
     sendEventElementSelected(item_token);
+}
+
+IPlaySyncManager* DisplayAgent::getPlaySyncManager()
+{
+    return playsync_manager;
 }
 
 } // NuguCapability

--- a/src/capability/display_agent.hh
+++ b/src/capability/display_agent.hh
@@ -34,6 +34,7 @@ public:
 
     // implement DisplayRenderAssembly
     void onElementSelected(const std::string& item_token) override;
+    IPlaySyncManager* getPlaySyncManager() override;
 
 private:
     void sendEventElementSelected(const std::string& item_token);

--- a/src/capability/display_render_assembly.hh
+++ b/src/capability/display_render_assembly.hh
@@ -46,13 +46,14 @@ public:
 
 protected:
     virtual void onElementSelected(const std::string& item_token) = 0;
+    virtual IPlaySyncManager* getPlaySyncManager() = 0;
 
     IDisplayListener* display_listener = nullptr;
     std::string disp_cur_ps_id = "";
     std::string disp_cur_token = "";
 
 private:
-    std::map<std::string, PlaySyncManager::DisplayRenderInfo*> render_info;
+    std::map<std::string, IPlaySyncManager::DisplayRenderInfo*> render_info;
 };
 }
 

--- a/src/capability/display_render_assembly.hpp
+++ b/src/capability/display_render_assembly.hpp
@@ -17,7 +17,6 @@
 #include <sys/time.h>
 
 #include "base/nugu_log.h"
-#include "core/capability_manager.hh"
 
 namespace NuguCapability {
 
@@ -42,7 +41,7 @@ DisplayRenderAssembly<T>::~DisplayRenderAssembly()
 template <typename T>
 std::string DisplayRenderAssembly<T>::composeRenderInfo(const RenderInfoParam& param)
 {
-    PlaySyncManager::DisplayRenderInfo* info = new PlaySyncManager::DisplayRenderInfo;
+    IPlaySyncManager::DisplayRenderInfo* info = new IPlaySyncManager::DisplayRenderInfo;
     struct timeval tv;
 
     gettimeofday(&tv, NULL);
@@ -79,7 +78,8 @@ void DisplayRenderAssembly<T>::displayCleared(const std::string& id)
         disp_cur_token = disp_cur_ps_id = "";
     }
 
-    CapabilityManager::getInstance()->getPlaySyncManager()->clearPendingContext(ps_id);
+    auto derived = static_cast<T*>(this);
+    derived->getPlaySyncManager()->clearPendingContext(ps_id);
 }
 
 template <typename T>
@@ -119,7 +119,8 @@ void DisplayRenderAssembly<T>::removeListener(IDisplayListener* listener)
 template <typename T>
 void DisplayRenderAssembly<T>::stopRenderingTimer(const std::string& id)
 {
-    CapabilityManager::getInstance()->getPlaySyncManager()->clearContextHold();
+    auto derived = static_cast<T*>(this);
+    derived->getPlaySyncManager()->clearContextHold();
 }
 
 template <typename T>

--- a/src/capability/extension_agent.cc
+++ b/src/capability/extension_agent.cc
@@ -17,8 +17,6 @@
 #include <string.h>
 
 #include "base/nugu_log.h"
-#include "core/capability_manager.hh"
-
 #include "extension_agent.hh"
 
 namespace NuguCapability {

--- a/src/capability/mic_agent.cc
+++ b/src/capability/mic_agent.cc
@@ -17,9 +17,6 @@
 #include <string.h>
 
 #include "base/nugu_log.h"
-#include "core/audio_recorder_manager.hh"
-#include "core/capability_manager.hh"
-
 #include "mic_agent.hh"
 
 namespace NuguCapability {
@@ -139,7 +136,7 @@ void MicAgent::control(bool enable, bool send_event)
     if (cur_status == pre_status)
         return;
 
-    AudioRecorderManager::getInstance()->setMute(cur_status == MicStatus::OFF);
+    capa_helper->setMute(cur_status == MicStatus::OFF);
 
     if (send_event)
         sendEventSetMicSucceeded();

--- a/src/capability/system_agent.cc
+++ b/src/capability/system_agent.cc
@@ -19,7 +19,6 @@
 
 #include "base/nugu_log.h"
 #include "base/nugu_network_manager.h"
-#include "core/capability_manager.hh"
 
 #include "system_agent.hh"
 
@@ -173,7 +172,7 @@ void SystemAgent::sendEventSynchronizeState(void)
     std::string ename = "SynchronizeState";
     std::string payload = "";
 
-    sendEvent(ename, CapabilityManager::getInstance()->makeAllContextInfo(), payload);
+    sendEvent(ename, capa_helper->makeAllContextInfo(), payload);
 }
 
 void SystemAgent::sendEventUserInactivityReport(int seconds)
@@ -338,8 +337,7 @@ void SystemAgent::parsingException(const char* message)
 
     if (exception == SystemException::PLAY_ROUTER_PROCESSING_EXCEPTION) {
         nugu_info("Release ASR focus due to 'not found play' state");
-        CapabilityManager* cmanager = CapabilityManager::getInstance();
-        cmanager->releaseFocus("asr");
+        capa_helper->releaseFocus("asr");
     }
 
     if (system_listener)
@@ -358,7 +356,7 @@ void SystemAgent::parsingNoDirectives(const char* message)
     }
 
     dialog_id = nugu_directive_peek_dialog_id(getNuguDirective());
-    CapabilityManager::getInstance()->sendCommand("System", "ASR", "releasefocus", dialog_id);
+    capa_helper->sendCommand("System", "ASR", "releasefocus", dialog_id);
 }
 
 void SystemAgent::parsingRevoke(const char* message)

--- a/src/capability/text_agent.cc
+++ b/src/capability/text_agent.cc
@@ -17,8 +17,6 @@
 #include <string.h>
 
 #include "base/nugu_log.h"
-#include "core/capability_manager.hh"
-
 #include "text_agent.hh"
 
 namespace NuguCapability {
@@ -155,11 +153,10 @@ void TextAgent::sendEventTextInput(const std::string& text, const std::string& t
     std::string session_id = "";
     std::list<std::string> domainTypes;
 
-    CapabilityManager* cmanager = CapabilityManager::getInstance();
-    cmanager->getCapabilityProperty("ASR", "es.playServiceId", ps_id);
-    cmanager->getCapabilityProperty("ASR", "es.property", property);
-    cmanager->getCapabilityProperty("ASR", "es.sessionId", session_id);
-    cmanager->getCapabilityProperties("ASR", "es.domainTypes", domainTypes);
+    capa_helper->getCapabilityProperty("ASR", "es.playServiceId", ps_id);
+    capa_helper->getCapabilityProperty("ASR", "es.property", property);
+    capa_helper->getCapabilityProperty("ASR", "es.sessionId", session_id);
+    capa_helper->getCapabilityProperties("ASR", "es.domainTypes", domainTypes);
 
     root["text"] = text;
     if (token.size())
@@ -180,7 +177,7 @@ void TextAgent::sendEventTextInput(const std::string& text, const std::string& t
 
     cur_dialog_id = event.getDialogMessageId();
 
-    sendEvent(&event, CapabilityManager::getInstance()->makeAllContextInfoStack(), payload);
+    sendEvent(&event, capa_helper->makeAllContextInfoStack(), payload);
 }
 
 void TextAgent::sendEventTextSourceFailed(const std::string& text, const std::string& token)

--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -67,7 +67,7 @@ TTSAgent::~TTSAgent()
     }
 
     initialized = false;
-    CapabilityManager::getInstance()->removeFocus("cap_tts");
+    capa_helper->removeFocus("cap_tts");
 }
 
 void TTSAgent::setAttribute(TTSAttribute&& attribute)
@@ -96,7 +96,7 @@ void TTSAgent::initialize()
 
     nugu_pcm_set_property(pcm, (NuguAudioProperty) { AUDIO_SAMPLE_RATE_22K, AUDIO_FORMAT_S16_LE, 1 });
 
-    CapabilityManager::getInstance()->addFocus("cap_tts", NUGU_FOCUS_TYPE_TTS, this);
+    capa_helper->addFocus("cap_tts", NUGU_FOCUS_TYPE_TTS, this);
 
     initialized = true;
 }
@@ -131,7 +131,7 @@ void TTSAgent::pcmEventCallback(enum nugu_media_event event, void* userdata)
         tts->sendEventSpeechFinished(tts->cur_token);
         tts->finish = true;
         tts->speak_status = MEDIA_STATUS_STOPPED;
-        CapabilityManager::getInstance()->releaseFocus("cap_tts");
+        tts->capa_helper->releaseFocus("cap_tts");
         break;
     default:
         break;
@@ -404,11 +404,11 @@ void TTSAgent::parsingSpeak(const char* message)
 
     startTTS(getNuguDirective());
 
-    if (CapabilityManager::getInstance()->isFocusOn(NUGU_FOCUS_TYPE_TTS)) {
+    if (capa_helper->isFocusOn(NUGU_FOCUS_TYPE_TTS)) {
         if (nugu_directive_get_data_size(speak_dir) > 0)
             getAttachmentData(speak_dir, this);
     } else {
-        CapabilityManager::getInstance()->requestFocus("cap_tts", NULL);
+        capa_helper->requestFocus("cap_tts", NULL);
     }
 
     if (tts_listener)

--- a/src/capability/tts_agent.hh
+++ b/src/capability/tts_agent.hh
@@ -22,7 +22,6 @@
 #include "base/nugu_pcm.h"
 #include "capability.hh"
 #include "capability/tts_interface.hh"
-#include "core/capability_manager.hh"
 
 namespace NuguCapability {
 

--- a/src/core/capability_helper.cc
+++ b/src/core/capability_helper.cc
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "capability_helper.hh"
+#include "audio_recorder_manager.hh"
+#include "capability_manager.hh"
+
+namespace NuguCore {
+
+CapabilityHelper* CapabilityHelper::instance = nullptr;
+
+CapabilityHelper::CapabilityHelper()
+{
+}
+
+CapabilityHelper::~CapabilityHelper()
+{
+}
+
+CapabilityHelper* CapabilityHelper::getInstance()
+{
+    if (!instance) {
+        instance = new CapabilityHelper();
+    }
+
+    return instance;
+}
+
+void CapabilityHelper::destroyInstance()
+{
+    if (instance) {
+        delete instance;
+        instance = nullptr;
+    }
+}
+
+IPlaySyncManager* CapabilityHelper::getPlaySyncManager()
+{
+    return CapabilityManager::getInstance()->getPlaySyncManager();
+}
+
+bool CapabilityHelper::setMute(bool mute)
+{
+    return AudioRecorderManager::getInstance()->setMute(mute);
+}
+
+void CapabilityHelper::sendCommand(const std::string& from, const std::string& to, const std::string& command, const std::string& param)
+{
+    CapabilityManager::getInstance()->sendCommand(from, to, command, param);
+}
+
+void CapabilityHelper::getCapabilityProperty(const std::string& cap, const std::string& property, std::string& value)
+{
+    CapabilityManager::getInstance()->getCapabilityProperty(cap, property, value);
+}
+
+void CapabilityHelper::getCapabilityProperties(const std::string& cap, const std::string& property, std::list<std::string>& values)
+{
+    CapabilityManager::getInstance()->getCapabilityProperties(cap, property, values);
+}
+
+int CapabilityHelper::addFocus(const std::string& fname, NuguFocusType type, IFocusListener* listener)
+{
+    return CapabilityManager::getInstance()->addFocus(fname, type, listener);
+}
+
+int CapabilityHelper::removeFocus(const std::string& fname)
+{
+    return CapabilityManager::getInstance()->removeFocus(fname);
+}
+
+int CapabilityHelper::releaseFocus(const std::string& fname)
+{
+    return CapabilityManager::getInstance()->releaseFocus(fname);
+}
+
+int CapabilityHelper::requestFocus(const std::string& fname, void* event)
+{
+    return CapabilityManager::getInstance()->requestFocus(fname, event);
+}
+
+bool CapabilityHelper::isFocusOn(NuguFocusType type)
+{
+    return CapabilityManager::getInstance()->isFocusOn(type);
+}
+
+std::string CapabilityHelper::makeContextInfo(Json::Value& ctx)
+{
+    return CapabilityManager::getInstance()->makeContextInfo(ctx);
+}
+
+std::string CapabilityHelper::makeAllContextInfo()
+{
+    return CapabilityManager::getInstance()->makeAllContextInfo();
+}
+
+std::string CapabilityHelper::makeAllContextInfoStack()
+{
+    return CapabilityManager::getInstance()->makeAllContextInfoStack();
+}
+
+} // NuguCore

--- a/src/core/capability_helper.hh
+++ b/src/core/capability_helper.hh
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NUGU_CAPABILITY_HELPER_H__
+#define __NUGU_CAPABILITY_HELPER_H__
+
+#include "clientkit/capability_helper_interface.hh"
+
+namespace NuguCore {
+
+using namespace NuguClientKit;
+
+class CapabilityHelper : public ICapabilityHelper {
+public:
+    static CapabilityHelper* getInstance();
+    static void destroyInstance();
+
+    // implements ICapabilityHelper
+    IPlaySyncManager* getPlaySyncManager() override;
+
+    bool setMute(bool mute) override;
+    void sendCommand(const std::string& from, const std::string& to, const std::string& command, const std::string& param) override;
+    void getCapabilityProperty(const std::string& cap, const std::string& property, std::string& value) override;
+    void getCapabilityProperties(const std::string& cap, const std::string& property, std::list<std::string>& values) override;
+
+    // about focus
+    int addFocus(const std::string& fname, NuguFocusType type, IFocusListener* listener) override;
+    int removeFocus(const std::string& fname) override;
+    int releaseFocus(const std::string& fname) override;
+    int requestFocus(const std::string& fname, void* event) override;
+    bool isFocusOn(NuguFocusType type) override;
+
+    // about context
+    std::string makeContextInfo(Json::Value& ctx) override;
+    std::string makeAllContextInfo() override;
+    std::string makeAllContextInfoStack() override;
+
+private:
+    CapabilityHelper();
+    virtual ~CapabilityHelper();
+
+    static CapabilityHelper* instance;
+};
+
+} // NuguCore
+
+#endif /* __NUGU_CAPABILITY_HELPER_H__ */

--- a/src/core/capability_manager.hh
+++ b/src/core/capability_manager.hh
@@ -28,14 +28,6 @@
 
 namespace NuguCore {
 
-class IFocusListener {
-public:
-    virtual ~IFocusListener() = default;
-    virtual NuguFocusResult onFocus(void* event) = 0;
-    virtual NuguFocusResult onUnfocus(void* event) = 0;
-    virtual NuguFocusStealResult onStealRequest(void* event, NuguFocusType target_type) = 0;
-};
-
 class CapabilityManager {
 private:
     CapabilityManager();

--- a/src/core/nugu_core_container.cc
+++ b/src/core/nugu_core_container.cc
@@ -15,6 +15,7 @@
  */
 
 #include "base/nugu_log.h"
+#include "capability_helper.hh"
 #include "media_player.hh"
 #include "network_manager.hh"
 #include "speech_recognizer.hh"
@@ -23,6 +24,11 @@
 #include "nugu_core_container.hh"
 
 namespace NuguCore {
+
+NuguCoreContainer::~NuguCoreContainer()
+{
+    CapabilityHelper::destroyInstance();
+}
 
 INetworkManager* NuguCoreContainer::createNetworkManager()
 {
@@ -51,6 +57,11 @@ IMediaPlayer* NuguCoreContainer::createMediaPlayer()
     // TODO : It needs guarantee related plugin is loaded.
 
     return new MediaPlayer();
+}
+
+ICapabilityHelper* NuguCoreContainer::getCapabilityHelper()
+{
+    return CapabilityHelper::getInstance();
 }
 
 } // NuguCore

--- a/src/core/nugu_core_container.hh
+++ b/src/core/nugu_core_container.hh
@@ -25,7 +25,7 @@ using namespace NuguClientKit;
 
 class NuguCoreContainer : public INuguCoreContainer {
 public:
-    virtual ~NuguCoreContainer() = default;
+    virtual ~NuguCoreContainer();
 
     INetworkManager* createNetworkManager();
 
@@ -33,6 +33,7 @@ public:
     IWakeupHandler* createWakeupHandler(const std::string& model_path = "") override;
     ISpeechRecognizer* createSpeechRecognizer(const std::string& model_path = "") override;
     IMediaPlayer* createMediaPlayer() override;
+    ICapabilityHelper* getCapabilityHelper() override;
 };
 
 } // NuguCore

--- a/src/core/playsync_manager.cc
+++ b/src/core/playsync_manager.cc
@@ -17,7 +17,6 @@
 #include <algorithm>
 
 #include "base/nugu_log.h"
-
 #include "playsync_manager.hh"
 
 #define HOLD_TIME_SHORT (7 * 1000) // 7 sec
@@ -44,11 +43,6 @@ namespace Test {
             for (auto element : context.second) {
                 context_log.append(element)
                     .append(", ");
-
-                // if (element == "TTS")
-                //     context_log.append("TTS, ");
-                // else if (element == "AudioPlayer")
-                //     context_log.append("AudioPlayer, ");
             }
 
             context_log.append("\n");

--- a/src/core/playsync_manager.hh
+++ b/src/core/playsync_manager.hh
@@ -19,56 +19,31 @@
 
 #include <functional>
 #include <map>
-#include <string>
-#include <vector>
 
 #include "base/nugu_timer.h"
 #include "capability/capability_interface.hh"
+#include "clientkit/playsync_manager_interface.hh"
 
 namespace NuguCore {
 
 using namespace NuguCapability;
 
-class IPlaySyncManagerListener {
-public:
-    virtual ~IPlaySyncManagerListener() = default;
-    virtual void onSyncDisplayContext(const std::string& id) = 0;
-    virtual bool onReleaseDisplayContext(const std::string& id, bool unconditionally) = 0;
-};
-
-class PlaySyncManager {
-public:
-    using DisplayRenderInfo = struct {
-        std::string id;
-        std::string type;
-        std::string payload;
-        std::string dialog_id;
-        std::string ps_id;
-        std::string token;
-    };
-    using DisplayRenderer = struct {
-        IPlaySyncManagerListener* listener = nullptr;
-        std::string cap_name;
-        std::string duration;
-        std::string display_id;
-        bool only_rendering = false;
-    };
-
+class PlaySyncManager : public IPlaySyncManager {
 public:
     PlaySyncManager();
     virtual ~PlaySyncManager();
 
-    void addContext(const std::string& ps_id, const std::string& cap_name);
-    void addContext(const std::string& ps_id, const std::string& cap_name, DisplayRenderer&& renderer);
-    void removeContext(const std::string& ps_id, const std::string& cap_name, bool immediately = true);
-    void clearPendingContext(const std::string& ps_id);
-    std::vector<std::string> getAllPlayStackItems();
-    std::string getPlayStackItem(const std::string& cap_name);
+    void addContext(const std::string& ps_id, const std::string& cap_name) override;
+    void addContext(const std::string& ps_id, const std::string& cap_name, DisplayRenderer&& renderer) override;
+    void removeContext(const std::string& ps_id, const std::string& cap_name, bool immediately = true) override;
+    void clearPendingContext(const std::string& ps_id) override;
+    std::vector<std::string> getAllPlayStackItems() override;
+    std::string getPlayStackItem(const std::string& cap_name) override;
 
-    void setExpectSpeech(bool expect_speech);
-    void onMicOn();
-    void clearContextHold();
-    void onASRError();
+    void setExpectSpeech(bool expect_speech) override;
+    void onMicOn() override;
+    void clearContextHold() override;
+    void onASRError() override;
 
     using ContextMap = std::map<std::string, std::vector<std::string>>;
 


### PR DESCRIPTION
It add CapabilityHelper which encapsulate CapabilityManager.
It is composed by methods which current CapabilityAgents required.

Also it's possible to get PlaySyncManager instance from CapabilityHelper.
(Its implementation is hidden in NuguCore, but we can access
from IPlaySyncManager interface).

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>