### PR TITLE
examples: change lvh.me to localhost

### DIFF
--- a/examples/oob_setup/README.md
+++ b/examples/oob_setup/README.md
@@ -12,11 +12,11 @@ The nugu_oob program is included in the `libnugu-examples` debian package.
 
 ## Get OAuth2 token
 
-First, please open the [http://lvh.me:8080](http://lvh.me:8080) using web browser.
+First, please open the [http://localhost:8080](http://localhost:8080) using web browser.
 
 Next, fill the information like `client_id`, `client_secret`, etc. in the `OAuth2 information` form and press the `Save` button to save it.
 
-Now, click the [Get OAuth2 token](http://lvh.me:8080/login) link to proceed with authentication.
+Now, click the [Get OAuth2 token](http://localhost:8080/login) link to proceed with authentication.
 
 ## How to get the OAuth2 token in your program
 

--- a/examples/oob_setup/nugu_oob_server.py
+++ b/examples/oob_setup/nugu_oob_server.py
@@ -40,7 +40,7 @@ DEFAULT_JSON_OAUTH = """{
 
 authorization_base_url = OAUTH2_URL + '/v1/auth/oauth/authorize'
 token_url = OAUTH2_URL + '/v1/auth/oauth/token'
-redirect_uri = 'http://lvh.me:8080/callback'
+redirect_uri = 'http://localhost:8080/callback'
 
 app = Flask(__name__)
 app.secret_key = 'test'


### PR DESCRIPTION
The authentication server now supports 'localhost' host name.
Therefore, change the 'lvh.me' to 'localhost'.

Signed-off-by: Inho Oh <inho.oh@sk.com>