### PR TITLE
Adjust CapabilityBuilder accessibility

### DIFF
--- a/include/clientkit/nugu_client.hh
+++ b/include/clientkit/nugu_client.hh
@@ -51,9 +51,6 @@ public:
      */
     class CapabilityBuilder {
     public:
-        explicit CapabilityBuilder(NuguClientImpl* client_impl);
-        virtual ~CapabilityBuilder();
-
         /**
          * @brief Add capability instance. It could create from CapabilityFactory or by self as inhering ICapabilityInterface
          * @param[in] cap_instance capability interface
@@ -68,6 +65,11 @@ public:
         bool construct();
 
     private:
+        friend class NuguClient;
+
+        explicit CapabilityBuilder(NuguClientImpl* client_impl);
+        virtual ~CapabilityBuilder() = default;
+
         NuguClientImpl* client_impl = nullptr;
     };
 
@@ -116,7 +118,7 @@ public:
 
 private:
     std::unique_ptr<NuguClientImpl> impl;
-    std::unique_ptr<CapabilityBuilder> cap_builder;
+    CapabilityBuilder* cap_builder;
 };
 
 /**

--- a/src/clientkit/nugu_client.cc
+++ b/src/clientkit/nugu_client.cc
@@ -25,10 +25,6 @@ NuguClient::CapabilityBuilder::CapabilityBuilder(NuguClientImpl* client_impl)
     this->client_impl = client_impl;
 }
 
-NuguClient::CapabilityBuilder::~CapabilityBuilder()
-{
-}
-
 NuguClient::CapabilityBuilder* NuguClient::CapabilityBuilder::add(ICapabilityInterface* cap_instance)
 {
     client_impl->registerCapability(cap_instance);
@@ -44,11 +40,15 @@ bool NuguClient::CapabilityBuilder::construct()
 NuguClient::NuguClient()
 {
     impl = std::unique_ptr<NuguClientImpl>(new NuguClientImpl());
-    cap_builder = std::unique_ptr<CapabilityBuilder>(new CapabilityBuilder(impl.get()));
+    cap_builder = new CapabilityBuilder(impl.get());
 }
 
 NuguClient::~NuguClient()
 {
+    if (cap_builder) {
+        delete cap_builder;
+        cap_builder = nullptr;
+    }
 }
 
 void NuguClient::setListener(INuguClientListener* listener)
@@ -63,7 +63,7 @@ void NuguClient::setWakeupWord(const std::string& wakeup_word)
 
 NuguClient::CapabilityBuilder* NuguClient::getCapabilityBuilder()
 {
-    return cap_builder.get();
+    return cap_builder;
 }
 
 bool NuguClient::initialize(void)


### PR DESCRIPTION
In previously, the Application is possible to create and
delete CapabilityBuilder directly, not through NuguClient.

It's not recommend usage, so, it adjust accessibility
to prevent to create/delete that instance directly.
Instead, the CapabilityBuilder instance is
only provided by NuguClient.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>