### PR TITLE
Remove capability handler getter

### DIFF
--- a/examples/standalone/nugu_sample.cc
+++ b/examples/standalone/nugu_sample.cc
@@ -67,15 +67,6 @@ std::unique_ptr<T> make_unique(Ts&&... params)
     return std::unique_ptr<T>(new T(std::forward<Ts>(params)...));
 }
 
-template <class T>
-T getCapabilityHandler(const std::string& cname)
-{
-    if (nugu_client)
-        return dynamic_cast<T>(nugu_client->getCapabilityHandler(cname));
-
-    return nullptr;
-}
-
 void msg_error(const std::string& message)
 {
     NuguSampleManager::error(message);

--- a/include/clientkit/nugu_client.hh
+++ b/include/clientkit/nugu_client.hh
@@ -109,13 +109,6 @@ public:
     INuguCoreContainer* getNuguCoreContainer();
 
     /**
-     * @brief Get CapabilityHandler object
-     * @param[in] cname capability interface name
-     * @return ICapabilityInterface if a feature agent has been created with the feature builder, otherwise NULL
-     */
-    ICapabilityInterface* getCapabilityHandler(const std::string& cname);
-
-    /**
      * @brief Get NetworkManager object
      * @return INetworkManager if a feature agent has been created with the feature builder, otherwise NULL
      */

--- a/src/clientkit/nugu_client.cc
+++ b/src/clientkit/nugu_client.cc
@@ -81,11 +81,6 @@ INuguCoreContainer* NuguClient::getNuguCoreContainer()
     return impl->getNuguCoreContainer();
 }
 
-ICapabilityInterface* NuguClient::getCapabilityHandler(const std::string& cname)
-{
-    return impl->getCapabilityHandler(cname);
-}
-
 INetworkManager* NuguClient::getNetworkManager()
 {
     return impl->getNetworkManager();


### PR DESCRIPTION
As the application manages capability instance,
NuguClient does not need to provide capability handler getter.

So, that method is removed.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>