### PR TITLE
Focus: release asr focus

### DIFF
--- a/src/core/capability_manager.cc
+++ b/src/core/capability_manager.cc
@@ -187,23 +187,23 @@ void CapabilityManager::preprocessDirective(NuguDirective* ndir)
 
     sendCommandAll("directive_dialog_id", nugu_directive_peek_dialog_id(ndir));
 
-    if (check_asr_focus_release && asr_dialog_id == nugu_directive_peek_dialog_id(ndir)) {
-        std::string groups = nugu_directive_peek_groups(ndir);
-
-        nugu_info("Check ASR Focus Release: %s", groups.c_str());
-        if (groups.find("TTS.Speak") == std::string::npos && groups.find("AudioPlayer.Play") == std::string::npos) {
-            nugu_info("ASR Focus Release by CapabilityManager");
-            sendCommand("CapabilityManager", "ASR", "releasefocus", asr_dialog_id);
-        } else {
-            nugu_info("ASR Focus Release by TTS or AudioPlayer");
-        }
-
-        check_asr_focus_release = false;
-    }
-
     if (name_space == "ASR" && dname == "NotifyResult") {
         check_asr_focus_release = true;
         asr_dialog_id = nugu_directive_peek_dialog_id(ndir);
+    } else {
+        if (check_asr_focus_release && asr_dialog_id == nugu_directive_peek_dialog_id(ndir)) {
+            std::string groups = nugu_directive_peek_groups(ndir);
+
+            nugu_info("Check ASR Focus Release: %s", groups.c_str());
+            if (groups.find("TTS.Speak") == std::string::npos && groups.find("AudioPlayer.Play") == std::string::npos) {
+                nugu_info("ASR Focus Release by CapabilityManager");
+                sendCommand("CapabilityManager", "ASR", "releasefocus", asr_dialog_id);
+            } else {
+                nugu_info("ASR Focus Release by TTS or AudioPlayer");
+            }
+
+            check_asr_focus_release = false;
+        }
     }
 }
 


### PR DESCRIPTION
The ASR.NotifyResult directive is sent repeatly when the asr is
partial encoding. Added exception handling for this case.

Signed-off-by: Hyojoong Kim <hyojoong.kim@sk.com>