### PR TITLE
network: add /v1/events API support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,15 @@ ADD_DEFINITIONS(
 
 	# Turn on the colorful log message
 	-DCONFIG_LOG_ANSICOLOR
+
+	# Environment variable names
+	# - Please comment out the following definition to avoid overwriting
+	#   the value by setting an environment variable. (e.g. Production)
+	-DNUGU_ENV_LOG="NUGU_LOG"
+	-DNUGU_ENV_LOG_MODULE="NUGU_LOG_MODULE"
+	-DNUGU_ENV_NETWORK_REGISTRY_SERVER="NUGU_REGISTRY_SERVER"
+	-DNUGU_ENV_NETWORK_USERAGENT="NUGU_USERAGENT"
+	-DNUGU_ENV_NETWORK_USE_EVENTS="NUGU_NETWORK_USE_EVENTS"
 )
 
 # Global include directories

--- a/include/base/nugu_network_manager.h
+++ b/include/base/nugu_network_manager.h
@@ -188,6 +188,16 @@ int nugu_network_manager_send_event_data(NuguEvent *nev, int is_end,
 					 size_t length, unsigned char *data);
 
 /**
+ * @brief Force close the NUGU_EVENT_TYPE_WITH_ATTACHMENT type event.
+ * @param[in] nev event object
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ * @see nugu_event_set_type()
+ */
+int nugu_network_manager_force_close_event(NuguEvent *nev);
+
+/**
  * @brief Initialize the network manager
  * @return result
  * @retval 0 success

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -5,6 +5,7 @@ ADD_LIBRARY(objhttp2 OBJECT
 	network/http2/http2_network.c
 	network/http2/v1_event.c
 	network/http2/v1_event_attachment.c
+	network/http2/v1_events.c
 	network/http2/v1_directives.cc
 	network/http2/v1_ping.c
 	network/http2/v1_policies.cc

--- a/src/base/network/dg_server.h
+++ b/src/base/network/dg_server.h
@@ -51,6 +51,7 @@ void dg_server_reset_retry_count(DGServer *server);
 int dg_server_send_event(DGServer *server, NuguEvent *nev);
 int dg_server_send_attachment(DGServer *server, NuguEvent *nev, int is_end,
 			      size_t length, unsigned char *data);
+int dg_server_force_close_event(DGServer *server, NuguEvent *nev);
 
 #ifdef __cplusplus
 }

--- a/src/base/network/http2/v1_events.c
+++ b/src/base/network/http2/v1_events.c
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string.h>
+#include <stdlib.h>
+
+#include <glib.h>
+
+#include "base/nugu_log.h"
+#include "base/nugu_equeue.h"
+
+#include "http2_request.h"
+#include "v1_events.h"
+
+#define CRLF "\r\n"
+
+#define PART_HEADER_JSON                                                       \
+	"Content-Disposition: form-data; name=\"event\"" CRLF                  \
+	"Content-Type: application/json" CRLF CRLF
+
+#define PART_HEADER_BINARY_FMT                                                 \
+	"Content-Disposition: form-data; name=\"attachment\";"                 \
+	" filename=\"%d;%s\"" CRLF                                             \
+	"Content-Type: application/octet-stream" CRLF                          \
+	"Content-Length: %zd" CRLF CRLF
+
+struct _v1_events {
+	HTTP2Request *req;
+	char *boundary;
+};
+
+/* invoked in a thread loop */
+static void _on_finish(HTTP2Request *req, void *userdata)
+{
+	int code;
+
+	code = http2_request_get_response_code(req);
+	if (code == HTTP2_RESPONSE_OK)
+		return;
+
+	nugu_error("event send failed: %d", code);
+
+	if (code == HTTP2_RESPONSE_AUTHFAIL || code == HTTP2_RESPONSE_FORBIDDEN)
+		nugu_equeue_push(NUGU_EQUEUE_TYPE_INVALID_TOKEN, NULL);
+	else
+		nugu_equeue_push(NUGU_EQUEUE_TYPE_SEND_EVENT_FAILED, NULL);
+}
+
+V1Events *v1_events_new(const char *host, HTTP2Network *net)
+{
+	char *tmp;
+	struct _v1_events *event;
+	int ret;
+
+	g_return_val_if_fail(host != NULL, NULL);
+	g_return_val_if_fail(net != NULL, NULL);
+
+	event = calloc(1, sizeof(struct _v1_events));
+	if (!event) {
+		error_nomem();
+		return NULL;
+	}
+
+	tmp = "this-is-a-boundary";
+	event->boundary = g_strdup_printf("%s--%s", CRLF, tmp);
+
+	event->req = http2_request_new();
+	http2_request_set_method(event->req, HTTP2_REQUEST_METHOD_POST);
+	http2_request_set_content_type(
+		event->req, HTTP2_REQUEST_CONTENT_TYPE_MULTIPART, tmp);
+
+	/* Set maximum timeout to 20 seconds */
+	http2_request_set_timeout(event->req, 20);
+
+	tmp = g_strdup_printf("%s/v1/events", host);
+	http2_request_set_url(event->req, tmp);
+	g_free(tmp);
+
+	http2_request_set_finish_callback(event->req, _on_finish, NULL);
+
+	ret = http2_network_add_request(net, event->req);
+	if (ret < 0) {
+		nugu_error("http2_network_add_request() failed: %d", ret);
+		http2_request_unref(event->req);
+		event->req = NULL;
+		v1_events_free(event);
+		return NULL;
+	}
+
+	return event;
+}
+
+void v1_events_free(V1Events *event)
+{
+	g_return_if_fail(event != NULL);
+
+	if (event->boundary)
+		free(event->boundary);
+
+	if (event->req)
+		http2_request_unref(event->req);
+
+	memset(event, 0, sizeof(V1Events));
+	free(event);
+}
+
+int v1_events_send_json(V1Events *event, const char *data, size_t length)
+{
+	g_return_val_if_fail(event != NULL, -1);
+
+	http2_request_lock_send_data(event->req);
+	http2_request_add_send_data(event->req,
+				    (unsigned char *)event->boundary,
+				    strlen(event->boundary));
+	http2_request_add_send_data(event->req, (unsigned char *)CRLF, 2);
+	http2_request_add_send_data(event->req,
+				    (unsigned char *)PART_HEADER_JSON,
+				    strlen(PART_HEADER_JSON));
+	http2_request_add_send_data(event->req, (const unsigned char *)data,
+				    length);
+	http2_request_add_send_data(event->req, (unsigned char *)CRLF, 2);
+	http2_request_unlock_send_data(event->req);
+
+	http2_request_resume(event->req);
+
+	return 0;
+}
+
+int v1_events_send_binary(V1Events *event, int seq, int is_end, size_t length,
+			  unsigned char *data)
+{
+	char *part_header;
+
+	g_return_val_if_fail(event != NULL, -1);
+
+	part_header =
+		g_strdup_printf(PART_HEADER_BINARY_FMT, seq,
+				(is_end == 1) ? "end" : "continued", length);
+
+	http2_request_lock_send_data(event->req);
+	http2_request_add_send_data(event->req,
+				    (unsigned char *)event->boundary,
+				    strlen(event->boundary));
+	http2_request_add_send_data(event->req, (unsigned char *)CRLF, 2);
+	http2_request_add_send_data(event->req, (unsigned char *)part_header,
+				    strlen(part_header));
+
+	if (data != NULL && length > 0) {
+		http2_request_add_send_data(
+			event->req, (const unsigned char *)data, length);
+		http2_request_add_send_data(event->req, (unsigned char *)CRLF,
+					    2);
+	}
+
+	http2_request_unlock_send_data(event->req);
+
+	g_free(part_header);
+
+	http2_request_resume(event->req);
+
+	return 0;
+}
+
+int v1_events_send_done(V1Events *event)
+{
+	g_return_val_if_fail(event != NULL, -1);
+
+	http2_request_lock_send_data(event->req);
+	http2_request_add_send_data(event->req,
+				    (unsigned char *)event->boundary,
+				    strlen(event->boundary));
+	http2_request_add_send_data(event->req, (unsigned char *)"--", 2);
+	http2_request_add_send_data(event->req, (unsigned char *)CRLF, 2);
+	http2_request_close_send_data(event->req);
+	http2_request_unlock_send_data(event->req);
+
+	http2_request_resume(event->req);
+
+	return 0;
+}

--- a/src/base/network/http2/v1_events.h
+++ b/src/base/network/http2/v1_events.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __HTTP2_V1_EVENTS_H__
+#define __HTTP2_V1_EVENTS_H__
+
+#include "http2/http2_network.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct _v1_events V1Events;
+
+V1Events *v1_events_new(const char *host, HTTP2Network *net);
+void v1_events_free(V1Events *event);
+
+int v1_events_send_json(V1Events *event, const char *data, size_t length);
+int v1_events_send_binary(V1Events *event, int seq, int is_end, size_t length,
+			  unsigned char *data);
+int v1_events_send_done(V1Events *event);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/base/nugu_log.c
+++ b/src/base/nugu_log.c
@@ -82,11 +82,12 @@ static struct _log_level_info {
 	[NUGU_LOG_LEVEL_DEBUG] = { 'D', LOG_DEBUG }
 };
 
+#ifdef NUGU_ENV_LOG
 static void _log_check_override_system(void)
 {
 	const char *env;
 
-	env = getenv("NUGU_LOG");
+	env = getenv(NUGU_ENV_LOG);
 	if (!env)
 		return;
 
@@ -101,7 +102,9 @@ static void _log_check_override_system(void)
 		_log_system = NUGU_LOG_SYSTEM_NONE;
 	}
 }
+#endif
 
+#ifdef NUGU_ENV_LOG_MODULE
 static void _log_check_override_module(void)
 {
 	gchar **modules = NULL;
@@ -110,7 +113,7 @@ static void _log_check_override_module(void)
 	gint i;
 	unsigned int bitset = 0;
 
-	env = getenv("NUGU_LOG_MODULE");
+	env = getenv(NUGU_ENV_LOG_MODULE);
 	if (!env)
 		return;
 
@@ -138,6 +141,7 @@ static void _log_check_override_module(void)
 	nugu_log_set_modules(bitset);
 	g_strfreev(modules);
 }
+#endif
 
 static void _log_check_override(void)
 {
@@ -146,8 +150,13 @@ static void _log_check_override(void)
 
 	_log_override_checked = 1;
 
+#ifdef NUGU_ENV_LOG
 	_log_check_override_system();
+#endif
+
+#ifdef NUGU_ENV_LOG_MODULE
 	_log_check_override_module();
+#endif
 }
 
 static int _log_make_prefix(char *prefix, enum nugu_log_level level,

--- a/src/base/nugu_network_manager.c
+++ b/src/base/nugu_network_manager.c
@@ -748,6 +748,28 @@ EXPORT_API int nugu_network_manager_send_event(NuguEvent *nev)
 	return dg_server_send_event(_network->server, nev);
 }
 
+EXPORT_API int nugu_network_manager_force_close_event(NuguEvent *nev)
+{
+	g_return_val_if_fail(nev != NULL, -1);
+
+	if (nugu_event_get_type(nev) == NUGU_EVENT_TYPE_DEFAULT) {
+		nugu_error("not supported event type");
+		return -1;
+	}
+
+	if (!_network) {
+		nugu_error("network manager not initialized");
+		return -1;
+	}
+
+	if (!_network->server) {
+		nugu_error("not connected");
+		return -1;
+	}
+
+	return dg_server_force_close_event(_network->server, nev);
+}
+
 EXPORT_API int nugu_network_manager_send_event_data(NuguEvent *nev, int is_end,
 						    size_t length,
 						    unsigned char *data)
@@ -835,7 +857,9 @@ const char *nugu_network_manager_peek_token(void)
 
 int nugu_network_manager_set_registry_url(const char *urlname)
 {
+#ifdef NUGU_ENV_NETWORK_REGISTRY_SERVER
 	char *override_value;
+#endif
 
 	if (!_network) {
 		nugu_error("network manager not initialized");
@@ -850,11 +874,15 @@ int nugu_network_manager_set_registry_url(const char *urlname)
 	if (_network->registry_url)
 		free(_network->registry_url);
 
-	override_value = getenv("NUGU_REGISTRY_SERVER");
+#ifdef NUGU_ENV_NETWORK_REGISTRY_SERVER
+	override_value = getenv(NUGU_ENV_NETWORK_REGISTRY_SERVER);
 	if (override_value)
 		_network->registry_url = strdup(override_value);
 	else
 		_network->registry_url = strdup(urlname);
+#else
+	_network->registry_url = strdup(urlname);
+#endif
 
 	return 0;
 }
@@ -871,7 +899,9 @@ const char *nugu_network_manager_peek_registry_url(void)
 
 int nugu_network_manager_set_useragent(const char *uagent)
 {
+#ifdef NUGU_ENV_NETWORK_USERAGENT
 	char *override_value;
+#endif
 
 	if (!_network) {
 		nugu_error("network manager not initialized");
@@ -886,11 +916,15 @@ int nugu_network_manager_set_useragent(const char *uagent)
 	if (_network->useragent)
 		free(_network->useragent);
 
-	override_value = getenv("NUGU_USERAGENT");
+#ifdef NUGU_ENV_NETWORK_USERAGENT
+	override_value = getenv(NUGU_ENV_NETWORK_USERAGENT);
 	if (override_value)
 		_network->useragent = strdup(override_value);
 	else
 		_network->useragent = strdup(uagent);
+#else
+	_network->useragent = strdup(uagent);
+#endif
 
 	return 0;
 }

--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -548,6 +548,9 @@ void ASRAgent::onListeningState(ListeningState state)
         nugu_dbg("ListeningState::TIMEOUT");
         nugu_info("time out");
 
+        if (rec_event)
+            rec_event->forceClose();
+
         stopRecognition();
         sendEventListenTimeout();
         releaseASRFocus(false, ASRError::LISTEN_TIMEOUT);

--- a/src/capability/capability.cc
+++ b/src/capability/capability.cc
@@ -72,6 +72,14 @@ void CapabilityEvent::setType(enum nugu_event_type type)
     nugu_event_set_type(event, type);
 }
 
+void CapabilityEvent::forceClose()
+{
+    if (nugu_event_get_type(event) == NUGU_EVENT_TYPE_DEFAULT)
+        return;
+
+    nugu_network_manager_force_close_event(event);
+}
+
 void CapabilityEvent::sendEvent(const std::string& context, const std::string& payload)
 {
     if (event == NULL) {

--- a/src/capability/capability.hh
+++ b/src/capability/capability.hh
@@ -40,6 +40,7 @@ public:
     std::string getDialogMessageId();
     void setDialogMessageId(const std::string& id);
     void setType(enum nugu_event_type type);
+    void forceClose();
     void sendEvent(const std::string& context, const std::string& payload);
     void sendAttachmentEvent(bool is_end, size_t size, unsigned char* data);
 


### PR DESCRIPTION
add POST to /v1/events API to support multipart based event.

There are 2 ways to send the event to server
- /v1/event (json) with /v1/event-attachment (binary)
- /v1/events (multipart)

The default option is /v1/event with /v1/event-attachment. But, it
can be changed by setting the environment variable below.

    $ export NUGU_NETWORK_USE_EVENTS=1

Signed-off-by: Inho Oh <inho.oh@sk.com>