### PR TITLE
base: fix directive sequencer callback concept

### DIFF
--- a/include/base/nugu_directive_sequencer.h
+++ b/include/base/nugu_directive_sequencer.h
@@ -39,9 +39,11 @@ extern "C" {
  * @brief Callback return type
  */
 typedef enum nugu_dirseq_return {
-	NUGU_DIRSEQ_STOP_PROPAGATE, /**< Stop event propagation */
-	NUGU_DIRSEQ_CONTINUE, /**< Pass to the next callback */
-	NUGU_DIRSEQ_REMOVE /**< Remove the directive */
+	NUGU_DIRSEQ_SUCCESS,
+	/**< Directive will be processed and managed(nugu_dirseq_complete()) */
+
+	NUGU_DIRSEQ_FAILURE
+	/**< Unknown/Unhandled directive (Removed Automatically) */
 } NuguDirseqReturn;
 
 /**
@@ -52,23 +54,19 @@ typedef NuguDirseqReturn (*NuguDirseqCallback)(NuguDirective *ndir,
 					       void *userdata);
 
 /**
- * @brief Add event callback to Directive sequencer
+ * @brief Set an event callback to directive sequencer
  * @param[in] callback callback function
  * @param[in] userdata data to pass to the user callback
  * @return result
  * @retval 0 success
  * @retval -1 failure
  */
-int nugu_dirseq_add_callback(NuguDirseqCallback callback, void *userdata);
+int nugu_dirseq_set_callback(NuguDirseqCallback callback, void *userdata);
 
 /**
- * @brief Remove event callback
- * @param[in] callback callback function
- * @return result
- * @retval 0 success
- * @retval -1 failure
+ * @brief Unset the event callback from directive sequencer
  */
-int nugu_dirseq_remove_callback(NuguDirseqCallback callback);
+void nugu_dirseq_unset_callback(void);
 
 /**
  * @brief Add new directive object to directive sequencer

--- a/src/core/capability_manager.cc
+++ b/src/core/capability_manager.cc
@@ -49,7 +49,7 @@ static NuguFocusStealResult on_steal_request(NuguFocus* focus, void* event, Nugu
 
 CapabilityManager::CapabilityManager()
 {
-    nugu_dirseq_add_callback(dirseqCallback, this);
+    nugu_dirseq_set_callback(dirseqCallback, this);
 
     wword = WAKEUP_WORD;
     playsync_manager = std::unique_ptr<PlaySyncManager>(new PlaySyncManager());
@@ -60,7 +60,7 @@ CapabilityManager::~CapabilityManager()
     caps.clear();
     focusmap.clear();
 
-    nugu_dirseq_remove_callback(dirseqCallback);
+    nugu_dirseq_unset_callback();
 }
 
 CapabilityManager* CapabilityManager::getInstance()
@@ -86,7 +86,7 @@ NuguDirseqReturn CapabilityManager::dirseqCallback(NuguDirective* ndir, void* us
     ICapabilityInterface* cap = agent->findCapability(std::string(name_space));
     if (!cap) {
         nugu_warn("capability(%s) is not support", name_space);
-        return NUGU_DIRSEQ_REMOVE;
+        return NUGU_DIRSEQ_FAILURE;
     }
 
     agent->preprocessDirective(ndir);
@@ -95,11 +95,11 @@ NuguDirseqReturn CapabilityManager::dirseqCallback(NuguDirective* ndir, void* us
     if (!agent->isSupportDirectiveVersion(version, cap)) {
         nugu_error("directives[%s] cannot work on %s[%s] agent",
             version, cap->getName().c_str(), cap->getVersion().c_str());
-        return NUGU_DIRSEQ_REMOVE;
+        return NUGU_DIRSEQ_FAILURE;
     }
 
     cap->processDirective(ndir);
-    return NUGU_DIRSEQ_CONTINUE;
+    return NUGU_DIRSEQ_SUCCESS;
 }
 
 void CapabilityManager::addCapability(const std::string& cname, ICapabilityInterface* cap)


### PR DESCRIPTION
The directive sequencer originally borrowed the concept of hooks to
register and process multiple callbacks.

However, since there is no need at the moment, so change it to handle
only one callback simply.

Signed-off-by: Inho Oh <inho.oh@sk.com>