### PR TITLE
base: add type to nugu_event

### DIFF
--- a/include/base/nugu_event.h
+++ b/include/base/nugu_event.h
@@ -41,6 +41,17 @@ extern "C" {
  */
 
 /**
+ * @brief event types
+ */
+enum nugu_event_type {
+	NUGU_EVENT_TYPE_DEFAULT,
+	/**< Single event with no additional data. */
+
+	NUGU_EVENT_TYPE_WITH_ATTACHMENT
+	/**< Event with additional data. */
+};
+
+/**
  * @brief Event object
  */
 typedef struct _nugu_event NuguEvent;
@@ -158,6 +169,23 @@ int nugu_event_set_referrer_id(NuguEvent *nev, const char *referrer_id);
  * @return referrer-dialog-request-id. Please don't free the data manually.
  */
 const char *nugu_event_peek_referrer_id(NuguEvent *nev);
+
+/**
+ * @brief Set the type of NuguEvent
+ * @param[in] nev event object
+ * @param[in] type event type
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ */
+int nugu_event_set_type(NuguEvent *nev, enum nugu_event_type type);
+
+/**
+ * @brief Get the type of NuguEvent
+ * @param[in] nev event object
+ * @return type of NuguEvent
+ */
+enum nugu_event_type nugu_event_get_type(NuguEvent *nev);
 
 /**
  * @brief Get the current sequence number of attachment data

--- a/src/base/nugu_event.c
+++ b/src/base/nugu_event.c
@@ -65,6 +65,8 @@ struct _nugu_event {
 	int seq;
 	char *json;
 	char *context;
+
+	enum nugu_event_type type;
 };
 
 EXPORT_API NuguEvent *nugu_event_new(const char *name_space, const char *name,
@@ -84,6 +86,7 @@ EXPORT_API NuguEvent *nugu_event_new(const char *name_space, const char *name,
 	nev->referrer_id = NULL;
 	nev->seq = 0;
 	nev->version = strdup(version);
+	nev->type = NUGU_EVENT_TYPE_DEFAULT;
 
 	return nev;
 }
@@ -261,4 +264,20 @@ EXPORT_API char *nugu_event_generate_payload(NuguEvent *nev)
 				      nev->version, payload);
 
 	return buf;
+}
+
+int nugu_event_set_type(NuguEvent *nev, enum nugu_event_type type)
+{
+	g_return_val_if_fail(nev != NULL, -1);
+
+	nev->type = type;
+
+	return 0;
+}
+
+enum nugu_event_type nugu_event_get_type(NuguEvent *nev)
+{
+	g_return_val_if_fail(nev != NULL, NUGU_EVENT_TYPE_DEFAULT);
+
+	return nev->type;
 }

--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -506,6 +506,7 @@ void ASRAgent::onListeningState(ListeningState state)
             delete rec_event;
 
         rec_event = new CapabilityEvent("Recognize", this);
+        rec_event->setType(NUGU_EVENT_TYPE_WITH_ATTACHMENT);
 
         playsync_manager->onMicOn();
 

--- a/src/capability/capability.cc
+++ b/src/capability/capability.cc
@@ -67,6 +67,11 @@ void CapabilityEvent::setDialogMessageId(const std::string& id)
     nugu_event_set_dialog_id(event, dialog_id.c_str());
 }
 
+void CapabilityEvent::setType(enum nugu_event_type type)
+{
+    nugu_event_set_type(event, type);
+}
+
 void CapabilityEvent::sendEvent(const std::string& context, const std::string& payload)
 {
     if (event == NULL) {

--- a/src/capability/capability.hh
+++ b/src/capability/capability.hh
@@ -37,7 +37,7 @@ public:
 
     std::string getDialogMessageId();
     void setDialogMessageId(const std::string& id);
-
+    void setType(enum nugu_event_type type);
     void sendEvent(const std::string& context, const std::string& payload);
     void sendAttachmentEvent(bool is_end, size_t size, unsigned char* data);
 


### PR DESCRIPTION
Add a type to distinguish between json only event and events with
attachment data in addition to json.

Signed-off-by: Inho Oh <inho.oh@sk.com>