### PR TITLE
network: fix to use random boundary for /v1/events

### DIFF
--- a/include/base/nugu_uuid.h
+++ b/include/base/nugu_uuid.h
@@ -94,13 +94,23 @@ int nugu_uuid_convert_timespec(const unsigned char *bytes, size_t bytes_len,
 			       struct timespec *out_time);
 
 /**
+ * @brief Generate random bytes and fill to destination buffer
+ * @param[in] dest destination buffer
+ * @param[in] dest_len length of buffer
+ * @return Result
+ * @retval 0 Success
+ * @retval -1 Failure
+ */
+int nugu_uuid_fill_random(unsigned char *dest, size_t dest_len);
+
+/**
  * @brief Fill to output buffer with NUGU UUID format using parameters
  * @param[in] time timestamp information
  * @param[in] hash hash value(e.g. SHA1(token))
  * @param[in] hash_len length of hash value
  * @param[out] out memory allocated output buffer
  * @param[in] out_len size of output buffer
- * @return Result of conversion success or failure
+ * @return Result
  * @retval 0 Success
  * @retval -1 Failure
  */

--- a/src/base/nugu_uuid.c
+++ b/src/base/nugu_uuid.c
@@ -32,6 +32,17 @@
 static const char *_cached_seed;
 static unsigned char _cached_hash[MAX_HASH_SIZE];
 
+EXPORT_API int nugu_uuid_fill_random(unsigned char *dest, size_t dest_len)
+{
+	g_return_val_if_fail(dest != NULL, -1);
+	g_return_val_if_fail(dest_len > 0, -1);
+
+	RAND_status();
+	RAND_bytes(dest, dest_len);
+
+	return 0;
+}
+
 EXPORT_API int nugu_uuid_convert_base16(const unsigned char *bytes,
 					size_t bytes_len, char *out,
 					size_t out_len)
@@ -149,9 +160,7 @@ EXPORT_API char *nugu_uuid_generate_time(void)
 	seed = nugu_network_manager_peek_token();
 	if (seed == NULL) {
 		_cached_seed = NULL;
-
-		RAND_status();
-		RAND_bytes(_cached_hash, sizeof(_cached_hash));
+		nugu_uuid_fill_random(_cached_hash, sizeof(_cached_hash));
 	} else if (seed != _cached_seed) {
 		unsigned char mdbuf[SHA_DIGEST_LENGTH];
 


### PR DESCRIPTION
Fix the pre-defined boundary to random boundary.

Signed-off-by: Inho Oh <inho.oh@sk.com>