### PR TITLE
change method to add capability

### DIFF
--- a/examples/standalone/capability/speaker_listener.cc
+++ b/examples/standalone/capability/speaker_listener.cc
@@ -55,12 +55,12 @@ void SpeakerListener::setSpeakerHandler(ISpeakerHandler* speaker)
     speaker_handler = speaker;
 }
 
-void SpeakerListener::setVolumeNuguSpeaker(nugu_volume_func vns)
+void SpeakerListener::setVolumeNuguSpeakerCallback(nugu_volume_func vns)
 {
     nugu_speaker_volume = std::move(vns);
 }
 
-void SpeakerListener::setMuteNuguSpeaker(nugu_mute_func mns)
+void SpeakerListener::setMuteNuguSpeakerCallback(nugu_mute_func mns)
 {
     nugu_speaker_mute = std::move(mns);
 }

--- a/examples/standalone/capability/speaker_listener.hh
+++ b/examples/standalone/capability/speaker_listener.hh
@@ -33,8 +33,8 @@ public:
     void requestSetMute(SpeakerType type, bool mute) override;
 
     void setSpeakerHandler(ISpeakerHandler* speaker);
-    void setVolumeNuguSpeaker(nugu_volume_func vns);
-    void setMuteNuguSpeaker(nugu_mute_func mns);
+    void setVolumeNuguSpeakerCallback(nugu_volume_func vns);
+    void setMuteNuguSpeakerCallback(nugu_mute_func mns);
 
 private:
     ISpeakerHandler* speaker_handler;

--- a/include/capability/capability_factory.hh
+++ b/include/capability/capability_factory.hh
@@ -42,14 +42,6 @@ class CapabilityFactory {
 public:
     CapabilityFactory() = delete;
 
-    struct Element {
-        std::string name;
-        bool is_default;
-        std::function<ICapabilityInterface*()> creator;
-    };
-
-    static const std::list<Element>& getCapabilityList();
-
     template <typename T, typename V, typename... Ts>
     static V* makeCapability(Ts&&... params);
 };

--- a/include/clientkit/nugu_client.hh
+++ b/include/clientkit/nugu_client.hh
@@ -55,15 +55,11 @@ public:
         virtual ~CapabilityBuilder();
 
         /**
-         * @brief Add capabilities to create in the capabilitybuilder. Capabilitybuilder support to insert customized capability agents.
-         * @param[in] capability agent name
-         * @param[in] clistener capability listener
+         * @brief Add capability instance. It could create from CapabilityFactory or by self as inhering ICapabilityInterface
          * @param[in] cap_instance capability interface
          * @return CapabilityBuilder object
          */
-        CapabilityBuilder* add(const std::string& cname,
-            ICapabilityListener* clistener = nullptr,
-            ICapabilityInterface* cap_instance = nullptr);
+        CapabilityBuilder* add(ICapabilityInterface* cap_instance);
 
         /**
          * @brief Construct with capabilities added to CapabilityBuilder.

--- a/src/capability/capability_factory.cc
+++ b/src/capability/capability_factory.cc
@@ -30,36 +30,6 @@
 
 namespace NuguCapability {
 
-// for restricting access to only this file
-namespace {
-    template <class T>
-    ICapabilityInterface* create()
-    {
-        return new T;
-    }
-}
-
-using CapabilityElement = CapabilityFactory::Element;
-
-const std::list<CapabilityElement>& CapabilityFactory::getCapabilityList()
-{
-    static std::list<CapabilityElement> CAPABILITY_LIST {
-        CapabilityElement { "ASR", true, &create<ASRAgent> },
-        CapabilityElement { "TTS", true, &create<TTSAgent> },
-        CapabilityElement { "AudioPlayer", true, &create<AudioPlayerAgent> },
-        CapabilityElement { "System", true, &create<SystemAgent> },
-        CapabilityElement { "Display", false, &create<DisplayAgent> },
-        CapabilityElement { "Extension", false, &create<ExtensionAgent> },
-        CapabilityElement { "Text", false, &create<TextAgent> },
-        CapabilityElement { "Delegation", false, &create<DelegationAgent> },
-        CapabilityElement { "Location", false, &create<LocationAgent> },
-        CapabilityElement { "Speaker", false, &create<SpeakerAgent> },
-        CapabilityElement { "Mic", false, &create<MicAgent> }
-    };
-
-    return CAPABILITY_LIST;
-}
-
 template <typename T, typename V, typename... Ts>
 V* CapabilityFactory::makeCapability(Ts&&... params)
 {
@@ -69,13 +39,13 @@ V* CapabilityFactory::makeCapability(Ts&&... params)
 template IASRHandler* CapabilityFactory::makeCapability<ASRAgent, IASRHandler>();
 template ITTSHandler* CapabilityFactory::makeCapability<TTSAgent, ITTSHandler>();
 template IAudioPlayerHandler* CapabilityFactory::makeCapability<AudioPlayerAgent, IAudioPlayerHandler>();
-template ISpeakerHandler* CapabilityFactory::makeCapability<SystemAgent, ISpeakerHandler>();
+template ISystemHandler* CapabilityFactory::makeCapability<SystemAgent, ISystemHandler>();
 template IDisplayHandler* CapabilityFactory::makeCapability<DisplayAgent, IDisplayHandler>();
 template IExtensionHandler* CapabilityFactory::makeCapability<ExtensionAgent, IExtensionHandler>();
 template ITextHandler* CapabilityFactory::makeCapability<TextAgent, ITextHandler>();
 template IDelegationHandler* CapabilityFactory::makeCapability<DelegationAgent, IDelegationHandler>();
 template ICapabilityInterface* CapabilityFactory::makeCapability<LocationAgent, ICapabilityInterface>();
 template ISpeakerHandler* CapabilityFactory::makeCapability<SpeakerAgent, ISpeakerHandler>();
-template IMicHandler* CapabilityFactory::makeCapability<SpeakerAgent, IMicHandler>();
+template IMicHandler* CapabilityFactory::makeCapability<MicAgent, IMicHandler>();
 
 } // NuguCapability

--- a/src/clientkit/nugu_client.cc
+++ b/src/clientkit/nugu_client.cc
@@ -29,9 +29,9 @@ NuguClient::CapabilityBuilder::~CapabilityBuilder()
 {
 }
 
-NuguClient::CapabilityBuilder* NuguClient::CapabilityBuilder::add(const std::string& cname, ICapabilityListener* clistener, ICapabilityInterface* cap_instance)
+NuguClient::CapabilityBuilder* NuguClient::CapabilityBuilder::add(ICapabilityInterface* cap_instance)
 {
-    client_impl->registerCapability(cname, std::make_pair(cap_instance, clistener));
+    client_impl->registerCapability(cap_instance);
 
     return this;
 }

--- a/src/clientkit/nugu_client_impl.hh
+++ b/src/clientkit/nugu_client_impl.hh
@@ -36,7 +36,7 @@ public:
     void setListener(INuguClientListener* listener);
     INuguClientListener* getListener();
     void setWakeupWord(const std::string& wakeup_word);
-    void registerCapability(const std::string& cname, std::pair<ICapabilityInterface*, ICapabilityListener*> capability);
+    void registerCapability(ICapabilityInterface* capability);
     int create(void);
     bool initialize(void);
     void deInitialize(void);
@@ -51,7 +51,7 @@ public:
 private:
     int createCapabilities(void);
 
-    using CapabilityMap = std::map<std::string, std::pair<ICapabilityInterface*, ICapabilityListener*>>;
+    using CapabilityMap = std::map<std::string, ICapabilityInterface*>;
 
     CapabilityMap icapability_map;
     INuguClientListener* listener = nullptr;


### PR DESCRIPTION
It change the method of adding capability which get only
capability instance to parameter. So, if you want to set
related listener or set attribute, you have to set before
adding to NuguClient.

ex)
ISystemHandle* system = CapabilityFactory::makeCapability<SystemAgent, ISystemHandler>();
NuguClient nugu_client = new NuguClient();
nugu_client->getCapabilityBuilder()
     ->add(system)
     ->construct();

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>