### PR TITLE
Move role capability instance management

### DIFF
--- a/examples/capability_injection/battery_agent.cc
+++ b/examples/capability_injection/battery_agent.cc
@@ -42,6 +42,11 @@ void BatteryAgent::initialize()
     // TODO : implements service logic
 }
 
+void BatteryAgent::deInitialize()
+{
+    // TODO : implements service logic
+}
+
 std::string BatteryAgent::getName()
 {
     return CAPABILITY_NAME;

--- a/examples/capability_injection/battery_agent.hh
+++ b/examples/capability_injection/battery_agent.hh
@@ -36,6 +36,7 @@ public:
     // implements ICapabilityInterface
     void setNuguCoreContainer(INuguCoreContainer* core_container) override;
     void initialize() override;
+    void deInitialize() override;
     std::string getName() override;
     std::string getVersion() override;
     void processDirective(NuguDirective* ndir) override;

--- a/examples/capability_injection/main_capability_injection.cc
+++ b/examples/capability_injection/main_capability_injection.cc
@@ -74,6 +74,10 @@ int main(int argc, char* argv[])
 
     auto nugu_client(std::make_shared<NuguClient>());
 
+    /* built-in capability */
+    auto system_handler(std::shared_ptr<ISystemHandler>(
+        CapabilityFactory::makeCapability<SystemAgent, ISystemHandler>()));
+
     /* add-on capability for injection */
     auto battery_agent(std::make_shared<BatteryAgent>());
     battery_agent->setBatteryLevel(battery_level);
@@ -81,7 +85,7 @@ int main(int argc, char* argv[])
 
     /* Register build-in capabilities */
     nugu_client->getCapabilityBuilder()
-        ->add(CapabilityFactory::makeCapability<SystemAgent, ISystemHandler>())
+        ->add(system_handler.get())
         ->add(battery_agent.get())
         ->construct();
 

--- a/include/clientkit/capability_interface.hh
+++ b/include/clientkit/capability_interface.hh
@@ -96,6 +96,11 @@ public:
     virtual void initialize() = 0;
 
     /**
+     * @brief deinitialize the current object.
+     */
+    virtual void deInitialize() = 0;
+
+    /**
      * @brief Get the capability name of the current object.
      * @return capability name of the object
      */

--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -153,18 +153,8 @@ ASRAgent::ASRAgent()
 
 ASRAgent::~ASRAgent()
 {
-    if (timer) {
-        nugu_timer_delete(timer);
-        timer = nullptr;
-    }
-
-    if (rec_event) {
-        delete rec_event;
-        rec_event = nullptr;
-    }
-
-    delete asr_focus_listener;
-    delete expect_focus_listener;
+    if (initialized)
+        deInitialize();
 }
 
 void ASRAgent::setAttribute(ASRAttribute&& attribute)
@@ -205,6 +195,24 @@ void ASRAgent::initialize()
     expect_focus_listener = new ExpectFocusListener(this);
 
     initialized = true;
+}
+
+void ASRAgent::deInitialize()
+{
+    if (timer) {
+        nugu_timer_delete(timer);
+        timer = nullptr;
+    }
+
+    if (rec_event) {
+        delete rec_event;
+        rec_event = nullptr;
+    }
+
+    delete asr_focus_listener;
+    delete expect_focus_listener;
+
+    initialized = false;
 }
 
 void ASRAgent::startRecognition()

--- a/src/capability/asr_agent.hh
+++ b/src/capability/asr_agent.hh
@@ -45,6 +45,7 @@ public:
 
     void setAttribute(ASRAttribute&& attribute) override;
     void initialize() override;
+    void deInitialize() override;
 
     void startRecognition(void) override;
     void stopRecognition(void) override;

--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -41,15 +41,8 @@ AudioPlayerAgent::AudioPlayerAgent()
 
 AudioPlayerAgent::~AudioPlayerAgent()
 {
-    aplayer_listeners.clear();
-
-    capa_helper->removeFocus("cap_audio");
-
-    if (player) {
-        player->removeListener(this);
-        delete player;
-        player = nullptr;
-    }
+    if (initialized)
+        deInitialize();
 }
 
 void AudioPlayerAgent::initialize()
@@ -65,6 +58,21 @@ void AudioPlayerAgent::initialize()
     capa_helper->addFocus("cap_audio", NUGU_FOCUS_TYPE_MEDIA, this);
 
     initialized = true;
+}
+
+void AudioPlayerAgent::deInitialize()
+{
+    aplayer_listeners.clear();
+
+    capa_helper->removeFocus("cap_audio");
+
+    if (player) {
+        player->removeListener(this);
+        delete player;
+        player = nullptr;
+    }
+
+    initialized = false;
 }
 
 NuguFocusResult AudioPlayerAgent::onFocus(void* event)

--- a/src/capability/audio_player_agent.hh
+++ b/src/capability/audio_player_agent.hh
@@ -45,6 +45,7 @@ public:
     AudioPlayerAgent();
     virtual ~AudioPlayerAgent();
     void initialize() override;
+    void deInitialize() override;
 
     void parsingDirective(const char* dname, const char* message) override;
     void updateInfoForContext(Json::Value& ctx) override;

--- a/src/capability/capability.cc
+++ b/src/capability/capability.cc
@@ -140,6 +140,10 @@ void Capability::initialize()
 {
 }
 
+void Capability::deInitialize()
+{
+}
+
 std::string Capability::getReferrerDialogRequestId()
 {
     return ref_dialog_id;

--- a/src/capability/capability.hh
+++ b/src/capability/capability.hh
@@ -57,6 +57,7 @@ public:
 
     void setNuguCoreContainer(INuguCoreContainer* core_container) override;
     void initialize() override;
+    void deInitialize() override;
 
     std::string getReferrerDialogRequestId();
     void setReferrerDialogRequestId(const std::string& id);

--- a/src/capability/system_agent.cc
+++ b/src/capability/system_agent.cc
@@ -60,6 +60,12 @@ SystemAgent::SystemAgent()
 
 SystemAgent::~SystemAgent()
 {
+}
+
+void SystemAgent::deInitialize()
+{
+    disconnect();
+
     if (timer) {
         nugu_timer_delete(timer);
         timer = nullptr;

--- a/src/capability/system_agent.hh
+++ b/src/capability/system_agent.hh
@@ -29,6 +29,8 @@ public:
     SystemAgent();
     virtual ~SystemAgent();
 
+    void deInitialize() override;
+
     void parsingDirective(const char* dname, const char* message) override;
     void updateInfoForContext(Json::Value& ctx) override;
     void setCapabilityListener(ICapabilityListener* clistener) override;

--- a/src/capability/text_agent.cc
+++ b/src/capability/text_agent.cc
@@ -39,10 +39,8 @@ TextAgent::TextAgent()
 
 TextAgent::~TextAgent()
 {
-    if (timer) {
-        nugu_timer_delete(timer);
-        timer = nullptr;
-    }
+    if (initialized)
+        deInitialize();
 }
 
 void TextAgent::setAttribute(TextAttribute&& attribute)
@@ -67,6 +65,16 @@ void TextAgent::initialize()
         this);
 
     initialized = true;
+}
+
+void TextAgent::deInitialize()
+{
+    if (timer) {
+        nugu_timer_delete(timer);
+        timer = nullptr;
+    }
+
+    initialized = false;
 }
 
 void TextAgent::parsingDirective(const char* dname, const char* message)

--- a/src/capability/text_agent.hh
+++ b/src/capability/text_agent.hh
@@ -31,6 +31,7 @@ public:
 
     void setAttribute(TextAttribute&& attribute) override;
     void initialize() override;
+    void deInitialize() override;
 
     void parsingDirective(const char* dname, const char* message) override;
     void updateInfoForContext(Json::Value& ctx) override;

--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -46,28 +46,8 @@ TTSAgent::TTSAgent()
 
 TTSAgent::~TTSAgent()
 {
-    if (speak_dir) {
-        nugu_directive_set_data_callback(speak_dir, NULL, NULL);
-        destoryDirective(speak_dir);
-        speak_dir = NULL;
-    }
-
-    if (decoder) {
-        nugu_decoder_free(decoder);
-        decoder = NULL;
-    }
-
-    if (pcm) {
-        nugu_pcm_stop(pcm);
-        nugu_pcm_set_event_callback(pcm, NULL, NULL);
-        nugu_pcm_set_status_callback(pcm, NULL, NULL);
-        nugu_pcm_remove(pcm);
-        nugu_pcm_free(pcm);
-        pcm = NULL;
-    }
-
-    initialized = false;
-    capa_helper->removeFocus("cap_tts");
+    if (initialized)
+        deInitialize();
 }
 
 void TTSAgent::setAttribute(TTSAttribute&& attribute)
@@ -99,6 +79,32 @@ void TTSAgent::initialize()
     capa_helper->addFocus("cap_tts", NUGU_FOCUS_TYPE_TTS, this);
 
     initialized = true;
+}
+
+void TTSAgent::deInitialize()
+{
+    if (speak_dir) {
+        nugu_directive_set_data_callback(speak_dir, NULL, NULL);
+        destoryDirective(speak_dir);
+        speak_dir = NULL;
+    }
+
+    if (decoder) {
+        nugu_decoder_free(decoder);
+        decoder = NULL;
+    }
+
+    if (pcm) {
+        nugu_pcm_stop(pcm);
+        nugu_pcm_set_event_callback(pcm, NULL, NULL);
+        nugu_pcm_set_status_callback(pcm, NULL, NULL);
+        nugu_pcm_remove(pcm);
+        nugu_pcm_free(pcm);
+        pcm = NULL;
+    }
+
+    initialized = false;
+    capa_helper->removeFocus("cap_tts");
 }
 
 void TTSAgent::pcmStatusCallback(enum nugu_media_status status, void* userdata)

--- a/src/capability/tts_agent.hh
+++ b/src/capability/tts_agent.hh
@@ -34,6 +34,7 @@ public:
 
     void setAttribute(TTSAttribute&& attribute) override;
     void initialize() override;
+    void deInitialize() override;
 
     void parsingDirective(const char* dname, const char* message) override;
     void updateInfoForContext(Json::Value& ctx) override;

--- a/src/clientkit/nugu_client_impl.cc
+++ b/src/clientkit/nugu_client_impl.cc
@@ -166,12 +166,6 @@ bool NuguClientImpl::initialize(void)
 
 void NuguClientImpl::deInitialize(void)
 {
-    ISystemHandler* sys_handler = dynamic_cast<ISystemHandler*>(getCapabilityHandler("System"));
-
-    // Send a disconnect event indicating normal termination
-    if (sys_handler)
-        sys_handler->disconnect();
-
     // release capabilities
     for (auto& capability : icapability_map) {
         std::string cname = capability.second->getName();
@@ -179,8 +173,7 @@ void NuguClientImpl::deInitialize(void)
         if (!cname.empty())
             nugu_core_container->removeCapability(cname);
 
-        // TODO:It needs to move responsibility to user application later
-        delete capability.second;
+        capability.second->deInitialize();
     }
 
     icapability_map.clear();


### PR DESCRIPTION
In previously, NuguClient had charge of capability instance
management, so, when deinitializing NuguClient, it removed
that instances.

As moving the role of managing capability instance to Application,
it add deinitialize method in capability interface for clearing
relevant resources which is needed to do before removing instance.

When deinitializing NuguClient, that added method is called, so
the Application may remove capability instance freely.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>