### PR TITLE
network: fix missing close_data bug

### DIFF
--- a/src/base/network/dg_server.c
+++ b/src/base/network/dg_server.c
@@ -239,9 +239,7 @@ int dg_server_send_attachment(DGServer *server, NuguEvent *nev, int is_end,
 
 	msg_id = nugu_uuid_generate_time();
 
-	if (data != NULL && length > 0)
-		v1_event_attachment_set_data(ea, data, length);
-
+	v1_event_attachment_set_data(ea, data, length);
 	v1_event_attachment_set_query(ea, nugu_event_peek_namespace(nev),
 				      nugu_event_peek_name(nev),
 				      nugu_event_peek_version(nev),

--- a/src/base/network/http2/v1_event_attachment.c
+++ b/src/base/network/http2/v1_event_attachment.c
@@ -112,8 +112,10 @@ int v1_event_attachment_set_data(V1EventAttachment *attach,
 {
 	g_return_val_if_fail(attach != NULL, -1);
 
-	if (http2_request_add_send_data(attach->req, data, length) < 0)
-		return -1;
+	if (data != NULL && length > 0) {
+		if (http2_request_add_send_data(attach->req, data, length) < 0)
+			return -1;
+	}
 
 	return http2_request_close_send_data(attach->req);
 }


### PR DESCRIPTION
Fixed a bug in which close_data was not called when the data size is 0
(e.g. is_end=true with attachment data).

Signed-off-by: Inho Oh <inho.oh@sk.com>