### PR TITLE
add missing nugu_ prefix to public APIs

### DIFF
--- a/include/base/nugu_audio.h
+++ b/include/base/nugu_audio.h
@@ -29,33 +29,33 @@ extern "C" {
  * @brief audio sample rate
  */
 enum nugu_audio_sample_rate {
-	AUDIO_SAMPLE_RATE_8K, /**< 8K */
-	AUDIO_SAMPLE_RATE_16K, /**< 16K */
-	AUDIO_SAMPLE_RATE_32K, /**< 32K */
-	AUDIO_SAMPLE_RATE_22K, /**< 22K */
-	AUDIO_SAMPLE_RATE_44K, /**< 44K */
-	AUDIO_SAMPLE_RATE_MAX
+	NUGU_AUDIO_SAMPLE_RATE_8K, /**< 8K */
+	NUGU_AUDIO_SAMPLE_RATE_16K, /**< 16K */
+	NUGU_AUDIO_SAMPLE_RATE_32K, /**< 32K */
+	NUGU_AUDIO_SAMPLE_RATE_22K, /**< 22K */
+	NUGU_AUDIO_SAMPLE_RATE_44K, /**< 44K */
+	NUGU_AUDIO_SAMPLE_RATE_MAX
 };
 
 /**
  * @brief audio format
  */
 enum nugu_audio_format {
-	AUDIO_FORMAT_S8, /**< Signed 8 bits */
-	AUDIO_FORMAT_U8, /**< Unsigned 8 bits */
-	AUDIO_FORMAT_S16_LE, /**< Signed 16 bits little endian */
-	AUDIO_FORMAT_S16_BE, /**< Signed 16 bits big endian */
-	AUDIO_FORMAT_U16_LE, /**< Unsigned 16 bits little endian */
-	AUDIO_FORMAT_U16_BE, /**< Unsigned 16 bits big endian */
-	AUDIO_FORMAT_S24_LE, /**< Signed 24 bits little endian */
-	AUDIO_FORMAT_S24_BE, /**< Signed 24 bits big endian */
-	AUDIO_FORMAT_U24_LE, /**< Unsigned 24 bits little endian */
-	AUDIO_FORMAT_U24_BE, /**< Unsigned 24 bits big endian */
-	AUDIO_FORMAT_S32_LE, /**< Signed 32 bits little endian */
-	AUDIO_FORMAT_S32_BE, /**< Signed 32 bits big endian */
-	AUDIO_FORMAT_U32_LE, /**< Unsigned 32 bits little endian */
-	AUDIO_FORMAT_U32_BE, /**< Unsigned 32 bits big endian */
-	AUDIO_FORMAT_MAX
+	NUGU_AUDIO_FORMAT_S8, /**< Signed 8 bits */
+	NUGU_AUDIO_FORMAT_U8, /**< Unsigned 8 bits */
+	NUGU_AUDIO_FORMAT_S16_LE, /**< Signed 16 bits little endian */
+	NUGU_AUDIO_FORMAT_S16_BE, /**< Signed 16 bits big endian */
+	NUGU_AUDIO_FORMAT_U16_LE, /**< Unsigned 16 bits little endian */
+	NUGU_AUDIO_FORMAT_U16_BE, /**< Unsigned 16 bits big endian */
+	NUGU_AUDIO_FORMAT_S24_LE, /**< Signed 24 bits little endian */
+	NUGU_AUDIO_FORMAT_S24_BE, /**< Signed 24 bits big endian */
+	NUGU_AUDIO_FORMAT_U24_LE, /**< Unsigned 24 bits little endian */
+	NUGU_AUDIO_FORMAT_U24_BE, /**< Unsigned 24 bits big endian */
+	NUGU_AUDIO_FORMAT_S32_LE, /**< Signed 32 bits little endian */
+	NUGU_AUDIO_FORMAT_S32_BE, /**< Signed 32 bits big endian */
+	NUGU_AUDIO_FORMAT_U32_LE, /**< Unsigned 32 bits little endian */
+	NUGU_AUDIO_FORMAT_U32_BE, /**< Unsigned 32 bits big endian */
+	NUGU_AUDIO_FORMAT_MAX
 };
 
 /**

--- a/include/base/nugu_buffer.h
+++ b/include/base/nugu_buffer.h
@@ -41,7 +41,7 @@ extern "C" {
  * @brief Not found return type of nugu_buffer_find_byte()
  * @see nugu_buffer_find_byte()
  */
-#define NOT_FOUND ((size_t)-1)
+#define NUGU_BUFFER_NOT_FOUND ((size_t)-1)
 
 /**
  * @brief Buffer object
@@ -105,8 +105,8 @@ size_t nugu_buffer_get_alloc_size(NuguBuffer *buf);
  * @brief Get the position of the data you want to find.
  * @param[in] buf buffer object
  * @param[in] want byte data you want to find
- * @return position. if fail, return NOT_FOUND
- * @see NOT_FOUND
+ * @return position. if fail, return NUGU_BUFFER_NOT_FOUND
+ * @see NUGU_BUFFER_NOT_FOUND
  */
 size_t nugu_buffer_find_byte(NuguBuffer *buf, unsigned char want);
 

--- a/include/base/nugu_decoder.h
+++ b/include/base/nugu_decoder.h
@@ -140,9 +140,9 @@ NuguPcm *nugu_decoder_get_pcm(NuguDecoder *dec);
  * @brief decoder type
  * @see nugu_decoder_driver_new()
  */
-enum decoder_type {
-	DECODER_TYPE_OPUS, /**< OPUS */
-	DECODER_TYPE_CUSTOM = 99 /**< Custom type */
+enum nugu_decoder_type {
+	NUGU_DECODER_TYPE_OPUS, /**< OPUS */
+	NUGU_DECODER_TYPE_CUSTOM = 99 /**< Custom type */
 };
 
 /**
@@ -178,7 +178,7 @@ struct nugu_decoder_driver_ops {
  * @see nugu_decoder_driver_free()
  */
 NuguDecoderDriver *nugu_decoder_driver_new(const char *name,
-					   enum decoder_type type,
+					   enum nugu_decoder_type type,
 					   struct nugu_decoder_driver_ops *ops);
 
 /**
@@ -222,7 +222,7 @@ NuguDecoderDriver *nugu_decoder_driver_find(const char *name);
  * @return decoder driver object
  * @see nugu_decoder_driver_find
  */
-NuguDecoderDriver *nugu_decoder_driver_find_bytype(enum decoder_type type);
+NuguDecoderDriver *nugu_decoder_driver_find_bytype(enum nugu_decoder_type type);
 
 /**
  * @}

--- a/include/base/nugu_directive.h
+++ b/include/base/nugu_directive.h
@@ -47,7 +47,7 @@ typedef struct _nugu_directive NuguDirective;
 /**
  * @brief Callback prototype for receiving an attachment
  */
-typedef void (*DirectiveDataCallback)(NuguDirective *ndir, void *userdata);
+typedef void (*NuguDirectiveDataCallback)(NuguDirective *ndir, void *userdata);
 
 /**
  * @brief Create new directive object
@@ -237,7 +237,7 @@ size_t nugu_directive_get_data_size(NuguDirective *ndir);
  * @see nugu_directive_remove_data_callback()
  */
 int nugu_directive_set_data_callback(NuguDirective *ndir,
-				     DirectiveDataCallback callback,
+				     NuguDirectiveDataCallback callback,
 				     void *userdata);
 
 /**

--- a/include/base/nugu_directive_sequencer.h
+++ b/include/base/nugu_directive_sequencer.h
@@ -38,23 +38,18 @@ extern "C" {
 /**
  * @brief Callback return type
  */
-enum dirseq_return {
-	DIRSEQ_STOP_PROPAGATE, /**< Stop event propagation */
-	DIRSEQ_CONTINUE, /**< Pass to the next callback */
-	DIRSEQ_REMOVE /**< Remove the directive */
-};
-
-/**
- * @brief Callback return type
- * @see enum dirseq_return
- */
-typedef enum dirseq_return DirseqReturn;
+typedef enum nugu_dirseq_return {
+	NUGU_DIRSEQ_STOP_PROPAGATE, /**< Stop event propagation */
+	NUGU_DIRSEQ_CONTINUE, /**< Pass to the next callback */
+	NUGU_DIRSEQ_REMOVE /**< Remove the directive */
+} NuguDirseqReturn;
 
 /**
  * @brief Callback prototype
- * @see DirseqReturn
+ * @see NuguDirseqReturn
  */
-typedef DirseqReturn (*DirseqCallback)(NuguDirective *ndir, void *userdata);
+typedef NuguDirseqReturn (*NuguDirseqCallback)(NuguDirective *ndir,
+					       void *userdata);
 
 /**
  * @brief Add event callback to Directive sequencer
@@ -64,7 +59,7 @@ typedef DirseqReturn (*DirseqCallback)(NuguDirective *ndir, void *userdata);
  * @retval 0 success
  * @retval -1 failure
  */
-int nugu_dirseq_add_callback(DirseqCallback callback, void *userdata);
+int nugu_dirseq_add_callback(NuguDirseqCallback callback, void *userdata);
 
 /**
  * @brief Remove event callback
@@ -73,7 +68,7 @@ int nugu_dirseq_add_callback(DirseqCallback callback, void *userdata);
  * @retval 0 success
  * @retval -1 failure
  */
-int nugu_dirseq_remove_callback(DirseqCallback callback);
+int nugu_dirseq_remove_callback(NuguDirseqCallback callback);
 
 /**
  * @brief Add new directive object to directive sequencer

--- a/include/base/nugu_log.h
+++ b/include/base/nugu_log.h
@@ -379,7 +379,7 @@ void nugu_hexdump(enum nugu_log_module module, const uint8_t *data,
  * @brief Default error message for 'Not enough memory'
  * @see nugu_error()
  */
-#define error_nomem() nugu_error("Not enough memory")
+#define nugu_error_nomem() nugu_error("Not enough memory")
 
 /**
  * @}

--- a/include/base/nugu_media.h
+++ b/include/base/nugu_media.h
@@ -54,36 +54,37 @@ extern "C" {
  * @brief media status
  */
 enum nugu_media_status {
-	MEDIA_STATUS_STOPPED, /**< media stopped */
-	MEDIA_STATUS_READY, /**< media ready */
-	MEDIA_STATUS_PLAYING, /**< media playing */
-	MEDIA_STATUS_PAUSED /**< media paused */
+	NUGU_MEDIA_STATUS_STOPPED, /**< media stopped */
+	NUGU_MEDIA_STATUS_READY, /**< media ready */
+	NUGU_MEDIA_STATUS_PLAYING, /**< media playing */
+	NUGU_MEDIA_STATUS_PAUSED /**< media paused */
 };
 
 /**
  * @brief media event type
  */
 enum nugu_media_event {
-	MEDIA_EVENT_MEDIA_SOURCE_CHANGED, /**< media source changed */
-	MEDIA_EVENT_MEDIA_INVALID, /**< media invalid */
-	MEDIA_EVENT_MEDIA_LOAD_FAILED, /**< media load failed */
-	MEDIA_EVENT_MEDIA_LOADED, /**< media loaded */
-	MEDIA_EVENT_MEDIA_UNDERRUN, /**< media buffer underrun */
-	MEDIA_EVENT_MEDIA_BUFFER_FULL, /**< media buffer full */
-	MEDIA_EVENT_END_OF_STREAM, /**< end of stream */
-	MEDIA_EVENT_MAX
+	NUGU_MEDIA_EVENT_MEDIA_SOURCE_CHANGED, /**< media source changed */
+	NUGU_MEDIA_EVENT_MEDIA_INVALID, /**< media invalid */
+	NUGU_MEDIA_EVENT_MEDIA_LOAD_FAILED, /**< media load failed */
+	NUGU_MEDIA_EVENT_MEDIA_LOADED, /**< media loaded */
+	NUGU_MEDIA_EVENT_MEDIA_UNDERRUN, /**< media buffer underrun */
+	NUGU_MEDIA_EVENT_MEDIA_BUFFER_FULL, /**< media buffer full */
+	NUGU_MEDIA_EVENT_END_OF_STREAM, /**< end of stream */
+	NUGU_MEDIA_EVENT_MAX
 };
 
 /**
  * @brief Callback type for media status
  */
-typedef void (*mediaStatusCallback)(enum nugu_media_status status,
+typedef void (*NuguMediaStatusCallback)(enum nugu_media_status status,
 				    void *userdata);
 
 /**
  * @brief Callback type for media event
  */
-typedef void (*mediaEventCallback)(enum nugu_media_event event, void *userdata);
+typedef void (*NuguMediaEventCallback)(enum nugu_media_event event,
+				       void *userdata);
 
 /**
  * @}

--- a/include/base/nugu_network_manager.h
+++ b/include/base/nugu_network_manager.h
@@ -62,8 +62,8 @@ typedef enum nugu_network_status {
  * @brief Callback prototype for receiving network status events
  * @see nugu_network_manager_set_status_callback()
  */
-typedef void (*NetworkManagerStatusCallback)(NuguNetworkStatus status,
-					     void *userdata);
+typedef void (*NuguNetworkManagerStatusCallback)(NuguNetworkStatus status,
+						 void *userdata);
 
 /**
  * @brief network handoff status
@@ -84,17 +84,17 @@ typedef enum nugu_network_handoff_status {
 /**
  * @brief Callback prototype for handoff status events
  */
-typedef void (*NetworkManagerHandoffStatusCallback)(
+typedef void (*NuguNetworkManagerHandoffStatusCallback)(
 	NuguNetworkHandoffStatus status, void *userdata);
 
 /**
  * @brief Callback prototype for result of event transfer request.
  * @see nugu_network_manager_send_event()
  */
-typedef void (*NetworkManagerEventResultCallback)(int success,
-						  const char *msg_id,
-						  const char *dialog_id,
-						  int code, void *userdata);
+typedef void (*NuguNetworkManagerEventResultCallback)(int success,
+						      const char *msg_id,
+						      const char *dialog_id,
+						      int code, void *userdata);
 
 /**
  * @brief network protocols
@@ -133,7 +133,7 @@ typedef struct nugu_network_server_policy {
  * @retval -1 failure
  */
 int nugu_network_manager_set_status_callback(
-	NetworkManagerStatusCallback callback, void *userdata);
+	NuguNetworkManagerStatusCallback callback, void *userdata);
 
 /**
  * @brief Set handoff status callback
@@ -144,7 +144,7 @@ int nugu_network_manager_set_status_callback(
  * @retval -1 failure
  */
 int nugu_network_manager_set_handoff_status_callback(
-	NetworkManagerHandoffStatusCallback callback, void *userdata);
+	NuguNetworkManagerHandoffStatusCallback callback, void *userdata);
 
 /**
  * @brief Set event result callback
@@ -155,7 +155,7 @@ int nugu_network_manager_set_handoff_status_callback(
  * @retval -1 failure
  */
 int nugu_network_manager_set_event_result_callback(
-	NetworkManagerEventResultCallback callback, void *userdata);
+	NuguNetworkManagerEventResultCallback callback, void *userdata);
 
 /**
  * @brief Set the current network status

--- a/include/base/nugu_pcm.h
+++ b/include/base/nugu_pcm.h
@@ -183,7 +183,7 @@ enum nugu_media_status nugu_pcm_get_status(NuguPcm *pcm);
  * @param[in] cb callback function
  * @param[in] userdata data to pass to the user callback
  */
-void nugu_pcm_set_status_callback(NuguPcm *pcm, mediaStatusCallback cb,
+void nugu_pcm_set_status_callback(NuguPcm *pcm, NuguMediaStatusCallback cb,
 				  void *userdata);
 
 /**
@@ -199,7 +199,7 @@ void nugu_pcm_emit_status(NuguPcm *pcm, enum nugu_media_status status);
  * @param[in] cb callback function
  * @param[in] userdata data to pass to the user callback
  */
-void nugu_pcm_set_event_callback(NuguPcm *pcm, mediaEventCallback cb,
+void nugu_pcm_set_event_callback(NuguPcm *pcm, NuguMediaEventCallback cb,
 				 void *userdata);
 
 /**

--- a/include/base/nugu_player.h
+++ b/include/base/nugu_player.h
@@ -211,7 +211,8 @@ enum nugu_media_status nugu_player_get_status(NuguPlayer *player);
  * @param[in] cb callback function
  * @param[in] userdata data to pass to the user callback
  */
-void nugu_player_set_status_callback(NuguPlayer *player, mediaStatusCallback cb,
+void nugu_player_set_status_callback(NuguPlayer *player,
+				     NuguMediaStatusCallback cb,
 				     void *userdata);
 
 /**
@@ -227,8 +228,8 @@ void nugu_player_emit_status(NuguPlayer *player, enum nugu_media_status status);
  * @param[in] cb callback function
  * @param[in] userdata data to pass to the user callback
  */
-void nugu_player_set_event_callback(NuguPlayer *player, mediaEventCallback cb,
-				    void *userdata);
+void nugu_player_set_event_callback(NuguPlayer *player,
+				    NuguMediaEventCallback cb, void *userdata);
 
 /**
  * @brief Emit event to registered callback

--- a/include/base/nugu_timer.h
+++ b/include/base/nugu_timer.h
@@ -40,7 +40,7 @@ typedef struct _nugu_timer NuguTimer;
 /**
  * @brief Callback prototype for timeout
  */
-typedef void (*timeoutCallback)(void *userdata);
+typedef void (*NuguTimeoutCallback)(void *userdata);
 
 /**
  * @brief Create new timer object
@@ -115,7 +115,7 @@ void nugu_timer_stop(NuguTimer *timer);
  * @param[in] callback callback function
  * @param[in] userdata data to pass to the user callback
  */
-void nugu_timer_set_callback(NuguTimer *timer, timeoutCallback callback,
+void nugu_timer_set_callback(NuguTimer *timer, NuguTimeoutCallback callback,
 			     void *userdata);
 
 /**

--- a/plugins/filedump.c
+++ b/plugins/filedump.c
@@ -127,7 +127,7 @@ static int init(NuguPlugin *p)
 	nugu_dbg("plugin-init '%s'", nugu_plugin_get_description(p)->name);
 
 	decoder_driver = nugu_decoder_driver_new(
-		"filedump", DECODER_TYPE_CUSTOM, &decoder_ops);
+		"filedump", NUGU_DECODER_TYPE_CUSTOM, &decoder_ops);
 	if (!decoder_driver)
 		return -1;
 

--- a/plugins/opus.c
+++ b/plugins/opus.c
@@ -178,7 +178,7 @@ static int init(NuguPlugin *p)
 {
 	nugu_dbg("plugin-init '%s'", nugu_plugin_get_description(p)->name);
 
-	driver = nugu_decoder_driver_new("opus", DECODER_TYPE_OPUS,
+	driver = nugu_decoder_driver_new("opus", NUGU_DECODER_TYPE_OPUS,
 					 &decoder_ops);
 	if (!driver)
 		return -1;

--- a/plugins/portaudio.c
+++ b/plugins/portaudio.c
@@ -52,19 +52,19 @@ static int _set_property_to_param(struct pa_audio_param *param,
 	g_return_val_if_fail(param != NULL, -1);
 
 	switch (prop.samplerate) {
-	case AUDIO_SAMPLE_RATE_8K:
+	case NUGU_AUDIO_SAMPLE_RATE_8K:
 		param->samplerate = 8000;
 		break;
-	case AUDIO_SAMPLE_RATE_16K:
+	case NUGU_AUDIO_SAMPLE_RATE_16K:
 		param->samplerate = 16000;
 		break;
-	case AUDIO_SAMPLE_RATE_32K:
+	case NUGU_AUDIO_SAMPLE_RATE_32K:
 		param->samplerate = 32000;
 		break;
-	case AUDIO_SAMPLE_RATE_22K:
+	case NUGU_AUDIO_SAMPLE_RATE_22K:
 		param->samplerate = 22050;
 		break;
-	case AUDIO_SAMPLE_RATE_44K:
+	case NUGU_AUDIO_SAMPLE_RATE_44K:
 		param->samplerate = 44100;
 		break;
 	default:
@@ -73,26 +73,26 @@ static int _set_property_to_param(struct pa_audio_param *param,
 	}
 
 	switch (prop.format) {
-	case AUDIO_FORMAT_S8:
+	case NUGU_AUDIO_FORMAT_S8:
 		param->format = paInt8;
 		param->samplebyte = 1;
 		break;
-	case AUDIO_FORMAT_U8:
+	case NUGU_AUDIO_FORMAT_U8:
 		param->format = paUInt8;
 		param->samplebyte = 1;
 		break;
-	case AUDIO_FORMAT_S16_LE:
-	case AUDIO_FORMAT_S16_BE:
+	case NUGU_AUDIO_FORMAT_S16_LE:
+	case NUGU_AUDIO_FORMAT_S16_BE:
 		param->format = paInt16;
 		param->samplebyte = 2;
 		break;
-	case AUDIO_FORMAT_S24_LE:
-	case AUDIO_FORMAT_S24_BE:
+	case NUGU_AUDIO_FORMAT_S24_LE:
+	case NUGU_AUDIO_FORMAT_S24_BE:
 		param->format = paInt24;
 		param->samplebyte = 3;
 		break;
-	case AUDIO_FORMAT_S32_LE:
-	case AUDIO_FORMAT_S32_BE:
+	case NUGU_AUDIO_FORMAT_S32_LE:
+	case NUGU_AUDIO_FORMAT_S32_BE:
 		param->format = paFloat32;
 		param->samplebyte = 4;
 		break;
@@ -144,7 +144,7 @@ static gboolean _playerEndOfStream(void *userdata)
 	NuguPcm *pcm = (NuguPcm *)userdata;
 
 	if (pcm)
-		nugu_pcm_emit_event(pcm, MEDIA_EVENT_END_OF_STREAM);
+		nugu_pcm_emit_event(pcm, NUGU_MEDIA_EVENT_END_OF_STREAM);
 	else
 		nugu_error("wrong parameter");
 
@@ -337,7 +337,7 @@ static int _pcm_start(NuguPcmDriver *driver, NuguPcm *pcm,
 		return -1;
 	}
 
-	nugu_pcm_emit_status(pcm, MEDIA_STATUS_READY);
+	nugu_pcm_emit_status(pcm, NUGU_MEDIA_STATUS_READY);
 
 	pcm_param->pause = 0;
 	pcm_param->stop = 0;
@@ -350,7 +350,7 @@ static int _pcm_start(NuguPcmDriver *driver, NuguPcm *pcm,
 
 	nugu_pcm_set_userdata(pcm, pcm_param);
 
-	nugu_pcm_emit_status(pcm, MEDIA_STATUS_PLAYING);
+	nugu_pcm_emit_status(pcm, NUGU_MEDIA_STATUS_PLAYING);
 
 	nugu_dbg("start done");
 	return 0;
@@ -378,7 +378,7 @@ static int _pcm_stop(NuguPcmDriver *driver, NuguPcm *pcm)
 	if (err != paNoError)
 		nugu_error("Pa_CloseStream return fail");
 
-	nugu_pcm_emit_status(pcm, MEDIA_STATUS_STOPPED);
+	nugu_pcm_emit_status(pcm, NUGU_MEDIA_STATUS_STOPPED);
 
 	free(pcm_param);
 	nugu_pcm_set_userdata(pcm, NULL);
@@ -406,7 +406,7 @@ static int _pcm_pause(NuguPcmDriver *driver, NuguPcm *pcm)
 	}
 
 	pcm_param->pause = 1;
-	nugu_pcm_emit_status(pcm, MEDIA_STATUS_PAUSED);
+	nugu_pcm_emit_status(pcm, NUGU_MEDIA_STATUS_PAUSED);
 
 	nugu_dbg("pause done");
 
@@ -431,7 +431,7 @@ static int _pcm_resume(NuguPcmDriver *driver, NuguPcm *pcm)
 	}
 
 	pcm_param->pause = 0;
-	nugu_pcm_emit_status(pcm, MEDIA_STATUS_PLAYING);
+	nugu_pcm_emit_status(pcm, NUGU_MEDIA_STATUS_PLAYING);
 
 	nugu_dbg("resume done");
 

--- a/src/base/network/dg_registry.c
+++ b/src/base/network/dg_registry.c
@@ -36,7 +36,7 @@ DGRegistry *dg_registry_new(void)
 
 	registry = calloc(1, sizeof(struct _dg_registry));
 	if (!registry) {
-		error_nomem();
+		nugu_error_nomem();
 		return NULL;
 	}
 

--- a/src/base/network/dg_server.c
+++ b/src/base/network/dg_server.c
@@ -72,7 +72,7 @@ DGServer *dg_server_new(const NuguNetworkServerPolicy *policy)
 
 	server = calloc(1, sizeof(struct _dg_server));
 	if (!server) {
-		error_nomem();
+		nugu_error_nomem();
 		g_free(tmp);
 		return NULL;
 	}

--- a/src/base/network/http2/http2_network.c
+++ b/src/base/network/http2/http2_network.c
@@ -256,7 +256,7 @@ HTTP2Network *http2_network_new()
 
 	net = calloc(1, sizeof(struct _http2_network));
 	if (!net) {
-		error_nomem();
+		nugu_error_nomem();
 		return NULL;
 	}
 
@@ -317,7 +317,7 @@ static struct request_item *_request_item_new(enum request_type type,
 
 	item = malloc(sizeof(struct request_item));
 	if (!item) {
-		error_nomem();
+		nugu_error_nomem();
 		return NULL;
 	}
 

--- a/src/base/network/http2/http2_request.c
+++ b/src/base/network/http2/http2_request.c
@@ -212,7 +212,7 @@ HTTP2Request *http2_request_new()
 
 	req = calloc(1, sizeof(struct _http2_request));
 	if (!req) {
-		error_nomem();
+		nugu_error_nomem();
 		return NULL;
 	}
 

--- a/src/base/network/http2/multipart_parser.c
+++ b/src/base/network/http2/multipart_parser.c
@@ -63,7 +63,7 @@ MultipartParser *multipart_parser_new()
 
 	parser = calloc(1, sizeof(struct _multipart_parser));
 	if (!parser) {
-		error_nomem();
+		nugu_error_nomem();
 		return NULL;
 	}
 

--- a/src/base/network/http2/v1_directives.cc
+++ b/src/base/network/http2/v1_directives.cc
@@ -71,7 +71,7 @@ static struct _parser_data* parser_data_new(void)
 
     pdata = (struct _parser_data*)calloc(1, sizeof(struct _parser_data));
     if (!pdata) {
-        error_nomem();
+        nugu_error_nomem();
         return NULL;
     }
 
@@ -232,7 +232,7 @@ static void _body_opus(const char* parent_msg_id, int is_end, const char* data, 
 
     item = (struct equeue_data_attachment*)malloc(sizeof(struct equeue_data_attachment));
     if (!item) {
-        error_nomem();
+        nugu_error_nomem();
         return;
     }
 
@@ -356,7 +356,7 @@ V1Directives* v1_directives_new(const char* host, int connection_timeout_secs)
 
     dir = (V1Directives*)calloc(1, sizeof(struct _v1_directives));
     if (!dir) {
-        error_nomem();
+        nugu_error_nomem();
         return NULL;
     }
 
@@ -391,13 +391,13 @@ int v1_directives_establish(V1Directives* dir, HTTP2Network* net)
 
     parser = multipart_parser_new();
     if (!parser) {
-        error_nomem();
+        nugu_error_nomem();
         return -1;
     }
 
     pdata = parser_data_new();
     if (!pdata) {
-        error_nomem();
+        nugu_error_nomem();
         multipart_parser_free(parser);
         return -1;
     }

--- a/src/base/network/http2/v1_event.c
+++ b/src/base/network/http2/v1_event.c
@@ -40,7 +40,7 @@ V1Event *v1_event_new(const char *host)
 
 	event = calloc(1, sizeof(struct _v1_event));
 	if (!event) {
-		error_nomem();
+		nugu_error_nomem();
 		return NULL;
 	}
 
@@ -97,7 +97,7 @@ static void _emit_send_result(int code, HTTP2Request *req)
 
 	event = calloc(1, sizeof(struct equeue_data_request_result));
 	if (!event) {
-		error_nomem();
+		nugu_error_nomem();
 		return;
 	}
 

--- a/src/base/network/http2/v1_event_attachment.c
+++ b/src/base/network/http2/v1_event_attachment.c
@@ -49,7 +49,7 @@ V1EventAttachment *v1_event_attachment_new(const char *host)
 
 	attach = calloc(1, sizeof(struct _v1_event_attachment));
 	if (!attach) {
-		error_nomem();
+		nugu_error_nomem();
 		return NULL;
 	}
 

--- a/src/base/network/http2/v1_events.c
+++ b/src/base/network/http2/v1_events.c
@@ -52,7 +52,7 @@ static void _emit_send_result(int code, HTTP2Request *req)
 
 	event = calloc(1, sizeof(struct equeue_data_request_result));
 	if (!event) {
-		error_nomem();
+		nugu_error_nomem();
 		return;
 	}
 
@@ -109,7 +109,7 @@ V1Events *v1_events_new(const char *host, HTTP2Network *net)
 
 	event = calloc(1, sizeof(struct _v1_events));
 	if (!event) {
-		error_nomem();
+		nugu_error_nomem();
 		return NULL;
 	}
 

--- a/src/base/network/http2/v1_ping.c
+++ b/src/base/network/http2/v1_ping.c
@@ -42,7 +42,7 @@ V1Ping *v1_ping_new(const char *host,
 
 	ping = calloc(1, sizeof(struct _v1_ping));
 	if (!ping) {
-		error_nomem();
+		nugu_error_nomem();
 		return NULL;
 	}
 

--- a/src/base/network/http2/v1_policies.cc
+++ b/src/base/network/http2/v1_policies.cc
@@ -53,7 +53,7 @@ static void _parse_servers(const Json::Value& root)
 
         server_item = (NuguNetworkServerPolicy*)calloc(1, sizeof(NuguNetworkServerPolicy));
         if (!server_item) {
-            error_nomem();
+            nugu_error_nomem();
             break;
         }
 
@@ -156,7 +156,7 @@ static int _parse_health_policy(const Json::Value& root)
 
     policy = (struct dg_health_check_policy*)malloc(sizeof(struct dg_health_check_policy));
     if (!policy) {
-        error_nomem();
+        nugu_error_nomem();
         return -1;
     }
 

--- a/src/base/nugu_buffer.c
+++ b/src/base/nugu_buffer.c
@@ -38,7 +38,7 @@ EXPORT_API NuguBuffer *nugu_buffer_new(size_t default_size)
 
 	buf = calloc(1, sizeof(struct _nugu_buffer));
 	if (!buf) {
-		error_nomem();
+		nugu_error_nomem();
 		return NULL;
 	}
 
@@ -51,7 +51,7 @@ EXPORT_API NuguBuffer *nugu_buffer_new(size_t default_size)
 	buf->data = calloc(1, buf->alloc_size);
 	if (!buf->data) {
 		free(buf);
-		error_nomem();
+		nugu_error_nomem();
 		return NULL;
 	}
 
@@ -92,7 +92,7 @@ static int _buffer_resize(NuguBuffer *buf, size_t needed)
 
 	tmp = realloc(buf->data, new_size);
 	if (!tmp) {
-		error_nomem();
+		nugu_error_nomem();
 		return -1;
 	}
 
@@ -158,7 +158,7 @@ EXPORT_API size_t nugu_buffer_find_byte(NuguBuffer *buf, unsigned char want)
 		pos++;
 	}
 
-	return NOT_FOUND;
+	return NUGU_BUFFER_NOT_FOUND;
 }
 
 EXPORT_API unsigned char nugu_buffer_peek_byte(NuguBuffer *buf, size_t pos)
@@ -234,7 +234,7 @@ EXPORT_API void *nugu_buffer_pop(NuguBuffer *buf, size_t size)
 
 	tmp = malloc(size + 1);
 	if (!tmp) {
-		error_nomem();
+		nugu_error_nomem();
 		return NULL;
 	}
 

--- a/src/base/nugu_decoder.c
+++ b/src/base/nugu_decoder.c
@@ -34,7 +34,7 @@ struct _nugu_decoder {
 
 struct _nugu_decoder_driver {
 	char *name;
-	enum decoder_type type;
+	enum nugu_decoder_type type;
 	struct nugu_decoder_driver_ops *ops;
 	int ref_count;
 };
@@ -42,7 +42,7 @@ struct _nugu_decoder_driver {
 static GList *_decoder_drivers;
 
 EXPORT_API NuguDecoderDriver *
-nugu_decoder_driver_new(const char *name, enum decoder_type type,
+nugu_decoder_driver_new(const char *name, enum nugu_decoder_type type,
 			struct nugu_decoder_driver_ops *ops)
 {
 	NuguDecoderDriver *driver;
@@ -120,7 +120,7 @@ EXPORT_API NuguDecoderDriver *nugu_decoder_driver_find(const char *name)
 }
 
 EXPORT_API NuguDecoderDriver *
-nugu_decoder_driver_find_bytype(enum decoder_type type)
+nugu_decoder_driver_find_bytype(enum nugu_decoder_type type)
 {
 	GList *cur;
 

--- a/src/base/nugu_directive.c
+++ b/src/base/nugu_directive.c
@@ -38,7 +38,7 @@ struct _nugu_directive {
 
 	char *media_type;
 	NuguBuffer *buf;
-	DirectiveDataCallback callback;
+	NuguDirectiveDataCallback callback;
 	void *callback_userdata;
 
 	int ref_count;
@@ -303,9 +303,8 @@ EXPORT_API size_t nugu_directive_get_data_size(NuguDirective *ndir)
 	return size;
 }
 
-EXPORT_API int nugu_directive_set_data_callback(NuguDirective *ndir,
-						DirectiveDataCallback callback,
-						void *userdata)
+EXPORT_API int nugu_directive_set_data_callback(
+	NuguDirective *ndir, NuguDirectiveDataCallback callback, void *userdata)
 {
 	g_return_val_if_fail(ndir != NULL, -1);
 	g_return_val_if_fail(callback != NULL, -1);

--- a/src/base/nugu_directive_sequencer.c
+++ b/src/base/nugu_directive_sequencer.c
@@ -24,7 +24,7 @@
 #include "base/nugu_directive_sequencer.h"
 
 struct _dirseq_callback {
-	DirseqCallback callback;
+	NuguDirseqCallback callback;
 	void *userdata;
 };
 
@@ -41,7 +41,8 @@ static gint _compare_callback(gconstpointer a, gconstpointer b)
 	return -1;
 }
 
-EXPORT_API int nugu_dirseq_add_callback(DirseqCallback callback, void *userdata)
+EXPORT_API int nugu_dirseq_add_callback(NuguDirseqCallback callback,
+					void *userdata)
 {
 	struct _dirseq_callback *cb;
 
@@ -61,7 +62,7 @@ EXPORT_API int nugu_dirseq_add_callback(DirseqCallback callback, void *userdata)
 	return 0;
 }
 
-EXPORT_API int nugu_dirseq_remove_callback(DirseqCallback callback)
+EXPORT_API int nugu_dirseq_remove_callback(NuguDirseqCallback callback)
 {
 	GList *l;
 
@@ -84,11 +85,11 @@ EXPORT_API int nugu_dirseq_remove_callback(DirseqCallback callback)
 	return 0;
 }
 
-static DirseqReturn nugu_dirseq_emit_callback(NuguDirective *ndir)
+static NuguDirseqReturn nugu_dirseq_emit_callback(NuguDirective *ndir)
 {
 	GList *l;
 	struct _dirseq_callback *cb;
-	DirseqReturn ret = DIRSEQ_REMOVE;
+	NuguDirseqReturn ret = NUGU_DIRSEQ_REMOVE;
 
 	g_return_val_if_fail(ndir != NULL, -1);
 
@@ -100,7 +101,7 @@ static DirseqReturn nugu_dirseq_emit_callback(NuguDirective *ndir)
 			continue;
 
 		ret = cb->callback(ndir, cb->userdata);
-		if (ret != DIRSEQ_CONTINUE)
+		if (ret != NUGU_DIRSEQ_CONTINUE)
 			break;
 	}
 
@@ -109,15 +110,16 @@ static DirseqReturn nugu_dirseq_emit_callback(NuguDirective *ndir)
 
 EXPORT_API int nugu_dirseq_push(NuguDirective *ndir)
 {
-	DirseqReturn ret;
+	NuguDirseqReturn ret;
 
 	list_dir = g_list_append(list_dir, ndir);
 	nugu_dbg("added: %s.%s 'id=%s'", nugu_directive_peek_namespace(ndir),
-	    nugu_directive_peek_name(ndir), nugu_directive_peek_msg_id(ndir));
+		 nugu_directive_peek_name(ndir),
+		 nugu_directive_peek_msg_id(ndir));
 
 	nugu_directive_set_active(ndir, 1);
 	ret = nugu_dirseq_emit_callback(ndir);
-	if (ret == DIRSEQ_REMOVE) {
+	if (ret == NUGU_DIRSEQ_REMOVE) {
 		nugu_dbg("directive removed");
 		list_dir = g_list_remove(list_dir, ndir);
 	}

--- a/src/base/nugu_equeue.c
+++ b/src/base/nugu_equeue.c
@@ -111,7 +111,7 @@ EXPORT_API int nugu_equeue_initialize(void)
 
 	_equeue = calloc(1, sizeof(struct _equeue));
 	if (!_equeue) {
-		error_nomem();
+		nugu_error_nomem();
 		pthread_mutex_unlock(&_lock);
 		return -1;
 	}
@@ -251,7 +251,7 @@ EXPORT_API int nugu_equeue_push(enum nugu_equeue_type type, void *data)
 
 	item = malloc(sizeof(struct _econtainer));
 	if (!item) {
-		error_nomem();
+		nugu_error_nomem();
 		pthread_mutex_unlock(&_lock);
 		return -1;
 	}

--- a/src/base/nugu_event.c
+++ b/src/base/nugu_event.c
@@ -20,6 +20,7 @@
 
 #include <glib.h>
 
+#include "base/nugu_log.h"
 #include "base/nugu_uuid.h"
 #include "base/nugu_event.h"
 
@@ -79,6 +80,11 @@ EXPORT_API NuguEvent *nugu_event_new(const char *name_space, const char *name,
 	g_return_val_if_fail(version != NULL, NULL);
 
 	nev = calloc(1, sizeof(NuguEvent));
+	if (!nev) {
+		nugu_error_nomem();
+		return NULL;
+	}
+
 	nev->name_space = strdup(name_space);
 	nev->name = strdup(name);
 	nev->msg_id = nugu_uuid_generate_time();

--- a/src/base/nugu_focus.c
+++ b/src/base/nugu_focus.c
@@ -103,6 +103,11 @@ EXPORT_API NuguFocus *nugu_focus_new(const char *name, NuguFocusType type,
 	struct _nugu_focus *focus;
 
 	focus = malloc(sizeof(struct _nugu_focus));
+	if (!focus) {
+		nugu_error_nomem();
+		return NULL;
+	}
+
 	focus->name = g_strdup(name);
 	focus->type = type;
 	focus->focus_cb = focus_cb;

--- a/src/base/nugu_network_manager.c
+++ b/src/base/nugu_network_manager.c
@@ -86,16 +86,16 @@ struct _nugu_network {
 
 	/* Handoff */
 	DGServer *handoff;
-	NetworkManagerHandoffStatusCallback handoff_callback;
+	NuguNetworkManagerHandoffStatusCallback handoff_callback;
 	void *handoff_callback_userdata;
 
 	/* Event result */
-	NetworkManagerEventResultCallback event_result_callback;
+	NuguNetworkManagerEventResultCallback event_result_callback;
 	void *event_result_callback_userdata;
 
 	/* Status & Callback */
 	NuguNetworkStatus cur_status;
-	NetworkManagerStatusCallback status_callback;
+	NuguNetworkManagerStatusCallback status_callback;
 	void *status_callback_userdata;
 };
 
@@ -569,7 +569,7 @@ static NetworkManager *nugu_network_manager_new(void)
 
 	nm = calloc(1, sizeof(NetworkManager));
 	if (!nm) {
-		error_nomem();
+		nugu_error_nomem();
 		return NULL;
 	}
 
@@ -740,9 +740,8 @@ EXPORT_API int nugu_network_manager_disconnect(void)
 	return 0;
 }
 
-EXPORT_API int
-nugu_network_manager_set_status_callback(NetworkManagerStatusCallback callback,
-					 void *userdata)
+EXPORT_API int nugu_network_manager_set_status_callback(
+	NuguNetworkManagerStatusCallback callback, void *userdata)
 {
 	if (!_network)
 		return -1;
@@ -754,7 +753,7 @@ nugu_network_manager_set_status_callback(NetworkManagerStatusCallback callback,
 }
 
 EXPORT_API int nugu_network_manager_set_handoff_status_callback(
-	NetworkManagerHandoffStatusCallback callback, void *userdata)
+	NuguNetworkManagerHandoffStatusCallback callback, void *userdata)
 {
 	if (!_network)
 		return -1;
@@ -766,7 +765,7 @@ EXPORT_API int nugu_network_manager_set_handoff_status_callback(
 }
 
 EXPORT_API int nugu_network_manager_set_event_result_callback(
-	NetworkManagerEventResultCallback callback, void *userdata)
+	NuguNetworkManagerEventResultCallback callback, void *userdata)
 {
 	if (!_network)
 		return -1;

--- a/src/base/nugu_pcm.c
+++ b/src/base/nugu_pcm.c
@@ -35,8 +35,8 @@ struct _nugu_pcm {
 	NuguPcmDriver *driver;
 	enum nugu_media_status status;
 	NuguAudioProperty property;
-	mediaEventCallback ecb;
-	mediaStatusCallback scb;
+	NuguMediaEventCallback ecb;
+	NuguMediaStatusCallback scb;
 	void *eud; /* user data for event callback */
 	void *sud; /* user data for status callback */
 	void *dud; /* user data for driver */
@@ -60,6 +60,11 @@ EXPORT_API NuguPcmDriver *nugu_pcm_driver_new(const char *name,
 	g_return_val_if_fail(ops != NULL, NULL);
 
 	driver = g_malloc0(sizeof(struct _nugu_pcm_driver));
+	if (!driver) {
+		nugu_error_nomem();
+		return NULL;
+	}
+
 	driver->name = g_strdup(name);
 	driver->ops = ops;
 	driver->ref_count = 0;
@@ -162,6 +167,11 @@ EXPORT_API NuguPcm *nugu_pcm_new(const char *name, NuguPcmDriver *driver)
 	g_return_val_if_fail(driver != NULL, NULL);
 
 	pcm = g_malloc0(sizeof(struct _nugu_pcm));
+	if (!pcm) {
+		nugu_error_nomem();
+		return NULL;
+	}
+
 	pcm->name = g_strdup(name);
 	pcm->driver = driver;
 	pcm->buf = nugu_buffer_new(0);
@@ -171,7 +181,7 @@ EXPORT_API NuguPcm *nugu_pcm_new(const char *name, NuguPcmDriver *driver)
 	pcm->sud = NULL;
 	pcm->eud = NULL;
 	pcm->dud = NULL;
-	pcm->status = MEDIA_STATUS_STOPPED;
+	pcm->status = NUGU_MEDIA_STATUS_STOPPED;
 	pcm->volume = NUGU_SET_VOLUME_MAX;
 
 	if (pcm->buf == NULL) {
@@ -336,7 +346,7 @@ EXPORT_API int nugu_pcm_get_volume(NuguPcm *pcm)
 }
 
 EXPORT_API void nugu_pcm_set_status_callback(NuguPcm *pcm,
-					     mediaStatusCallback cb,
+					     NuguMediaStatusCallback cb,
 					     void *userdata)
 {
 	g_return_if_fail(pcm != NULL);
@@ -361,12 +371,13 @@ EXPORT_API void nugu_pcm_emit_status(NuguPcm *pcm,
 
 EXPORT_API enum nugu_media_status nugu_pcm_get_status(NuguPcm *pcm)
 {
-	g_return_val_if_fail(pcm != NULL, MEDIA_STATUS_STOPPED);
+	g_return_val_if_fail(pcm != NULL, NUGU_MEDIA_STATUS_STOPPED);
 
 	return pcm->status;
 }
 
-EXPORT_API void nugu_pcm_set_event_callback(NuguPcm *pcm, mediaEventCallback cb,
+EXPORT_API void nugu_pcm_set_event_callback(NuguPcm *pcm,
+					    NuguMediaEventCallback cb,
 					    void *userdata)
 {
 	g_return_if_fail(pcm != NULL);
@@ -379,8 +390,8 @@ EXPORT_API void nugu_pcm_emit_event(NuguPcm *pcm, enum nugu_media_event event)
 {
 	g_return_if_fail(pcm != NULL);
 
-	if (event == MEDIA_EVENT_END_OF_STREAM)
-		pcm->status = MEDIA_STATUS_STOPPED;
+	if (event == NUGU_MEDIA_EVENT_END_OF_STREAM)
+		pcm->status = NUGU_MEDIA_STATUS_STOPPED;
 
 	if (pcm->ecb != NULL)
 		pcm->ecb(event, pcm->eud);

--- a/src/base/nugu_player.c
+++ b/src/base/nugu_player.c
@@ -35,8 +35,8 @@ struct _nugu_player {
 	enum nugu_media_status status;
 	char *playurl;
 	int volume;
-	mediaEventCallback ecb;
-	mediaStatusCallback scb;
+	NuguMediaEventCallback ecb;
+	NuguMediaStatusCallback scb;
 	void *eud; /* user data for event callback */
 	void *sud; /* user data for status callback */
 	void *device;
@@ -55,6 +55,11 @@ nugu_player_driver_new(const char *name, struct nugu_player_driver_ops *ops)
 	g_return_val_if_fail(ops != NULL, NULL);
 
 	driver = g_malloc0(sizeof(struct _nugu_player_driver));
+	if (!driver) {
+		nugu_error_nomem();
+		return NULL;
+	}
+
 	driver->name = g_strdup(name);
 	driver->ops = ops;
 	driver->ref_count = 0;
@@ -157,6 +162,11 @@ EXPORT_API NuguPlayer *nugu_player_new(const char *name,
 	g_return_val_if_fail(driver->ops->create != NULL, NULL);
 
 	player = g_malloc0(sizeof(struct _nugu_player));
+	if (!player) {
+		nugu_error_nomem();
+		return NULL;
+	}
+
 	player->name = g_strdup(name);
 	player->driver = driver;
 	player->ecb = NULL;
@@ -167,7 +177,7 @@ EXPORT_API NuguPlayer *nugu_player_new(const char *name,
 	player->volume = NUGU_SET_VOLUME_DEFAULT;
 	player->driver->ref_count++;
 	player->device = player->driver->ops->create(player);
-	player->status = MEDIA_STATUS_STOPPED;
+	player->status = NUGU_MEDIA_STATUS_STOPPED;
 
 	return player;
 }
@@ -385,7 +395,7 @@ EXPORT_API enum nugu_media_status nugu_player_get_status(NuguPlayer *player)
 }
 
 EXPORT_API void nugu_player_set_status_callback(NuguPlayer *player,
-						mediaStatusCallback cb,
+						NuguMediaStatusCallback cb,
 						void *userdata)
 {
 	g_return_if_fail(player != NULL);
@@ -409,7 +419,7 @@ EXPORT_API void nugu_player_emit_status(NuguPlayer *player,
 }
 
 EXPORT_API void nugu_player_set_event_callback(NuguPlayer *player,
-					       mediaEventCallback cb,
+					       NuguMediaEventCallback cb,
 					       void *userdata)
 {
 	g_return_if_fail(player != NULL);
@@ -423,8 +433,8 @@ EXPORT_API void nugu_player_emit_event(NuguPlayer *player,
 {
 	g_return_if_fail(player != NULL);
 
-	if (event == MEDIA_EVENT_END_OF_STREAM)
-		player->status = MEDIA_STATUS_STOPPED;
+	if (event == NUGU_MEDIA_EVENT_END_OF_STREAM)
+		player->status = NUGU_MEDIA_STATUS_STOPPED;
 
 	if (player->ecb != NULL)
 		player->ecb(event, player->eud);

--- a/src/base/nugu_plugin.c
+++ b/src/base/nugu_plugin.c
@@ -46,7 +46,7 @@ EXPORT_API NuguPlugin *nugu_plugin_new(struct nugu_plugin_desc *desc)
 
 	p = malloc(sizeof(struct _plugin));
 	if (!p) {
-		error_nomem();
+		nugu_error_nomem();
 		return NULL;
 	}
 

--- a/src/base/nugu_recorder.c
+++ b/src/base/nugu_recorder.c
@@ -70,6 +70,11 @@ nugu_recorder_driver_new(const char *name, struct nugu_recorder_driver_ops *ops)
 	g_return_val_if_fail(name != NULL, NULL);
 
 	driver = malloc(sizeof(struct _nugu_recorder_driver));
+	if (!driver) {
+		nugu_error_nomem();
+		return NULL;
+	}
+
 	driver->name = g_strdup(name);
 	driver->ops = ops;
 

--- a/src/base/nugu_ringbuffer.c
+++ b/src/base/nugu_ringbuffer.c
@@ -57,6 +57,11 @@ EXPORT_API NuguRingBuffer *nugu_ring_buffer_new(int item_size, int max_items)
 	g_return_val_if_fail(max_items > 0, NULL);
 
 	buffer = (NuguRingBuffer *)calloc(1, sizeof(struct _nugu_ring_buffer));
+	if (!buffer) {
+		nugu_error_nomem();
+		return NULL;
+	}
+
 	buffer->buf = (unsigned char *)calloc(1, item_size * max_items);
 	buffer->item_size = item_size;
 	buffer->max_items = max_items;

--- a/src/base/nugu_timer.c
+++ b/src/base/nugu_timer.c
@@ -19,6 +19,7 @@
 
 #include <glib.h>
 
+#include "base/nugu_log.h"
 #include "base/nugu_timer.h"
 
 struct _nugu_timer {
@@ -26,7 +27,7 @@ struct _nugu_timer {
 	long interval;
 	int repeat;
 	int count;
-	timeoutCallback cb;
+	NuguTimeoutCallback cb;
 	void *userdata;
 };
 
@@ -48,6 +49,11 @@ EXPORT_API NuguTimer *nugu_timer_new(long interval, int repeat)
 	NuguTimer *timer;
 
 	timer = g_malloc0(sizeof(struct _nugu_timer));
+	if (!timer) {
+		nugu_error_nomem();
+		return NULL;
+	}
+
 	timer->source = NULL;
 	timer->interval = interval;
 	timer->repeat = repeat;
@@ -138,7 +144,7 @@ EXPORT_API void nugu_timer_stop(NuguTimer *timer)
 }
 
 EXPORT_API void nugu_timer_set_callback(NuguTimer *timer,
-					timeoutCallback callback,
+					NuguTimeoutCallback callback,
 					void *userdata)
 {
 	g_return_if_fail(timer != NULL);

--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -72,7 +72,7 @@ void TTSAgent::initialize()
     nugu_pcm_set_status_callback(pcm, pcmStatusCallback, this);
     nugu_pcm_set_event_callback(pcm, pcmEventCallback, this);
 
-    nugu_pcm_set_property(pcm, (NuguAudioProperty) { AUDIO_SAMPLE_RATE_22K, AUDIO_FORMAT_S16_LE, 1 });
+    nugu_pcm_set_property(pcm, (NuguAudioProperty) { NUGU_AUDIO_SAMPLE_RATE_22K, NUGU_AUDIO_FORMAT_S16_LE, 1 });
 
     capa_helper->addFocus("cap_tts", NUGU_FOCUS_TYPE_TTS, this);
 
@@ -112,14 +112,14 @@ void TTSAgent::pcmStatusCallback(enum nugu_media_status status, void* userdata)
     nugu_dbg("pcm state changed(%d -> %d)", tts->speak_status, status);
 
     switch (status) {
-    case MEDIA_STATUS_PLAYING:
+    case NUGU_MEDIA_STATUS_PLAYING:
         tts->sendEventSpeechStarted(tts->cur_token);
         break;
-    case MEDIA_STATUS_STOPPED:
+    case NUGU_MEDIA_STATUS_STOPPED:
         tts->sendEventSpeechStopped(tts->cur_token);
         break;
     default:
-        status = MEDIA_STATUS_STOPPED;
+        status = NUGU_MEDIA_STATUS_STOPPED;
         break;
     }
 
@@ -131,10 +131,10 @@ void TTSAgent::pcmEventCallback(enum nugu_media_event event, void* userdata)
     TTSAgent* tts = static_cast<TTSAgent*>(userdata);
 
     switch (event) {
-    case MEDIA_EVENT_END_OF_STREAM:
+    case NUGU_MEDIA_EVENT_END_OF_STREAM:
         tts->sendEventSpeechFinished(tts->cur_token);
         tts->finish = true;
-        tts->speak_status = MEDIA_STATUS_STOPPED;
+        tts->speak_status = NUGU_MEDIA_STATUS_STOPPED;
         tts->capa_helper->releaseFocus("cap_tts");
         break;
     default:
@@ -179,13 +179,13 @@ NuguFocusResult TTSAgent::onFocus(void* event)
 
     switch (speak_status) {
     case -1:
-    case MEDIA_STATUS_STOPPED:
-    case MEDIA_STATUS_READY:
+    case NUGU_MEDIA_STATUS_STOPPED:
+    case NUGU_MEDIA_STATUS_READY:
         nugu_info("nugu_pcm_start(speak->pcm)");
         if (nugu_directive_get_data_size(speak_dir) > 0)
             getAttachmentData(speak_dir, this);
         break;
-    case MEDIA_STATUS_PLAYING:
+    case NUGU_MEDIA_STATUS_PLAYING:
         nugu_info("already playing");
         break;
     }
@@ -201,7 +201,7 @@ NuguFocusResult TTSAgent::onUnfocus(void* event)
 
     playsync_manager->removeContext(playstackctl_ps_id, getName(), !finish);
 
-    if (tts_listener && cur_status != MEDIA_STATUS_STOPPED)
+    if (tts_listener && cur_status != NUGU_MEDIA_STATUS_STOPPED)
         tts_listener->onTTSCancel(dialog_id);
 
     return NUGU_FOCUS_REMOVE;
@@ -228,7 +228,7 @@ void TTSAgent::stopTTS()
         nugu_pcm_stop(pcm);
     }
 
-    if (tts_listener && cur_status != MEDIA_STATUS_STOPPED && cur_status != -1)
+    if (tts_listener && cur_status != NUGU_MEDIA_STATUS_STOPPED && cur_status != -1)
         tts_listener->onTTSCancel(dialog_id);
 }
 
@@ -292,11 +292,11 @@ void TTSAgent::updateInfoForContext(Json::Value& ctx)
     case -1:
         tts["ttsActivity"] = "IDLE";
         break;
-    case MEDIA_STATUS_STOPPED:
+    case NUGU_MEDIA_STATUS_STOPPED:
         tts["ttsActivity"] = "STOPPED";
         break;
-    case MEDIA_STATUS_READY:
-    case MEDIA_STATUS_PLAYING:
+    case NUGU_MEDIA_STATUS_READY:
+    case NUGU_MEDIA_STATUS_PLAYING:
         tts["ttsActivity"] = "PLAYING";
         break;
     default:

--- a/src/core/audio_recorder_manager.cc
+++ b/src/core/audio_recorder_manager.cc
@@ -264,51 +264,51 @@ NuguAudioProperty AudioRecorderManager::convertNuguAudioProperty(std::string& sa
     std::transform(format.begin(), format.end(), format.begin(), ::tolower);
 
     if (sample == "8k")
-        property.samplerate = AUDIO_SAMPLE_RATE_8K;
+        property.samplerate = NUGU_AUDIO_SAMPLE_RATE_8K;
     else if (sample == "16k")
-        property.samplerate = AUDIO_SAMPLE_RATE_16K;
+        property.samplerate = NUGU_AUDIO_SAMPLE_RATE_16K;
     else if (sample == "32k")
-        property.samplerate = AUDIO_SAMPLE_RATE_32K;
+        property.samplerate = NUGU_AUDIO_SAMPLE_RATE_32K;
     else if (sample == "22k")
-        property.samplerate = AUDIO_SAMPLE_RATE_22K;
+        property.samplerate = NUGU_AUDIO_SAMPLE_RATE_22K;
     else if (sample == "44k")
-        property.samplerate = AUDIO_SAMPLE_RATE_44K;
+        property.samplerate = NUGU_AUDIO_SAMPLE_RATE_44K;
     else {
         nugu_error("not support the sample rate => %s", sample.c_str());
-        property.samplerate = AUDIO_SAMPLE_RATE_16K;
+        property.samplerate = NUGU_AUDIO_SAMPLE_RATE_16K;
     }
 
     if (format == "s8")
-        property.format = AUDIO_FORMAT_S8;
+        property.format = NUGU_AUDIO_FORMAT_S8;
     else if (format == "u8")
-        property.format = AUDIO_FORMAT_U8;
+        property.format = NUGU_AUDIO_FORMAT_U8;
     else if (format == "s16le")
-        property.format = AUDIO_FORMAT_S16_LE;
+        property.format = NUGU_AUDIO_FORMAT_S16_LE;
     else if (format == "s16be")
-        property.format = AUDIO_FORMAT_S16_BE;
+        property.format = NUGU_AUDIO_FORMAT_S16_BE;
     else if (format == "u16le")
-        property.format = AUDIO_FORMAT_U16_LE;
+        property.format = NUGU_AUDIO_FORMAT_U16_LE;
     else if (format == "u16be")
-        property.format = AUDIO_FORMAT_U16_BE;
+        property.format = NUGU_AUDIO_FORMAT_U16_BE;
     else if (format == "s24le")
-        property.format = AUDIO_FORMAT_S24_LE;
+        property.format = NUGU_AUDIO_FORMAT_S24_LE;
     else if (format == "s24be")
-        property.format = AUDIO_FORMAT_S24_BE;
+        property.format = NUGU_AUDIO_FORMAT_S24_BE;
     else if (format == "u24le")
-        property.format = AUDIO_FORMAT_U24_LE;
+        property.format = NUGU_AUDIO_FORMAT_U24_LE;
     else if (format == "u24be")
-        property.format = AUDIO_FORMAT_U24_BE;
+        property.format = NUGU_AUDIO_FORMAT_U24_BE;
     else if (format == "s32le")
-        property.format = AUDIO_FORMAT_S32_LE;
+        property.format = NUGU_AUDIO_FORMAT_S32_LE;
     else if (format == "s32be")
-        property.format = AUDIO_FORMAT_S32_BE;
+        property.format = NUGU_AUDIO_FORMAT_S32_BE;
     else if (format == "u32le")
-        property.format = AUDIO_FORMAT_U32_LE;
+        property.format = NUGU_AUDIO_FORMAT_U32_LE;
     else if (format == "u32be")
-        property.format = AUDIO_FORMAT_U32_BE;
+        property.format = NUGU_AUDIO_FORMAT_U32_BE;
     else {
         nugu_error("not support the format => %s", format.c_str());
-        property.format = AUDIO_FORMAT_S16_LE;
+        property.format = NUGU_AUDIO_FORMAT_S16_LE;
     }
 
     property.channel = std::stoi(channel);

--- a/src/core/capability_manager.cc
+++ b/src/core/capability_manager.cc
@@ -82,14 +82,14 @@ void CapabilityManager::destroyInstance()
     }
 }
 
-DirseqReturn CapabilityManager::dirseqCallback(NuguDirective* ndir, void* userdata)
+NuguDirseqReturn CapabilityManager::dirseqCallback(NuguDirective* ndir, void* userdata)
 {
     CapabilityManager* agent = static_cast<CapabilityManager*>(userdata);
     const char* name_space = nugu_directive_peek_namespace(ndir);
     ICapabilityInterface* cap = agent->findCapability(std::string(name_space));
     if (!cap) {
         nugu_warn("capability(%s) is not support", name_space);
-        return DIRSEQ_REMOVE;
+        return NUGU_DIRSEQ_REMOVE;
     }
 
     agent->preprocessDirective(ndir);
@@ -98,11 +98,11 @@ DirseqReturn CapabilityManager::dirseqCallback(NuguDirective* ndir, void* userda
     if (!agent->isSupportDirectiveVersion(version, cap)) {
         nugu_error("directives[%s] cannot work on %s[%s] agent",
             version, cap->getName().c_str(), cap->getVersion().c_str());
-        return DIRSEQ_REMOVE;
+        return NUGU_DIRSEQ_REMOVE;
     }
 
     cap->processDirective(ndir);
-    return DIRSEQ_CONTINUE;
+    return NUGU_DIRSEQ_CONTINUE;
 }
 
 void CapabilityManager::addCapability(const std::string& cname, ICapabilityInterface* cap)

--- a/src/core/capability_manager.hh
+++ b/src/core/capability_manager.hh
@@ -37,7 +37,7 @@ public:
     static void destroyInstance();
     PlaySyncManager* getPlaySyncManager();
 
-    static DirseqReturn dirseqCallback(NuguDirective* ndir, void* userdata);
+    static NuguDirseqReturn dirseqCallback(NuguDirective* ndir, void* userdata);
 
     void addCapability(const std::string& cname, ICapabilityInterface* cap);
     void removeCapability(const std::string& cname);

--- a/src/core/media_player.cc
+++ b/src/core/media_player.cc
@@ -83,21 +83,21 @@ MediaPlayer::MediaPlayer(int volume)
     }
     nugu_player_add(d->player);
 
-    mediaStatusCallback scb = [](enum nugu_media_status status,
+    NuguMediaStatusCallback scb = [](enum nugu_media_status status,
                                   void* userdata) {
         MediaPlayer* mplayer = static_cast<MediaPlayer*>(userdata);
 
         switch (status) {
-        case MEDIA_STATUS_STOPPED:
+        case NUGU_MEDIA_STATUS_STOPPED:
             mplayer->setState(MediaPlayerState::STOPPED);
             break;
-        case MEDIA_STATUS_READY:
+        case NUGU_MEDIA_STATUS_READY:
             mplayer->setState(MediaPlayerState::READY);
             break;
-        case MEDIA_STATUS_PLAYING:
+        case NUGU_MEDIA_STATUS_PLAYING:
             mplayer->setState(MediaPlayerState::PLAYING);
             break;
-        case MEDIA_STATUS_PAUSED:
+        case NUGU_MEDIA_STATUS_PAUSED:
             mplayer->setState(MediaPlayerState::PAUSED);
             break;
         default:
@@ -107,7 +107,7 @@ MediaPlayer::MediaPlayer(int volume)
     };
     nugu_player_set_status_callback(d->player, scb, this);
 
-    mediaEventCallback ecb = [](enum nugu_media_event event,
+    NuguMediaEventCallback ecb = [](enum nugu_media_event event,
                                  void* userdata) {
         MediaPlayer* mplayer = static_cast<MediaPlayer*>(userdata);
         MediaPlayerPrivate* d = MediaPlayerPrivate::mp_map[mplayer];
@@ -121,19 +121,19 @@ MediaPlayer::MediaPlayer(int volume)
             return;
 
         switch (event) {
-        case MEDIA_EVENT_MEDIA_SOURCE_CHANGED:
+        case NUGU_MEDIA_EVENT_MEDIA_SOURCE_CHANGED:
             for (auto l : d->listeners)
                 l->mediaChanged(mplayer->url());
             break;
-        case MEDIA_EVENT_MEDIA_INVALID:
+        case NUGU_MEDIA_EVENT_MEDIA_INVALID:
             for (auto l : d->listeners)
                 l->mediaEventReport(MediaPlayerEvent::INVALID_MEDIA_URL);
             break;
-        case MEDIA_EVENT_MEDIA_LOAD_FAILED:
+        case NUGU_MEDIA_EVENT_MEDIA_LOAD_FAILED:
             for (auto l : d->listeners)
                 l->mediaEventReport(MediaPlayerEvent::LOADING_MEDIA_FAILED);
             break;
-        case MEDIA_EVENT_MEDIA_LOADED: {
+        case NUGU_MEDIA_EVENT_MEDIA_LOADED: {
             int duration = nugu_player_get_duration(player);
             if (duration > 0)
                 mplayer->setDuration(duration);
@@ -141,7 +141,7 @@ MediaPlayer::MediaPlayer(int volume)
             for (auto l : d->listeners)
                 l->mediaEventReport(MediaPlayerEvent::LOADING_MEDIA_SUCCESS);
         } break;
-        case MEDIA_EVENT_END_OF_STREAM:
+        case NUGU_MEDIA_EVENT_END_OF_STREAM:
             // ignore STOP event after EOF
             d->state = MediaPlayerState::STOPPED;
 

--- a/tests/core-timer/nugu_timer_mock.cc
+++ b/tests/core-timer/nugu_timer_mock.cc
@@ -28,7 +28,7 @@ struct _nugu_timer {
     int fake_count;
     int repeat;
     int count;
-    timeoutCallback cb;
+    NuguTimeoutCallback cb;
     void* userdata;
     int start;
 };
@@ -151,7 +151,7 @@ void nugu_timer_stop(NuguTimer* timer)
     timers = g_list_remove(timers, timer);
 }
 
-void nugu_timer_set_callback(NuguTimer* timer, timeoutCallback callback,
+void nugu_timer_set_callback(NuguTimer* timer, NuguTimeoutCallback callback,
     void* userdata)
 {
     timer->cb = callback;

--- a/tests/test-nugu-buffer.c
+++ b/tests/test-nugu-buffer.c
@@ -85,20 +85,20 @@ static void test_buffer_byte(void)
 	NuguBuffer *buf;
 	int pos;
 
-	g_assert(nugu_buffer_find_byte(NULL, '0') == NOT_FOUND);
+	g_assert(nugu_buffer_find_byte(NULL, '0') == NUGU_BUFFER_NOT_FOUND);
 	g_assert(nugu_buffer_peek_byte(NULL, 0) == 0);
 
 	buf = nugu_buffer_new(0);
 	g_assert(buf != NULL);
 
 	g_assert(nugu_buffer_add(buf, "abcde", 5) == 5);
-	g_assert(nugu_buffer_find_byte(buf, '0') == NOT_FOUND);
+	g_assert(nugu_buffer_find_byte(buf, '0') == NUGU_BUFFER_NOT_FOUND);
 	g_assert(nugu_buffer_find_byte(buf, 'a') == 0);
 	g_assert(nugu_buffer_find_byte(buf, 'b') == 1);
 	g_assert(nugu_buffer_find_byte(buf, 'c') == 2);
 	g_assert(nugu_buffer_find_byte(buf, 'd') == 3);
 	g_assert(nugu_buffer_find_byte(buf, 'e') == 4);
-	g_assert(nugu_buffer_find_byte(buf, '\0') == NOT_FOUND);
+	g_assert(nugu_buffer_find_byte(buf, '\0') == NUGU_BUFFER_NOT_FOUND);
 
 	g_assert(nugu_buffer_peek_byte(buf, 0) == 'a');
 	g_assert(nugu_buffer_peek_byte(buf, 1) == 'b');
@@ -120,7 +120,7 @@ static void test_buffer_byte(void)
 
 	g_assert(nugu_buffer_clear(buf) == 0);
 	g_assert(nugu_buffer_get_size(buf) == 0);
-	g_assert(nugu_buffer_find_byte(buf, '\r') == NOT_FOUND);
+	g_assert(nugu_buffer_find_byte(buf, '\r') == NUGU_BUFFER_NOT_FOUND);
 
 	g_assert(nugu_buffer_free(buf, 1) == NULL);
 }

--- a/tests/test-nugu-decoder.c
+++ b/tests/test-nugu-decoder.c
@@ -63,7 +63,7 @@ static void test_decoder_decode(void)
 	size_t result_length = 0;
 	void *output;
 
-	driver = nugu_decoder_driver_new("test", DECODER_TYPE_CUSTOM,
+	driver = nugu_decoder_driver_new("test", NUGU_DECODER_TYPE_CUSTOM,
 					 &decoder_driver_ops);
 	g_assert(driver != NULL);
 
@@ -93,38 +93,39 @@ static void test_decoder_default(void)
 	char *mydata = "test";
 	size_t result_length = 999;
 
-	g_assert(nugu_decoder_driver_new(NULL, DECODER_TYPE_CUSTOM, NULL) ==
-		 NULL);
-	g_assert(nugu_decoder_driver_new("test", DECODER_TYPE_CUSTOM, NULL) ==
-		 NULL);
-	g_assert(nugu_decoder_driver_new(NULL, DECODER_TYPE_CUSTOM,
+	g_assert(nugu_decoder_driver_new(NULL, NUGU_DECODER_TYPE_CUSTOM,
+					 NULL) == NULL);
+	g_assert(nugu_decoder_driver_new("test", NUGU_DECODER_TYPE_CUSTOM,
+					 NULL) == NULL);
+	g_assert(nugu_decoder_driver_new(NULL, NUGU_DECODER_TYPE_CUSTOM,
 					 &empty_ops) == NULL);
 	g_assert(nugu_decoder_driver_register(NULL) < 0);
 	g_assert(nugu_decoder_driver_remove(NULL) < 0);
 	g_assert(nugu_decoder_driver_find(NULL) == NULL);
 	g_assert(nugu_decoder_driver_find("") == NULL);
 
-	driver = nugu_decoder_driver_new("test", DECODER_TYPE_CUSTOM,
+	driver = nugu_decoder_driver_new("test", NUGU_DECODER_TYPE_CUSTOM,
 					 &empty_ops);
 	g_assert(driver != NULL);
 
 	g_assert(nugu_decoder_driver_find("test") == NULL);
 	g_assert(nugu_decoder_driver_register(driver) == 0);
 	g_assert(nugu_decoder_driver_find("test") == driver);
-	g_assert(nugu_decoder_driver_find_bytype(DECODER_TYPE_CUSTOM) ==
+	g_assert(nugu_decoder_driver_find_bytype(NUGU_DECODER_TYPE_CUSTOM) ==
 		 driver);
-	g_assert(nugu_decoder_driver_find_bytype(DECODER_TYPE_OPUS) == NULL);
+	g_assert(nugu_decoder_driver_find_bytype(NUGU_DECODER_TYPE_OPUS) ==
+		 NULL);
 	g_assert(nugu_decoder_driver_remove(driver) == 0);
 	g_assert(nugu_decoder_driver_find("test") == NULL);
 
 	nugu_decoder_driver_free(driver);
 
-	driver = nugu_decoder_driver_new("test1", DECODER_TYPE_CUSTOM,
+	driver = nugu_decoder_driver_new("test1", NUGU_DECODER_TYPE_CUSTOM,
 					 &empty_ops);
 	g_assert(driver != NULL);
 	g_assert(nugu_decoder_driver_register(driver) == 0);
 
-	driver2 = nugu_decoder_driver_new("test2", DECODER_TYPE_CUSTOM,
+	driver2 = nugu_decoder_driver_new("test2", NUGU_DECODER_TYPE_CUSTOM,
 					  &empty_ops);
 	g_assert(driver2 != NULL);
 	g_assert(nugu_decoder_driver_register(driver2) == 0);

--- a/tests/test-nugu-pcm.c
+++ b/tests/test-nugu-pcm.c
@@ -49,18 +49,18 @@ static int dummy_start(NuguPcmDriver *driver, NuguPcm *pcm,
 		       NuguAudioProperty prop)
 {
 	if (pcm == nugu_pcm_find("pcm2")) {
-		nugu_pcm_emit_status(pcm, MEDIA_STATUS_READY);
-		nugu_pcm_emit_event(pcm, MEDIA_EVENT_MEDIA_LOAD_FAILED);
+		nugu_pcm_emit_status(pcm, NUGU_MEDIA_STATUS_READY);
+		nugu_pcm_emit_event(pcm, NUGU_MEDIA_EVENT_MEDIA_LOAD_FAILED);
 	} else {
-		nugu_pcm_emit_event(pcm, MEDIA_EVENT_MEDIA_LOADED);
-		nugu_pcm_emit_status(pcm, MEDIA_STATUS_PLAYING);
+		nugu_pcm_emit_event(pcm, NUGU_MEDIA_EVENT_MEDIA_LOADED);
+		nugu_pcm_emit_status(pcm, NUGU_MEDIA_STATUS_PLAYING);
 	}
 	return 0;
 }
 
 static int dummy_stop(NuguPcmDriver *driver, NuguPcm *pcm)
 {
-	nugu_pcm_emit_status(pcm, MEDIA_STATUS_STOPPED);
+	nugu_pcm_emit_status(pcm, NUGU_MEDIA_STATUS_STOPPED);
 	return 0;
 }
 
@@ -110,13 +110,13 @@ static void test_pcm_default(void)
 	nugu_pcm_set_status_callback(pcm, pcm_status_callback, NULL);
 	nugu_pcm_set_event_callback(pcm, pcm_event_callback, NULL);
 
-	prop.samplerate = AUDIO_SAMPLE_RATE_22K;
-	prop.format = AUDIO_FORMAT_S16_LE;
+	prop.samplerate = NUGU_AUDIO_SAMPLE_RATE_22K;
+	prop.format = NUGU_AUDIO_FORMAT_S16_LE;
 	prop.channel = 1;
 	g_assert(nugu_pcm_set_property(pcm, prop) == 0);
 
-	CHECK_EVENT(MEDIA_EVENT_MEDIA_LOADED);
-	CHECK_STATUS(MEDIA_STATUS_PLAYING);
+	CHECK_EVENT(NUGU_MEDIA_EVENT_MEDIA_LOADED);
+	CHECK_STATUS(NUGU_MEDIA_STATUS_PLAYING);
 	g_assert(nugu_pcm_start(pcm) == 0);
 
 	/* push data 10 bytes */
@@ -138,7 +138,7 @@ static void test_pcm_default(void)
 	g_assert_cmpstr(tmp, ==, "abc");
 	g_assert(nugu_pcm_get_data_size(pcm) == 2);
 
-	CHECK_STATUS(MEDIA_STATUS_STOPPED);
+	CHECK_STATUS(NUGU_MEDIA_STATUS_STOPPED);
 	g_assert(nugu_pcm_stop(pcm) == 0);
 
 	nugu_pcm_remove(pcm);
@@ -169,22 +169,22 @@ static void test_pcm_multiple(void)
 	nugu_pcm_set_status_callback(pcm2, pcm_status_callback2, NULL);
 	nugu_pcm_set_event_callback(pcm2, pcm_event_callback2, NULL);
 
-	prop.samplerate = AUDIO_SAMPLE_RATE_22K;
-	prop.format = AUDIO_FORMAT_S16_LE;
+	prop.samplerate = NUGU_AUDIO_SAMPLE_RATE_22K;
+	prop.format = NUGU_AUDIO_FORMAT_S16_LE;
 	prop.channel = 1;
 	g_assert(nugu_pcm_set_property(pcm1, prop) == 0);
 
-	CHECK_STATUS(MEDIA_STATUS_PLAYING);
+	CHECK_STATUS(NUGU_MEDIA_STATUS_PLAYING);
 	g_assert(nugu_pcm_start(pcm1) == 0);
 
-	CHECK_STATUS(MEDIA_STATUS_STOPPED);
+	CHECK_STATUS(NUGU_MEDIA_STATUS_STOPPED);
 	g_assert(nugu_pcm_stop(pcm1) == 0);
 
-	CHECK_EVENT2(MEDIA_EVENT_MEDIA_LOAD_FAILED);
-	CHECK_STATUS2(MEDIA_STATUS_READY);
+	CHECK_EVENT2(NUGU_MEDIA_EVENT_MEDIA_LOAD_FAILED);
+	CHECK_STATUS2(NUGU_MEDIA_STATUS_READY);
 	g_assert(nugu_pcm_start(pcm2) == 0);
 
-	CHECK_STATUS2(MEDIA_STATUS_STOPPED);
+	CHECK_STATUS2(NUGU_MEDIA_STATUS_STOPPED);
 	g_assert(nugu_pcm_stop(pcm2) == 0);
 
 	nugu_pcm_remove(pcm1);

--- a/tests/test-nugu-player.c
+++ b/tests/test-nugu-player.c
@@ -66,10 +66,11 @@ static int dummy_start(void *device, NuguPlayer *player)
 {
 	(void)device;
 	if (g_strcmp0(_playurl, WRONG_PLAYURL) == 0)
-		nugu_player_emit_event(player, MEDIA_EVENT_MEDIA_LOAD_FAILED);
+		nugu_player_emit_event(player,
+				       NUGU_MEDIA_EVENT_MEDIA_LOAD_FAILED);
 	else {
-		nugu_player_emit_event(player, MEDIA_EVENT_MEDIA_LOADED);
-		nugu_player_emit_status(player, MEDIA_STATUS_PLAYING);
+		nugu_player_emit_event(player, NUGU_MEDIA_EVENT_MEDIA_LOADED);
+		nugu_player_emit_status(player, NUGU_MEDIA_STATUS_PLAYING);
 	}
 	_seek_pos = 0;
 	_position = 0;
@@ -78,19 +79,19 @@ static int dummy_start(void *device, NuguPlayer *player)
 static int dummy_stop(void *device, NuguPlayer *player)
 {
 	(void)device;
-	nugu_player_emit_status(player, MEDIA_STATUS_STOPPED);
+	nugu_player_emit_status(player, NUGU_MEDIA_STATUS_STOPPED);
 	return 0;
 }
 static int dummy_pause(void *device, NuguPlayer *player)
 {
 	(void)device;
-	nugu_player_emit_status(player, MEDIA_STATUS_PAUSED);
+	nugu_player_emit_status(player, NUGU_MEDIA_STATUS_PAUSED);
 	return 0;
 }
 static int dummy_resume(void *device, NuguPlayer *player)
 {
 	(void)device;
-	nugu_player_emit_status(player, MEDIA_STATUS_PLAYING);
+	nugu_player_emit_status(player, NUGU_MEDIA_STATUS_PLAYING);
 	return 0;
 }
 static int dummy_seek(void *device, NuguPlayer *player, int sec)
@@ -101,7 +102,7 @@ static int dummy_seek(void *device, NuguPlayer *player, int sec)
 
 	if (_seek_pos > _duration) {
 		_seek_pos = _duration;
-		nugu_player_emit_event(player, MEDIA_EVENT_END_OF_STREAM);
+		nugu_player_emit_event(player, NUGU_MEDIA_EVENT_END_OF_STREAM);
 	} else if (_seek_pos < 0) {
 		_seek_pos = 0;
 	}
@@ -110,7 +111,7 @@ static int dummy_seek(void *device, NuguPlayer *player, int sec)
 }
 static int dummy_set_source(void *device, NuguPlayer *player, const char *url)
 {
-	nugu_player_emit_event(player, MEDIA_EVENT_MEDIA_SOURCE_CHANGED);
+	nugu_player_emit_event(player, NUGU_MEDIA_EVENT_MEDIA_SOURCE_CHANGED);
 	dummy_stop(device, player);
 
 	_playurl = url;
@@ -128,7 +129,7 @@ static int dummy_get_duration(void *device, NuguPlayer *player)
 {
 	(void)device;
 	(void)player;
-	if (_status == MEDIA_STATUS_STOPPED)
+	if (_status == NUGU_MEDIA_STATUS_STOPPED)
 		_duration = -1;
 	else
 		_duration = DUMMY_DURATION;
@@ -140,7 +141,7 @@ static int dummy_get_position(void *device, NuguPlayer *player)
 {
 	(void)device;
 	(void)player;
-	if (_status == MEDIA_STATUS_STOPPED)
+	if (_status == NUGU_MEDIA_STATUS_STOPPED)
 		_position = -1;
 	else if (_seek_pos)
 		_position = _seek_pos;
@@ -192,22 +193,22 @@ static void test_player_default(void)
 	nugu_player_set_status_callback(player, player_status_callback, NULL);
 	nugu_player_set_event_callback(player, player_event_callback, NULL);
 
-	CHECK_EVENT(MEDIA_EVENT_MEDIA_SOURCE_CHANGED);
-	CHECK_STATUS(MEDIA_STATUS_STOPPED);
+	CHECK_EVENT(NUGU_MEDIA_EVENT_MEDIA_SOURCE_CHANGED);
+	CHECK_STATUS(NUGU_MEDIA_STATUS_STOPPED);
 	nugu_player_set_source(player, RIGHT_PLAYURL);
 
-	CHECK_EVENT(MEDIA_EVENT_MEDIA_LOADED);
-	CHECK_STATUS(MEDIA_STATUS_PLAYING);
+	CHECK_EVENT(NUGU_MEDIA_EVENT_MEDIA_LOADED);
+	CHECK_STATUS(NUGU_MEDIA_STATUS_PLAYING);
 	CHECK_VOLUME(NUGU_SET_VOLUME_DEFAULT);
 	g_assert(nugu_player_start(player) == 0);
 
-	CHECK_STATUS(MEDIA_STATUS_PAUSED);
+	CHECK_STATUS(NUGU_MEDIA_STATUS_PAUSED);
 	g_assert(nugu_player_pause(player) == 0);
 
-	CHECK_STATUS(MEDIA_STATUS_PLAYING);
+	CHECK_STATUS(NUGU_MEDIA_STATUS_PLAYING);
 	g_assert(nugu_player_resume(player) == 0);
 
-	CHECK_STATUS(MEDIA_STATUS_STOPPED);
+	CHECK_STATUS(NUGU_MEDIA_STATUS_STOPPED);
 	g_assert(nugu_player_stop(player) == 0);
 
 	nugu_player_remove(player);
@@ -234,7 +235,7 @@ static void test_player_info(void)
 	nugu_player_set_source(player, RIGHT_PLAYURL);
 
 	CHECK_VOLUME(NUGU_SET_VOLUME_DEFAULT);
-	CHECK_STATUS(MEDIA_STATUS_PLAYING);
+	CHECK_STATUS(NUGU_MEDIA_STATUS_PLAYING);
 	g_assert(nugu_player_start(player) == 0);
 
 	g_assert(nugu_player_get_duration(player) == DUMMY_DURATION);
@@ -264,21 +265,21 @@ static void test_player_probe(void)
 	nugu_player_set_event_callback(player, player_event_callback, NULL);
 
 	/* set available media content source */
-	CHECK_EVENT(MEDIA_EVENT_MEDIA_SOURCE_CHANGED);
-	CHECK_STATUS(MEDIA_STATUS_STOPPED);
+	CHECK_EVENT(NUGU_MEDIA_EVENT_MEDIA_SOURCE_CHANGED);
+	CHECK_STATUS(NUGU_MEDIA_STATUS_STOPPED);
 	nugu_player_set_source(player, RIGHT_PLAYURL);
 
-	CHECK_EVENT(MEDIA_EVENT_MEDIA_LOADED);
-	CHECK_STATUS(MEDIA_STATUS_PLAYING);
+	CHECK_EVENT(NUGU_MEDIA_EVENT_MEDIA_LOADED);
+	CHECK_STATUS(NUGU_MEDIA_STATUS_PLAYING);
 	CHECK_VOLUME(NUGU_SET_VOLUME_DEFAULT);
 	g_assert(nugu_player_start(player) == 0);
 
 	/* set unavailable media content source */
-	CHECK_EVENT(MEDIA_EVENT_MEDIA_SOURCE_CHANGED);
-	CHECK_STATUS(MEDIA_STATUS_STOPPED);
+	CHECK_EVENT(NUGU_MEDIA_EVENT_MEDIA_SOURCE_CHANGED);
+	CHECK_STATUS(NUGU_MEDIA_STATUS_STOPPED);
 	nugu_player_set_source(player, WRONG_PLAYURL);
 
-	CHECK_EVENT(MEDIA_EVENT_MEDIA_LOAD_FAILED);
+	CHECK_EVENT(NUGU_MEDIA_EVENT_MEDIA_LOAD_FAILED);
 	g_assert(nugu_player_start(player) == 0);
 
 	nugu_player_remove(player);
@@ -302,13 +303,13 @@ static void test_nugu_player_seek(void)
 	nugu_player_set_status_callback(player, player_status_callback, NULL);
 	nugu_player_set_event_callback(player, player_event_callback, NULL);
 
-	CHECK_EVENT(MEDIA_EVENT_MEDIA_SOURCE_CHANGED);
-	CHECK_STATUS(MEDIA_STATUS_STOPPED);
+	CHECK_EVENT(NUGU_MEDIA_EVENT_MEDIA_SOURCE_CHANGED);
+	CHECK_STATUS(NUGU_MEDIA_STATUS_STOPPED);
 	nugu_player_set_source(player, RIGHT_PLAYURL);
 
 	/* test for positive seek */
-	CHECK_EVENT(MEDIA_EVENT_MEDIA_LOADED);
-	CHECK_STATUS(MEDIA_STATUS_PLAYING);
+	CHECK_EVENT(NUGU_MEDIA_EVENT_MEDIA_LOADED);
+	CHECK_STATUS(NUGU_MEDIA_STATUS_PLAYING);
 	CHECK_VOLUME(NUGU_SET_VOLUME_DEFAULT);
 	g_assert(nugu_player_start(player) == 0);
 
@@ -318,16 +319,16 @@ static void test_nugu_player_seek(void)
 	g_assert(nugu_player_seek(player, DUMMY_SEEK_ONE_THIRD) == 0);
 	g_assert(nugu_player_get_position(player) == 2 * DUMMY_SEEK_ONE_THIRD);
 
-	CHECK_EVENT(MEDIA_EVENT_END_OF_STREAM);
+	CHECK_EVENT(NUGU_MEDIA_EVENT_END_OF_STREAM);
 	g_assert(nugu_player_seek(player, DUMMY_SEEK_ONE_THIRD) == 0);
 	g_assert(nugu_player_get_position(player) == DUMMY_DURATION);
 
-	CHECK_STATUS(MEDIA_STATUS_STOPPED);
+	CHECK_STATUS(NUGU_MEDIA_STATUS_STOPPED);
 	g_assert(nugu_player_stop(player) == 0);
 
 	/* test for negative seek */
-	CHECK_EVENT(MEDIA_EVENT_MEDIA_LOADED);
-	CHECK_STATUS(MEDIA_STATUS_PLAYING);
+	CHECK_EVENT(NUGU_MEDIA_EVENT_MEDIA_LOADED);
+	CHECK_STATUS(NUGU_MEDIA_STATUS_PLAYING);
 	CHECK_VOLUME(NUGU_SET_VOLUME_DEFAULT);
 	g_assert(nugu_player_start(player) == 0);
 
@@ -343,16 +344,16 @@ static void test_nugu_player_seek(void)
 	g_assert(nugu_player_seek(player, -DUMMY_SEEK_ONE_THIRD) == 0);
 	g_assert(nugu_player_get_position(player) == 0);
 
-	CHECK_STATUS(MEDIA_STATUS_STOPPED);
+	CHECK_STATUS(NUGU_MEDIA_STATUS_STOPPED);
 	g_assert(nugu_player_stop(player) == 0);
 
 	/* test for positive seek when palyer is paused */
-	CHECK_EVENT(MEDIA_EVENT_MEDIA_LOADED);
-	CHECK_STATUS(MEDIA_STATUS_PLAYING);
+	CHECK_EVENT(NUGU_MEDIA_EVENT_MEDIA_LOADED);
+	CHECK_STATUS(NUGU_MEDIA_STATUS_PLAYING);
 	CHECK_VOLUME(NUGU_SET_VOLUME_DEFAULT);
 	g_assert(nugu_player_start(player) == 0);
 
-	CHECK_STATUS(MEDIA_STATUS_PAUSED);
+	CHECK_STATUS(NUGU_MEDIA_STATUS_PAUSED);
 	g_assert(nugu_player_pause(player) == 0);
 
 	g_assert(nugu_player_get_position(player) == DUMMY_POSITION);
@@ -360,12 +361,12 @@ static void test_nugu_player_seek(void)
 	g_assert(nugu_player_seek(player, DUMMY_SEEK_ONE_HALF) == 0);
 	g_assert(nugu_player_get_position(player) == DUMMY_SEEK_ONE_HALF);
 
-	g_assert(nugu_player_get_status(player) == MEDIA_STATUS_PAUSED);
+	g_assert(nugu_player_get_status(player) == NUGU_MEDIA_STATUS_PAUSED);
 
-	CHECK_STATUS(MEDIA_STATUS_PLAYING);
+	CHECK_STATUS(NUGU_MEDIA_STATUS_PLAYING);
 	g_assert(nugu_player_resume(player) == 0);
 
-	CHECK_STATUS(MEDIA_STATUS_STOPPED);
+	CHECK_STATUS(NUGU_MEDIA_STATUS_STOPPED);
 	g_assert(nugu_player_stop(player) == 0);
 
 	nugu_player_remove(player);
@@ -390,14 +391,14 @@ static void test_player_volume(void)
 	nugu_player_set_status_callback(player, player_status_callback, NULL);
 	nugu_player_set_event_callback(player, player_event_callback, NULL);
 
-	CHECK_EVENT(MEDIA_EVENT_MEDIA_SOURCE_CHANGED);
-	CHECK_STATUS(MEDIA_STATUS_STOPPED);
+	CHECK_EVENT(NUGU_MEDIA_EVENT_MEDIA_SOURCE_CHANGED);
+	CHECK_STATUS(NUGU_MEDIA_STATUS_STOPPED);
 	nugu_player_set_source(player, RIGHT_PLAYURL);
 
 	g_assert(nugu_player_get_volume(player) == NUGU_SET_VOLUME_DEFAULT);
 
-	CHECK_EVENT(MEDIA_EVENT_MEDIA_LOADED);
-	CHECK_STATUS(MEDIA_STATUS_PLAYING);
+	CHECK_EVENT(NUGU_MEDIA_EVENT_MEDIA_LOADED);
+	CHECK_STATUS(NUGU_MEDIA_STATUS_PLAYING);
 	CHECK_VOLUME(NUGU_SET_VOLUME_DEFAULT);
 	g_assert(nugu_player_start(player) == 0);
 
@@ -417,7 +418,7 @@ static void test_player_volume(void)
 		g_assert(nugu_player_get_volume(player) == i);
 	}
 
-	CHECK_STATUS(MEDIA_STATUS_STOPPED);
+	CHECK_STATUS(NUGU_MEDIA_STATUS_STOPPED);
 	g_assert(nugu_player_stop(player) == 0);
 
 	nugu_player_remove(player);

--- a/tests/test-nugu-recorder.c
+++ b/tests/test-nugu-recorder.c
@@ -24,8 +24,8 @@
 #include "base/nugu_recorder.h"
 
 #define SET_DEFAULT_AUDIO_PROPERTY(property)                                   \
-	property.samplerate = AUDIO_SAMPLE_RATE_16K;                           \
-	property.format = AUDIO_FORMAT_S16_LE;                                 \
+	property.samplerate = NUGU_AUDIO_SAMPLE_RATE_16K;                      \
+	property.format = NUGU_AUDIO_FORMAT_S16_LE;                            \
 	property.channel = 1
 
 #define DEFAULT_PLUGIN_NAME "portaudio"
@@ -49,8 +49,8 @@ static int dummy_start(NuguRecorderDriver *driver, NuguRecorder *rec,
 {
 	(void)driver;
 
-	g_assert(property.samplerate == AUDIO_SAMPLE_RATE_16K);
-	g_assert(property.format == AUDIO_FORMAT_S16_LE);
+	g_assert(property.samplerate == NUGU_AUDIO_SAMPLE_RATE_16K);
+	g_assert(property.format == NUGU_AUDIO_FORMAT_S16_LE);
 	g_assert(property.channel == 1);
 
 	g_assert(nugu_recorder_push_frame(rec, MOCK_AUDIO_FRAMES,
@@ -76,8 +76,8 @@ static int timeout_start(NuguRecorderDriver *driver, NuguRecorder *rec,
 	(void)driver;
 	(void)rec;
 
-	g_assert(property.samplerate == AUDIO_SAMPLE_RATE_16K);
-	g_assert(property.format == AUDIO_FORMAT_S16_LE);
+	g_assert(property.samplerate == NUGU_AUDIO_SAMPLE_RATE_16K);
+	g_assert(property.format == NUGU_AUDIO_FORMAT_S16_LE);
 	g_assert(property.channel == 1);
 
 	return 0;


### PR DESCRIPTION
To prevent name collisions, add 'nugu_' or 'NUGU_' prefix to all public
APIs.

Signed-off-by: Inho Oh <inho.oh@sk.com>