### PR TITLE
tests: fix build error on allwinner target

### DIFF
--- a/tests/core-timer/nugu_timer_mock.cc
+++ b/tests/core-timer/nugu_timer_mock.cc
@@ -16,11 +16,12 @@
  * limitations under the License.
  */
 
-#include <glib.h>
 #include <stdio.h>
 #include <string.h>
 
-#include <base/nugu_timer.h>
+#include <glib.h>
+
+#include "base/nugu_timer.h"
 
 struct _nugu_timer {
     GSource* source;

--- a/tests/core-timer/test-core-NuguTimer.cc
+++ b/tests/core-timer/test-core-NuguTimer.cc
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-#include <base/nugu_timer.h>
-#include <glib.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
+#include <glib.h>
+
+#include "base/nugu_timer.h"
 #include "nugu_timer.hh"
 
 using namespace NuguCore;
@@ -226,7 +227,7 @@ int main(int argc, char* argv[])
     g_type_init();
 #endif
 
-    g_test_init(&argc, &argv, NULL);
+    g_test_init(&argc, &argv, (void*)NULL);
     g_log_set_always_fatal((GLogLevelFlags)G_LOG_FATAL_MASK);
 
     G_TEST_ADD_FUNC("/core/NuguTimer/Trigger", test_nugutimer_trigger);


### PR DESCRIPTION
Fix build error for following error message

    error: missing sentinel in function call

Signed-off-by: Inho Oh <inho.oh@sk.com>