### PR TITLE
SystemAgent: Remove context info

### DIFF
--- a/examples/standalone/capability/system_listener.cc
+++ b/examples/standalone/capability/system_listener.cc
@@ -62,13 +62,3 @@ void SystemListener::onRevoke(RevokeReason reason)
     }
 }
 
-bool SystemListener::requestDeviceCharging(bool& charge)
-{
-    return false;
-}
-
-bool SystemListener::requestDeviceBattery(int& battery)
-{
-    return false;
-}
-

--- a/examples/standalone/capability/system_listener.hh
+++ b/examples/standalone/capability/system_listener.hh
@@ -28,8 +28,6 @@ public:
     void onException(SystemException exception) override;
     void onTurnOff(void) override;
     void onRevoke(RevokeReason reason) override;
-    bool requestDeviceCharging(bool& charge) override;
-    bool requestDeviceBattery(int& battery) override;
 };
 
 #endif /* __TTS_LISTENER_H__ */

--- a/include/capability/system_interface.hh
+++ b/include/capability/system_interface.hh
@@ -76,20 +76,6 @@ public:
      * @param[in] reason reason for revoke
      */
     virtual void onRevoke(RevokeReason reason) = 0;
-
-    /**
-     * @brief SDK request information about device's charging status
-     * @param[out] charge device's charging status
-     * @return return device charge status accessible
-     */
-    virtual bool requestDeviceCharging(bool& charge) = 0;
-
-    /**
-     * @brief SDK request information about device's remaining battery
-     * @param[out] battery device's battery
-     * @return return device battery measurability
-     */
-    virtual bool requestDeviceBattery(int& battery) = 0;
 };
 
 /**

--- a/src/capability/system_agent.cc
+++ b/src/capability/system_agent.cc
@@ -118,25 +118,6 @@ void SystemAgent::updateInfoForContext(Json::Value& ctx)
     Json::Value root;
 
     root["version"] = getVersion();
-    if (system_listener) {
-        bool charging = false;
-        int battery = -1;
-
-        if (system_listener->requestDeviceCharging(charging))
-            root["charging"] = charging;
-
-        if (system_listener->requestDeviceBattery(battery)) {
-            if (battery <= 0)
-                battery = 1;
-
-            if (battery > 100)
-                battery = 100;
-
-            root["battery"] = battery;
-        }
-
-        nugu_dbg("charging: %d, battery: %d", charging, battery);
-    }
     ctx[getName()] = root;
 }
 


### PR DESCRIPTION
Device battery information is managed separately in the new
capability interface as Battery Interface.

Signed-off-by: Hyojoong Kim <hyojoong.kim@sk.com>