### PR TITLE
SpeakerAgent: update api

### DIFF
--- a/examples/standalone/capability/speaker_listener.cc
+++ b/examples/standalone/capability/speaker_listener.cc
@@ -18,7 +18,7 @@
 
 #include "speaker_listener.hh"
 
-void SpeakerListener::requestSetVolume(SpeakerType type, int volume, bool linear)
+void SpeakerListener::requestSetVolume(const std::string& ps_id, SpeakerType type, int volume, bool linear)
 {
     std::cout << "[Speaker] type: " << (int)type << ", volume: " << volume << ", linear: " << linear << std::endl;
     bool success = false;
@@ -26,11 +26,13 @@ void SpeakerListener::requestSetVolume(SpeakerType type, int volume, bool linear
     if (type == SpeakerType::NUGU && nugu_speaker_volume)
         success = nugu_speaker_volume(volume);
 
-    if (speaker_handler)
-        speaker_handler->informSetVolumeResult(type, volume, success);
+    if (speaker_handler) {
+        speaker_handler->informVolumeChanged(type, volume);
+        speaker_handler->sendEventVolumeChanged(ps_id, success);
+    }
 }
 
-void SpeakerListener::requestSetMute(SpeakerType type, bool mute)
+void SpeakerListener::requestSetMute(const std::string& ps_id, SpeakerType type, bool mute)
 {
     std::cout << "[Speaker] type: " << (int)type << ", mute: " << mute << std::endl;
     bool success = false;
@@ -38,8 +40,10 @@ void SpeakerListener::requestSetMute(SpeakerType type, bool mute)
     if (type == SpeakerType::NUGU && nugu_speaker_mute)
         success = nugu_speaker_mute(mute);
 
-    if (speaker_handler)
-        speaker_handler->informSetMuteResult(type, mute, success);
+    if (speaker_handler) {
+        speaker_handler->informMuteChanged(type, mute);
+        speaker_handler->sendEventMuteChanged(ps_id, success);
+    }
 }
 
 void SpeakerListener::setSpeakerHandler(ISpeakerHandler* speaker)

--- a/examples/standalone/capability/speaker_listener.hh
+++ b/examples/standalone/capability/speaker_listener.hh
@@ -29,8 +29,8 @@ class SpeakerListener : public ISpeakerListener {
 public:
     virtual ~SpeakerListener() = default;
 
-    void requestSetVolume(SpeakerType type, int volume, bool linear) override;
-    void requestSetMute(SpeakerType type, bool mute) override;
+    void requestSetVolume(const std::string& ps_id, SpeakerType type, int volume, bool linear) override;
+    void requestSetMute(const std::string& ps_id, SpeakerType type, bool mute) override;
 
     void setSpeakerHandler(ISpeakerHandler* speaker);
     void setVolumeNuguSpeakerCallback(nugu_volume_func vns);

--- a/include/capability/speaker_interface.hh
+++ b/include/capability/speaker_interface.hh
@@ -74,18 +74,22 @@ public:
 
     /**
      * @brief The SDK requests the volume setting received from the server.
+     * @param[in] ps_id play service id
      * @param[in] type speaker type
      * @param[in] volume volume level
      * @param[in] linear change volume method. if linear is true volume is changed gradually, otherwise immediately
+     * @see sendEventVolumeChanged()
      */
-    virtual void requestSetVolume(SpeakerType type, int volume, bool linear) = 0;
+    virtual void requestSetVolume(const std::string& ps_id, SpeakerType type, int volume, bool linear) = 0;
 
     /**
      * @brief The SDK requests the mute setting received from the server.
+     * @param[in] ps_id play service id
      * @param[in] type speaker type
      * @param[in] mute volume mute
+     * @see sendEventMuteChanged()
      */
-    virtual void requestSetMute(SpeakerType type, bool mute) = 0;
+    virtual void requestSetMute(const std::string& ps_id, SpeakerType type, bool mute) = 0;
 };
 
 /**
@@ -114,20 +118,18 @@ public:
      */
     virtual void informMuteChanged(SpeakerType type, bool mute) = 0;
     /**
-     * @brief Inform the result of request SetVolume to the SDK.
-     * @param[in] type speaker type
-     * @param[in] volume volume level
+     * @brief Send event the result of request SetVolume to the SDK.
+     * @param[in] ps_id play service id
      * @param[in] result result of SetVolume
      */
-    virtual void informSetVolumeResult(SpeakerType type, int volume, bool result) = 0;
+    virtual void sendEventVolumeChanged(const std::string& ps_id, bool result) = 0;
 
     /**
-     * @brief Inform the result of request SetMute to the SDK.
-     * @param[in] type speaker type
-     * @param[in] mute volume mute
+     * @brief Send event the result of request SetMute to the SDK.
+     * @param[in] ps_id play service id
      * @param[in] result result of SetMute
      */
-    virtual void informSetMuteResult(SpeakerType type, bool mute, bool result) = 0;
+    virtual void sendEventMuteChanged(const std::string& ps_id, bool result) = 0;
 };
 
 /**

--- a/src/capability/speaker_agent.hh
+++ b/src/capability/speaker_agent.hh
@@ -37,27 +37,26 @@ public:
     void informVolumeChanged(SpeakerType type, int volume) override;
     void informMuteChanged(SpeakerType type, bool mute) override;
 
-    void informSetVolumeResult(SpeakerType type, int volume, bool result) override;
-    void informSetMuteResult(SpeakerType type, bool mute, bool result) override;
+    void sendEventVolumeChanged(const std::string& ps_id, bool result) override;
+    void sendEventMuteChanged(const std::string& ps_id, bool result) override;
 
 private:
-    void sendEventCommon(const std::string& ename);
-    void sendEventSetVolumeSucceeded();
-    void sendEventSetVolumeFailed();
-    void sendEventSetMuteSucceeded();
-    void sendEventSetMuteFailed();
+    void sendEventCommon(const std::string& ps_id, const std::string& ename);
+    void sendEventSetVolumeSucceeded(const std::string& ps_id);
+    void sendEventSetVolumeFailed(const std::string& ps_id);
+    void sendEventSetMuteSucceeded(const std::string& ps_id);
+    void sendEventSetMuteFailed(const std::string& ps_id);
 
     void parsingSetVolume(const char* message);
     void parsingSetMute(const char* message);
 
-    void updateSpeakerInfo(SpeakerType type, int volume, bool mute);
+    void updateSpeakerVolume(SpeakerType type, int volume);
+    void updateSpeakerMute(SpeakerType type, bool mute);
     bool getSpeakerType(const std::string& name, SpeakerType& type);
     std::string getSpeakerName(SpeakerType& type);
 
     std::map<SpeakerType, SpeakerInfo*> speakers;
-    SpeakerInfo cur_speaker;
     ISpeakerListener* speaker_listener;
-    std::string ps_id;
 };
 
 } // NuguCore


### PR DESCRIPTION
The application tells the NUGU SDK which volume and mute has been
changed with the button. When an application receives a volume
change request from the NUGU SDK, it must control the volume and
ask the NUGU SDK to send a control result event to the server.

Signed-off-by: Hyojoong Kim <hyojoong.kim@sk.com>