### PR TITLE
Open Capability Default Attribute Value

### DIFF
--- a/include/capability/asr_interface.hh
+++ b/include/capability/asr_interface.hh
@@ -35,6 +35,10 @@ using namespace NuguClientKit;
  * @{
  */
 
+#define NUGU_ASR_EPD_TYPE "CLIENT"
+#define NUGU_ASR_ENCODING "COMPLETE"
+#define NUGU_SERVER_RESPONSE_TIMEOUT_SEC 10
+
 /**
  * @brief ASR state list
  * @see IASRListener::onState

--- a/include/capability/text_interface.hh
+++ b/include/capability/text_interface.hh
@@ -34,6 +34,8 @@ using namespace NuguClientKit;
  * @{
  */
 
+#define NUGU_SERVER_RESPONSE_TIMEOUT_SEC 10
+
 /**
  * @brief TextState
  */

--- a/include/capability/tts_interface.hh
+++ b/include/capability/tts_interface.hh
@@ -34,6 +34,8 @@ using namespace NuguClientKit;
  * @{
  */
 
+#define NUGU_TTS_ENGINE "skt"
+
 /**
  * @brief TTSState
  */

--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -25,11 +25,6 @@ namespace NuguCapability {
 static const char* CAPABILITY_NAME = "ASR";
 static const char* CAPABILITY_VERSION = "1.0";
 
-// define default attribute values
-static const char* ASR_EPD_TYPE = "CLIENT";
-static const char* ASR_ENCODING = "COMPLETE";
-static const int SERVER_RESPONSE_TIMEOUT_SEC = 10;
-
 class ASRFocusListener : public IFocusListener {
 public:
     explicit ASRFocusListener(ASRAgent* agent, ISpeechRecognizer* speech_recognizer);
@@ -141,9 +136,9 @@ ASRAgent::ASRAgent()
     , asr_focus_listener(nullptr)
     , expect_focus_listener(nullptr)
     , model_path("")
-    , epd_type(ASR_EPD_TYPE)
-    , asr_encoding(ASR_ENCODING)
-    , response_timeout(SERVER_RESPONSE_TIMEOUT_SEC)
+    , epd_type(NUGU_ASR_EPD_TYPE)
+    , asr_encoding(NUGU_ASR_ENCODING)
+    , response_timeout(NUGU_SERVER_RESPONSE_TIMEOUT_SEC)
 {
 }
 

--- a/src/capability/text_agent.cc
+++ b/src/capability/text_agent.cc
@@ -24,16 +24,13 @@ namespace NuguCapability {
 static const char* CAPABILITY_NAME = "Text";
 static const char* CAPABILITY_VERSION = "1.0";
 
-// define default property values
-static const int SERVER_RESPONSE_TIMEOUT_SEC = 10;
-
 TextAgent::TextAgent()
     : Capability(CAPABILITY_NAME, CAPABILITY_VERSION)
     , text_listener(nullptr)
     , timer(nullptr)
     , cur_state(TextState::IDLE)
     , cur_dialog_id("")
-    , response_timeout(SERVER_RESPONSE_TIMEOUT_SEC)
+    , response_timeout(NUGU_SERVER_RESPONSE_TIMEOUT_SEC)
 {
 }
 

--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -26,9 +26,6 @@ namespace NuguCapability {
 static const char* CAPABILITY_NAME = "TTS";
 static const char* CAPABILITY_VERSION = "1.0";
 
-// define default property values
-static const char* TTS_ENGINE = "skt";
-
 TTSAgent::TTSAgent()
     : Capability(CAPABILITY_NAME, CAPABILITY_VERSION)
     , cur_token("")
@@ -40,7 +37,7 @@ TTSAgent::TTSAgent()
     , dialog_id("")
     , ps_id("")
     , tts_listener(nullptr)
-    , tts_engine(TTS_ENGINE)
+    , tts_engine(NUGU_TTS_ENGINE)
 {
 }
 
@@ -72,7 +69,7 @@ void TTSAgent::initialize()
     nugu_pcm_set_status_callback(pcm, pcmStatusCallback, this);
     nugu_pcm_set_event_callback(pcm, pcmEventCallback, this);
 
-    nugu_pcm_set_property(pcm, (NuguAudioProperty){ NUGU_AUDIO_SAMPLE_RATE_22K, NUGU_AUDIO_FORMAT_S16_LE, 1 });
+    nugu_pcm_set_property(pcm, (NuguAudioProperty) { NUGU_AUDIO_SAMPLE_RATE_22K, NUGU_AUDIO_FORMAT_S16_LE, 1 });
 
     capa_helper->addFocus("cap_tts", NUGU_FOCUS_TYPE_TTS, this);
 


### PR DESCRIPTION
The ASR,TTS,Text Agent need attibutes for activating.
Even the setter about attribute is provided, cause default
values exist in sdk privately, the user never know that value.

So, it update to show each agent's default value in
related interface header file.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>