### PR TITLE
add capabilty suspend,restore

### DIFF
--- a/examples/capability_injection/battery_agent.cc
+++ b/examples/capability_injection/battery_agent.cc
@@ -47,6 +47,16 @@ void BatteryAgent::deInitialize()
     // TODO : implements service logic
 }
 
+void BatteryAgent::suspend()
+{
+    // TODO : implements service logic
+}
+
+void BatteryAgent::restore()
+{
+    // TODO : implements service logic
+}
+
 std::string BatteryAgent::getName()
 {
     return CAPABILITY_NAME;

--- a/examples/capability_injection/battery_agent.hh
+++ b/examples/capability_injection/battery_agent.hh
@@ -37,6 +37,8 @@ public:
     void setNuguCoreContainer(INuguCoreContainer* core_container) override;
     void initialize() override;
     void deInitialize() override;
+    void suspend() override;
+    void restore() override;
     std::string getName() override;
     std::string getVersion() override;
     void processDirective(NuguDirective* ndir) override;

--- a/include/clientkit/capability.hh
+++ b/include/clientkit/capability.hh
@@ -129,6 +129,16 @@ public:
     void deInitialize() override;
 
     /**
+     * @brief Suspend current action
+     */
+    void suspend() override;
+
+    /**
+     * @brief Restore previous suspended action
+     */
+    void restore() override;
+
+    /**
      * @brief Get referred dialog request id.
      * @return referred dialog request id
      */

--- a/include/clientkit/capability_helper_interface.hh
+++ b/include/clientkit/capability_helper_interface.hh
@@ -97,6 +97,16 @@ public:
     virtual void sendCommand(const std::string& from, const std::string& to, const std::string& command, const std::string& param) = 0;
 
     /**
+     * @brief Suspend all current capability action
+     */
+    virtual void suspendAll() = 0;
+
+    /**
+     * @brief Restore previous suspended capability action
+     */
+    virtual void restoreAll() = 0;
+
+    /**
      * @brief Get property from CapabilityAgent.
      * @param[in] cap CapabilityAgent
      * @param[in] property property key

--- a/include/clientkit/capability_interface.hh
+++ b/include/clientkit/capability_interface.hh
@@ -72,6 +72,16 @@ public:
     virtual void deInitialize() = 0;
 
     /**
+     * @brief Suspend current action
+     */
+    virtual void suspend() = 0;
+
+    /**
+     * @brief Restore previous suspended action
+     */
+    virtual void restore() = 0;
+
+    /**
      * @brief Get the capability name of the current object.
      * @return capability name of the object
      */

--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -201,6 +201,11 @@ void ASRAgent::deInitialize()
     initialized = false;
 }
 
+void ASRAgent::suspend()
+{
+    // TODO : implements related suspend action
+}
+
 bool ASRAgent::startRecognition()
 {
     nugu_dbg("startRecognition()");

--- a/src/capability/asr_agent.hh
+++ b/src/capability/asr_agent.hh
@@ -45,6 +45,7 @@ public:
     void setAttribute(ASRAttribute&& attribute) override;
     void initialize() override;
     void deInitialize() override;
+    void suspend() override;
 
     bool startRecognition() override;
     void stopRecognition() override;

--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -73,6 +73,16 @@ void AudioPlayerAgent::deInitialize()
     initialized = false;
 }
 
+void AudioPlayerAgent::suspend()
+{
+    // TODO : implements related suspend action
+}
+
+void AudioPlayerAgent::restore()
+{
+    // TODO : implements related restore action
+}
+
 void AudioPlayerAgent::onFocus(void* event)
 {
     if (is_paused)

--- a/src/capability/audio_player_agent.hh
+++ b/src/capability/audio_player_agent.hh
@@ -43,6 +43,8 @@ public:
     virtual ~AudioPlayerAgent();
     void initialize() override;
     void deInitialize() override;
+    void suspend() override;
+    void restore() override;
 
     void parsingDirective(const char* dname, const char* message) override;
     void updateInfoForContext(Json::Value& ctx) override;

--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -102,6 +102,11 @@ void TTSAgent::deInitialize()
     capa_helper->removeFocus("cap_tts");
 }
 
+void TTSAgent::suspend()
+{
+    // TODO : implements related suspend action
+}
+
 void TTSAgent::pcmStatusCallback(enum nugu_media_status status, void* userdata)
 {
     TTSAgent* tts = static_cast<TTSAgent*>(userdata);

--- a/src/capability/tts_agent.hh
+++ b/src/capability/tts_agent.hh
@@ -35,6 +35,7 @@ public:
     void setAttribute(TTSAttribute&& attribute) override;
     void initialize() override;
     void deInitialize() override;
+    void suspend() override;
 
     void parsingDirective(const char* dname, const char* message) override;
     void updateInfoForContext(Json::Value& ctx) override;

--- a/src/clientkit/capability.cc
+++ b/src/clientkit/capability.cc
@@ -155,6 +155,14 @@ void Capability::deInitialize()
 {
 }
 
+void Capability::suspend()
+{
+}
+
+void Capability::restore()
+{
+}
+
 std::string Capability::getReferrerDialogRequestId()
 {
     return pimpl->ref_dialog_id;

--- a/src/core/capability_helper.cc
+++ b/src/core/capability_helper.cc
@@ -62,6 +62,16 @@ void CapabilityHelper::sendCommand(const std::string& from, const std::string& t
     CapabilityManager::getInstance()->sendCommand(from, to, command, param);
 }
 
+void CapabilityHelper::suspendAll()
+{
+    CapabilityManager::getInstance()->suspendAll();
+}
+
+void CapabilityHelper::restoreAll()
+{
+    CapabilityManager::getInstance()->restoreAll();
+}
+
 void CapabilityHelper::getCapabilityProperty(const std::string& cap, const std::string& property, std::string& value)
 {
     CapabilityManager::getInstance()->getCapabilityProperty(cap, property, value);

--- a/src/core/capability_helper.hh
+++ b/src/core/capability_helper.hh
@@ -33,6 +33,8 @@ public:
 
     bool setMute(bool mute) override;
     void sendCommand(const std::string& from, const std::string& to, const std::string& command, const std::string& param) override;
+    void suspendAll() override;
+    void restoreAll() override;
     void getCapabilityProperty(const std::string& cap, const std::string& property, std::string& value) override;
     void getCapabilityProperties(const std::string& cap, const std::string& property, std::list<std::string>& values) override;
 

--- a/src/core/capability_manager.cc
+++ b/src/core/capability_manager.cc
@@ -261,6 +261,20 @@ void CapabilityManager::getCapabilityProperties(const std::string& cap, const st
     }
 }
 
+void CapabilityManager::suspendAll()
+{
+    for (const auto& iter : caps) {
+        iter.second->suspend();
+    }
+}
+
+void CapabilityManager::restoreAll()
+{
+    for (const auto& iter : caps) {
+        iter.second->restore();
+    }
+}
+
 bool CapabilityManager::isFocusOn(NuguFocusType type)
 {
     NuguFocus* focus = nugu_focus_peek_top();

--- a/src/core/capability_manager.hh
+++ b/src/core/capability_manager.hh
@@ -55,6 +55,8 @@ public:
     void sendCommandAll(const std::string& command, const std::string& param);
     void getCapabilityProperty(const std::string& cap, const std::string& property, std::string& value);
     void getCapabilityProperties(const std::string& cap, const std::string& property, std::list<std::string>& values);
+    void suspendAll();
+    void restoreAll();
 
     bool isFocusOn(NuguFocusType type);
     int addFocus(const std::string& fname, NuguFocusType type, IFocusListener* listener);


### PR DESCRIPTION
In some case, because it needs to suspend all current
capability actions, it add suspend and restore function
in ICapabilityInterface.

There don't need to override above methods in all capability.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>