### PR TITLE
change capability_interface namespace

### DIFF
--- a/include/capability/asr_interface.hh
+++ b/include/capability/asr_interface.hh
@@ -17,9 +17,11 @@
 #ifndef __NUGU_ASR_INTERFACE_H__
 #define __NUGU_ASR_INTERFACE_H__
 
-#include <capability/capability_interface.hh>
+#include <clientkit/capability_interface.hh>
 
 namespace NuguCapability {
+
+using namespace NuguClientKit;
 
 /**
  * @file asr_interface.hh

--- a/include/capability/audio_player_interface.hh
+++ b/include/capability/audio_player_interface.hh
@@ -17,10 +17,12 @@
 #ifndef __NUGU_AUDIO_PLAYER_INTERFACE_H__
 #define __NUGU_AUDIO_PLAYER_INTERFACE_H__
 
-#include <capability/capability_interface.hh>
 #include <capability/display_interface.hh>
+#include <clientkit/capability_interface.hh>
 
 namespace NuguCapability {
+
+using namespace NuguClientKit;
 
 /**
  * @file audio_player_interface.hh

--- a/include/capability/capability_factory.hh
+++ b/include/capability/capability_factory.hh
@@ -20,9 +20,11 @@
 #include <functional>
 #include <list>
 
-#include <capability/capability_interface.hh>
+#include <clientkit/capability_interface.hh>
 
 namespace NuguCapability {
+
+using namespace NuguClientKit;
 
 class ASRAgent;
 class TTSAgent;

--- a/include/capability/delegation_interface.hh
+++ b/include/capability/delegation_interface.hh
@@ -17,9 +17,11 @@
 #ifndef __NUGU_DELEGATION_INTERFACE_H__
 #define __NUGU_DELEGATION_INTERFACE_H__
 
-#include <capability/capability_interface.hh>
+#include <clientkit/capability_interface.hh>
 
 namespace NuguCapability {
+
+using namespace NuguClientKit;
 
 /**
  * @file delegation_interface.hh

--- a/include/capability/display_interface.hh
+++ b/include/capability/display_interface.hh
@@ -17,9 +17,11 @@
 #ifndef __NUGU_DISPLAY_INTERFACE_H__
 #define __NUGU_DISPLAY_INTERFACE_H__
 
-#include <capability/capability_interface.hh>
+#include <clientkit/capability_interface.hh>
 
 namespace NuguCapability {
+
+using namespace NuguClientKit;
 
 /**
  * @file display_interface.hh

--- a/include/capability/extension_interface.hh
+++ b/include/capability/extension_interface.hh
@@ -17,9 +17,11 @@
 #ifndef __NUGU_EXTENSION_INTERFACE_H__
 #define __NUGU_EXTENSION_INTERFACE_H__
 
-#include <capability/capability_interface.hh>
+#include <clientkit/capability_interface.hh>
 
 namespace NuguCapability {
+
+using namespace NuguClientKit;
 
 /**
  * @file extension_interface.hh

--- a/include/capability/location_interface.hh
+++ b/include/capability/location_interface.hh
@@ -17,9 +17,11 @@
 #ifndef __NUGU_LOCATION_INTERFACE_H__
 #define __NUGU_LOCATION_INTERFACE_H__
 
-#include <capability/capability_interface.hh>
+#include <clientkit/capability_interface.hh>
 
 namespace NuguCapability {
+
+using namespace NuguClientKit;
 
 /**
  * @file location_interface.hh

--- a/include/capability/mic_interface.hh
+++ b/include/capability/mic_interface.hh
@@ -17,9 +17,11 @@
 #ifndef __NUGU_MIC_INTERFACE_H__
 #define __NUGU_MIC_INTERFACE_H__
 
-#include <capability/capability_interface.hh>
+#include <clientkit/capability_interface.hh>
 
 namespace NuguCapability {
+
+using namespace NuguClientKit;
 
 /**
  * @file mic_interface.hh

--- a/include/capability/speaker_interface.hh
+++ b/include/capability/speaker_interface.hh
@@ -17,9 +17,11 @@
 #ifndef __NUGU_SPEAKER_INTERFACE_H__
 #define __NUGU_SPEAKER_INTERFACE_H__
 
-#include <capability/capability_interface.hh>
+#include <clientkit/capability_interface.hh>
 
 namespace NuguCapability {
+
+using namespace NuguClientKit;
 
 /**
  * @file speaker_interface.hh

--- a/include/capability/system_interface.hh
+++ b/include/capability/system_interface.hh
@@ -17,9 +17,11 @@
 #ifndef __NUGU_SYSTEM_INTERFACE_H__
 #define __NUGU_SYSTEM_INTERFACE_H__
 
-#include <capability/capability_interface.hh>
+#include <clientkit/capability_interface.hh>
 
 namespace NuguCapability {
+
+using namespace NuguClientKit;
 
 /**
  * @file system_interface.hh

--- a/include/capability/text_interface.hh
+++ b/include/capability/text_interface.hh
@@ -17,9 +17,11 @@
 #ifndef __NUGU_TEXT_INTERFACE_H__
 #define __NUGU_TEXT_INTERFACE_H__
 
-#include <capability/capability_interface.hh>
+#include <clientkit/capability_interface.hh>
 
 namespace NuguCapability {
+
+using namespace NuguClientKit;
 
 /**
  * @file text_interface.hh

--- a/include/capability/tts_interface.hh
+++ b/include/capability/tts_interface.hh
@@ -17,9 +17,11 @@
 #ifndef __NUGU_TTS_INTERFACE_H__
 #define __NUGU_TTS_INTERFACE_H__
 
-#include <capability/capability_interface.hh>
+#include <clientkit/capability_interface.hh>
 
 namespace NuguCapability {
+
+using namespace NuguClientKit;
 
 /**
  * @file tts_interface.hh

--- a/include/clientkit/capability_interface.hh
+++ b/include/clientkit/capability_interface.hh
@@ -17,22 +17,20 @@
 #ifndef __NUGU_CAPABILITY_INTERFACE_H__
 #define __NUGU_CAPABILITY_INTERFACE_H__
 
+#include <json/json.h>
 #include <list>
 #include <string>
 
 #include <base/nugu_directive.h>
-#include <capability/capability_observer.hh>
+#include <clientkit/capability_observer.hh>
 #include <clientkit/nugu_core_container_interface.hh>
-#include <json/json.h>
 
-namespace NuguCapability {
-
-using namespace NuguClientKit;
+namespace NuguClientKit {
 
 /**
  * @file capability_interface.hh
  * @defgroup CapabilityInterface CapabilityInterface
- * @ingroup SDKNuguCapability
+ * @ingroup SDKNuguClientKit
  * @brief capability interface
  *
  * An abstract object that a capability agent must perform in common.
@@ -161,6 +159,6 @@ public:
  * @}
  */
 
-} // NuguCapability
+} // NuguClientKit
 
 #endif /* __NUGU_CAPABILITY_INTERFACE_H__ */

--- a/include/clientkit/capability_observer.hh
+++ b/include/clientkit/capability_observer.hh
@@ -19,12 +19,12 @@
 
 #include <string>
 
-namespace NuguCapability {
+namespace NuguClientKit {
 
 /**
  * @file capability_observer.hh
  * @defgroup CapabilityInterface CapabilityObserver
- * @ingroup SDKNuguCapability
+ * @ingroup SDKNuguClientKit
  * @brief Capability observer interface
  *
  *
@@ -59,6 +59,6 @@ public:
  * @}
  */
 
-} // NuguCapability
+} // NuguClientKit
 
 #endif /* __NUGU_CAPABILITY_OBSERVER_H__ */

--- a/include/clientkit/nugu_client.hh
+++ b/include/clientkit/nugu_client.hh
@@ -20,7 +20,7 @@
 #include <memory>
 #include <string>
 
-#include <capability/capability_interface.hh>
+#include <clientkit/capability_interface.hh>
 #include <clientkit/nugu_client_listener.hh>
 #include <clientkit/nugu_core_container_interface.hh>
 

--- a/include/clientkit/nugu_client_listener.hh
+++ b/include/clientkit/nugu_client_listener.hh
@@ -17,11 +17,9 @@
 #ifndef __NUGU_CLIENT_LISTENER_H__
 #define __NUGU_CLIENT_LISTENER_H__
 
-#include <capability/capability_observer.hh>
+#include <clientkit/capability_observer.hh>
 
 namespace NuguClientKit {
-
-using namespace NuguCapability;
 
 /**
  * @file nugu_client_listener.hh
@@ -35,7 +33,7 @@ using namespace NuguCapability;
 
 /**
  * @brief nugu client listener interface
- * @see NuguInterface::ICapabilityObserver
+ * @see ICapabilityObserver
  */
 class INuguClientListener : public ICapabilityObserver {
 public:

--- a/src/capability/audio_player_agent.hh
+++ b/src/capability/audio_player_agent.hh
@@ -21,7 +21,6 @@
 #include "capability.hh"
 #include "capability/audio_player_interface.hh"
 #include "capability/display_interface.hh"
-#include "clientkit/media_player_interface.hh"
 #include "display_render_assembly.hh"
 
 namespace NuguCapability {

--- a/src/capability/capability.hh
+++ b/src/capability/capability.hh
@@ -23,9 +23,11 @@
 
 #include "base/nugu_event.h"
 #include "base/nugu_network_manager.h"
-#include "capability/capability_interface.hh"
+#include "clientkit/capability_interface.hh"
 
 namespace NuguCapability {
+
+using namespace NuguClientKit;
 
 class Capability;
 class CapabilityEvent {

--- a/src/clientkit/nugu_client_impl.cc
+++ b/src/clientkit/nugu_client_impl.cc
@@ -21,10 +21,8 @@
 #include "base/nugu_equeue.h"
 #include "base/nugu_log.h"
 #include "base/nugu_plugin.h"
-
 #include "capability/capability_factory.hh"
 #include "capability/system_interface.hh"
-
 #include "core/audio_recorder_manager.hh"
 #include "core/capability_manager_helper.hh"
 
@@ -33,6 +31,7 @@
 namespace NuguClientKit {
 
 using namespace NuguCore;
+using namespace NuguCapability;
 
 NuguClientImpl::NuguClientImpl()
 {

--- a/src/clientkit/nugu_client_impl.hh
+++ b/src/clientkit/nugu_client_impl.hh
@@ -20,7 +20,7 @@
 #include <map>
 #include <memory>
 
-#include "capability/capability_interface.hh"
+#include "clientkit/capability_interface.hh"
 #include "clientkit/nugu_client_listener.hh"
 #include "core/nugu_core_container.hh"
 

--- a/src/core/capability_manager.hh
+++ b/src/core/capability_manager.hh
@@ -22,8 +22,7 @@
 
 #include "base/nugu_directive_sequencer.h"
 #include "base/nugu_focus.h"
-#include "capability/capability_interface.hh"
-
+#include "clientkit/capability_interface.hh"
 #include "playsync_manager.hh"
 
 namespace NuguCore {

--- a/src/core/capability_manager_helper.hh
+++ b/src/core/capability_manager_helper.hh
@@ -17,11 +17,11 @@
 #ifndef __NUGU_CAPABILITY_MANAGER_HELPER_H__
 #define __NUGU_CAPABILITY_MANAGER_HELPER_H__
 
-#include "capability/capability_interface.hh"
+#include "clientkit/capability_interface.hh"
 
 namespace NuguCore {
 
-using namespace NuguCapability;
+using namespace NuguClientKit;
 
 class CapabilityManagerHelper {
 public:

--- a/src/core/media_player.hh
+++ b/src/core/media_player.hh
@@ -20,7 +20,6 @@
 #include <string>
 
 #include "base/nugu_media.h"
-
 #include "clientkit/media_player_interface.hh"
 
 namespace NuguCore {

--- a/src/core/playsync_manager.hh
+++ b/src/core/playsync_manager.hh
@@ -21,12 +21,11 @@
 #include <map>
 
 #include "base/nugu_timer.h"
-#include "capability/capability_interface.hh"
-#include "clientkit/playsync_manager_interface.hh"
+#include "clientkit/capability_interface.hh"
 
 namespace NuguCore {
 
-using namespace NuguCapability;
+using namespace NuguClientKit;
 
 class PlaySyncManager : public IPlaySyncManager {
 public:


### PR DESCRIPTION
Because ICapabilityInterface which is the most base class
of All CapabilityAgents has located in NuguCapability namespace,
NuguSample, NuguClientKit, NuguCore all has dependent it.

As it's not appropriate, change namespace to NuguClientKit
for reducing dependency, and increasing usage.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>