### PR TITLE
add capability injection example

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -5,6 +5,7 @@ ADD_SUBDIRECTORY(oob_setup)
 ADD_SUBDIRECTORY(standalone)
 ADD_SUBDIRECTORY(simple_text)
 ADD_SUBDIRECTORY(simple_asr)
+ADD_SUBDIRECTORY(capability_injection)
 
 # A shell script that executes a program using the token information
 # generated in the OAuth2 example.

--- a/examples/capability_injection/CMakeLists.txt
+++ b/examples/capability_injection/CMakeLists.txt
@@ -1,0 +1,7 @@
+FILE(GLOB_RECURSE SRC *.cc)
+ADD_EXECUTABLE(nugu_capability_injection ${SRC})
+TARGET_LINK_LIBRARIES(nugu_capability_injection
+	${pkgs_LDFLAGS}
+	-L${CMAKE_BINARY_DIR}/src -lnugu)
+ADD_DEPENDENCIES(nugu_capability_injection libnugu)
+INSTALL(TARGETS nugu_capability_injection RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/examples/capability_injection/battery_agent.cc
+++ b/examples/capability_injection/battery_agent.cc
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+#include <iostream>
+
+#include "battery_agent.hh"
+
+static const char* CAPABILITY_NAME = "Battery";
+static const char* CAPABILITY_VERSION = "1.0";
+
+void BatteryAgent::setBatteryLevel(const std::string& level)
+{
+    battery_level = level;
+}
+
+void BatteryAgent::setCharging(bool charging)
+{
+    battery_charging = charging;
+}
+
+void BatteryAgent::setNuguCoreContainer(INuguCoreContainer* core_container)
+{
+    this->core_container = core_container;
+}
+
+void BatteryAgent::initialize()
+{
+    // TODO : implements service logic
+}
+
+std::string BatteryAgent::getName()
+{
+    return CAPABILITY_NAME;
+}
+
+std::string BatteryAgent::getVersion()
+{
+    return CAPABILITY_VERSION;
+}
+
+void BatteryAgent::processDirective(NuguDirective* ndir)
+{
+    // TODO : implements service logic
+}
+
+void BatteryAgent::updateInfoForContext(Json::Value& ctx)
+{
+    Json::Value battery;
+
+    battery["version"] = getVersion();
+    battery["level"] = battery_level;
+    battery["charging"] = battery_charging;
+    ctx[getName()] = battery;
+
+    std::cout << ">> Collecting BatteryAgent Context Info : " << battery << std::endl;
+}
+
+void BatteryAgent::receiveCommand(const std::string& from, const std::string& command, const std::string& param)
+{
+    // TODO : implements service logic
+}
+
+void BatteryAgent::receiveCommandAll(const std::string& command, const std::string& param)
+{
+    // TODO : implements service logic
+}
+
+void BatteryAgent::getProperty(const std::string& property, std::string& value)
+{
+    // TODO : implements service logic
+}
+
+void BatteryAgent::getProperties(const std::string& property, std::list<std::string>& values)
+{
+    // TODO : implements service logic
+}
+
+void BatteryAgent::setCapabilityListener(ICapabilityListener* clistener)
+{
+    if (clistener)
+        battery_listener = dynamic_cast<IBatteryListener*>(clistener);
+}
+
+void BatteryAgent::registerObserver(ICapabilityObserver* observer)
+{
+    auto iterator = std::find(observers.begin(), observers.end(), observer);
+
+    if (iterator == observers.end())
+        observers.emplace_back(observer);
+}
+
+void BatteryAgent::removeObserver(ICapabilityObserver* observer)
+{
+    auto iterator = std::find(observers.begin(), observers.end(), observer);
+
+    if (iterator != observers.end())
+        observers.erase(iterator);
+}
+
+void BatteryAgent::notifyObservers(CapabilitySignal signal, void* data)
+{
+    for (auto observer : observers)
+        observer->notify(getName(), signal, data);
+}

--- a/examples/capability_injection/battery_agent.hh
+++ b/examples/capability_injection/battery_agent.hh
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NUGU_BATTERY_AGENT_H__
+#define __NUGU_BATTERY_AGENT_H__
+
+#include <vector>
+
+#include <clientkit/capability_interface.hh>
+
+using namespace NuguClientKit;
+
+class IBatteryListener : public ICapabilityListener {
+public:
+    virtual ~IBatteryListener() = default;
+};
+
+class BatteryAgent : public ICapabilityInterface {
+public:
+    void setBatteryLevel(const std::string& level);
+    void setCharging(bool charging);
+
+    // implements ICapabilityInterface
+    void setNuguCoreContainer(INuguCoreContainer* core_container) override;
+    void initialize() override;
+    std::string getName() override;
+    std::string getVersion() override;
+    void processDirective(NuguDirective* ndir) override;
+    void updateInfoForContext(Json::Value& ctx) override;
+    void receiveCommand(const std::string& from, const std::string& command, const std::string& param) override;
+    void receiveCommandAll(const std::string& command, const std::string& param) override;
+    void getProperty(const std::string& property, std::string& value) override;
+    void getProperties(const std::string& property, std::list<std::string>& values) override;
+    void setCapabilityListener(ICapabilityListener* clistener) override;
+    void registerObserver(ICapabilityObserver* observer) override;
+    void removeObserver(ICapabilityObserver* observer) override;
+    void notifyObservers(CapabilitySignal signal, void* data) override;
+
+private:
+    std::string battery_level = "10";
+    bool battery_charging = false;
+
+    INuguCoreContainer* core_container = nullptr;
+    IBatteryListener* battery_listener = nullptr;
+    std::vector<ICapabilityObserver*> observers;
+};
+
+#endif /* __NUGU_BATTERY_AGENT_H__ */

--- a/examples/capability_injection/main_capability_injection.cc
+++ b/examples/capability_injection/main_capability_injection.cc
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <glib.h>
+#include <iostream>
+#include <string>
+
+#include <base/nugu_log.h>
+#include <capability/capability_factory.hh>
+#include <capability/system_interface.hh>
+#include <clientkit/nugu_client.hh>
+
+#include "battery_agent.hh"
+
+using namespace NuguClientKit;
+using namespace NuguCapability;
+
+class MyNetwork : public INetworkManagerListener {
+public:
+    void onStatusChanged(NetworkStatus status)
+    {
+        switch (status) {
+        case NetworkStatus::DISCONNECTED:
+            std::cout << "Network disconnected !" << std::endl;
+            break;
+        case NetworkStatus::CONNECTED:
+            std::cout << "Network connected !" << std::endl;
+            break;
+        case NetworkStatus::CONNECTING:
+            std::cout << "Network connecting..." << std::endl;
+            break;
+        default:
+            break;
+        }
+    }
+
+    void onError(NetworkError error)
+    {
+        switch (error) {
+        case NetworkError::TOKEN_ERROR:
+            std::cout << "Token error !" << std::endl;
+            break;
+        case NetworkError::UNKNOWN:
+            std::cout << "Unknown error !" << std::endl;
+            break;
+        }
+    }
+};
+
+int main(int argc, char* argv[])
+{
+    if (argc != 2) {
+        std::cout << "Usage: " << argv[0] << " battery level (ex.40)]" << std::endl;
+        return 0;
+    }
+
+    std::string battery_level = argv[1];
+
+    /* Turn off the SDK internal log */
+    nugu_log_set_system(NUGU_LOG_SYSTEM_NONE);
+
+    auto nugu_client(std::make_shared<NuguClient>());
+
+    /* add-on capability for injection */
+    auto battery_agent(std::make_shared<BatteryAgent>());
+    battery_agent->setBatteryLevel(battery_level);
+    battery_agent->setCharging(true);
+
+    /* Register build-in capabilities */
+    nugu_client->getCapabilityBuilder()
+        ->add(CapabilityFactory::makeCapability<SystemAgent, ISystemHandler>())
+        ->add(battery_agent.get())
+        ->construct();
+
+    if (!nugu_client->initialize()) {
+        std::cout << "SDK Initialization failed." << std::endl;
+        return -1;
+    }
+
+    auto network_manager_listener(std::make_shared<MyNetwork>());
+    auto network_manager(nugu_client->getNetworkManager());
+    network_manager->addListener(network_manager_listener.get());
+    network_manager->setToken(getenv("NUGU_TOKEN"));
+    network_manager->connect();
+
+    /* Start GMainLoop */
+    GMainLoop* loop = g_main_loop_new(NULL, FALSE);
+
+    std::cout << "Start the eventloop" << std::endl;
+    g_main_loop_run(loop);
+
+    /* wait until g_main_loop_quit() */
+
+    g_main_loop_unref(loop);
+
+    nugu_client->deInitialize();
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
It add capability agent injection example.
The target example is BatteryAgent. From that,
you can check a context about battery level is extracted.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>