### PR TITLE
Focus: release asr focus

### DIFF
--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -260,7 +260,7 @@ void ASRAgent::receiveCommand(const std::string& from, const std::string& comman
             es_attr = {};
         }
     } else if (!convert_command.compare("releasefocus")) {
-        if (from == "System") {
+        if (from == "System" || from == "CapabilityManager") {
             if (dialog_id == param)
                 capa_helper->releaseFocus("asr");
         } else {

--- a/src/capability/system_agent.cc
+++ b/src/capability/system_agent.cc
@@ -362,15 +362,13 @@ void SystemAgent::parsingNoDirectives(const char* message)
 {
     Json::Value root;
     Json::Reader reader;
-    const char* dialog_id;
 
     if (!reader.parse(message, root)) {
         nugu_error("parsing error");
         return;
     }
 
-    dialog_id = nugu_directive_peek_dialog_id(getNuguDirective());
-    capa_helper->sendCommand("System", "ASR", "releasefocus", dialog_id);
+    // Do Nothing
 }
 
 void SystemAgent::parsingRevoke(const char* message)

--- a/src/capability/system_agent.hh
+++ b/src/capability/system_agent.hh
@@ -17,8 +17,8 @@
 #ifndef __NUGU_SYSTEM_AGENT_H__
 #define __NUGU_SYSTEM_AGENT_H__
 
-#include "clientkit/capability.hh"
 #include "capability/system_interface.hh"
+#include "clientkit/capability.hh"
 
 namespace NuguCapability {
 

--- a/src/core/capability_manager.hh
+++ b/src/core/capability_manager.hh
@@ -70,6 +70,8 @@ private:
     std::map<std::string, NuguFocus*> focusmap;
     std::string wword;
     std::unique_ptr<PlaySyncManager> playsync_manager = nullptr;
+    bool check_asr_focus_release = false;
+    std::string asr_dialog_id;
 };
 
 } // NuguCore


### PR DESCRIPTION
ASRAgent occupy the speaker's focus until the directives will be
arrived as "TTS.Speak" or "AudioPlayer.Play". In certain services,
there is a case where there is no corresponding directives
in the utterance response, and a focus release issue occurs.

Signed-off-by: Hyojoong Kim <hyojoong.kim@sk.com>