### PR TITLE
build: add build options to plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,11 @@ SET(prefix ${CMAKE_INSTALL_PREFIX})
 SET(bindir "${prefix}/${CMAKE_INSTALL_BINDIR}")
 SET(plugindir "${CMAKE_INSTALL_FULL_LIBDIR}/nugu")
 
+# Set default build options
+OPTION(ENABLE_GSTREAMER_PLUGIN "Enable the GStreamer plugin" ON)
+OPTION(ENABLE_OPUS_PLUGIN "Enable the OPUS plugin" ON)
+OPTION(ENABLE_PORTAUDIO_PLUGIN "Enable the PortAudio plugin" ON)
+
 # Generate compile_commands.json
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
@@ -33,17 +38,30 @@ IF (NOT CMAKE_BUILD_TYPE)
 	SET(CMAKE_BUILD_TYPE Debug)
 ENDIF()
 
-# Get CFLAGS and LDFLAGS from pkg-config
-pkg_check_modules(pkgs REQUIRED
-	nugu-kwd
-	nugu-epd
-	glib-2.0
-	gio-2.0
-	gio-unix-2.0
-	gthread-2.0
+# Set NUGU SDK library default dependency
+SET(DEFAULT_LIB_DEPENDENCY
+	glib-2.0 gio-2.0 gio-unix-2.0 gthread-2.0
 	openssl
 	zlib)
+SET(FORCE_LIB_DEPENDENCY)
+
+# Add vendor specific library dependency (keyword detector, end-point detector)
+LIST(APPEND DEFAULT_LIB_DEPENDENCY nugu-kwd nugu-epd)
+
+# Gstreamer does not support dynamic loading/unloading of their libraries.
+# Therefore, add the library dependency to NUGU SDK instead of NUGU Plugin.
+IF(ENABLE_GSTREAMER_PLUGIN)
+	LIST(APPEND FORCE_LIB_DEPENDENCY gstreamer-1.0 gstreamer-pbutils-1.0)
+ENDIF(ENABLE_GSTREAMER_PLUGIN)
+
+# Get CFLAGS and LDFLAGS from pkg-config list
+pkg_check_modules(pkgs REQUIRED ${DEFAULT_LIB_DEPENDENCY})
 FOREACH(flag ${pkgs_CFLAGS})
+	ADD_COMPILE_OPTIONS(${flag})
+ENDFOREACH(flag)
+
+pkg_check_modules(force_pkgs REQUIRED ${FORCE_LIB_DEPENDENCY})
+FOREACH(flag ${force_pkgs_CFLAGS})
 	ADD_COMPILE_OPTIONS(${flag})
 ENDFOREACH(flag)
 
@@ -94,6 +112,9 @@ IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 		-Wl,--gc-sections)
 
 	IF (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+		# Link with force dependency libraries
+		LINK_LIBRARIES(-Wl,--no-as-needed ${force_pkgs_LDFLAGS})
+
 		# Link only needed libraries
 		LINK_LIBRARIES(-Wl,--as-needed)
 

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -12,31 +12,35 @@ FOREACH(plugin ${PLUGINS})
 ENDFOREACH(plugin)
 
 # OPUS plugin
-pkg_check_modules(opus REQUIRED opus)
-ADD_LIBRARY(opus SHARED opus.c)
-TARGET_COMPILE_OPTIONS(opus PRIVATE ${opus_CFLAGS})
-TARGET_LINK_LIBRARIES(opus ${pkgs_LDFLAGS} ${opus_LDFLAGS}
-	-L${CMAKE_BINARY_DIR}/src -lnugu -ldl)
-SET_TARGET_PROPERTIES(opus PROPERTIES PREFIX "" OUTPUT_NAME opus)
-INSTALL(TARGETS opus LIBRARY DESTINATION ${plugindir})
-ADD_DEPENDENCIES(opus libnugu)
+IF(ENABLE_OPUS_PLUGIN)
+	pkg_check_modules(opus REQUIRED opus)
+	ADD_LIBRARY(opus SHARED opus.c)
+	TARGET_COMPILE_OPTIONS(opus PRIVATE ${opus_CFLAGS})
+	TARGET_LINK_LIBRARIES(opus ${pkgs_LDFLAGS} ${opus_LDFLAGS}
+		-L${CMAKE_BINARY_DIR}/src -lnugu -ldl)
+	SET_TARGET_PROPERTIES(opus PROPERTIES PREFIX "" OUTPUT_NAME opus)
+	INSTALL(TARGETS opus LIBRARY DESTINATION ${plugindir})
+	ADD_DEPENDENCIES(opus libnugu)
+ENDIF(ENABLE_OPUS_PLUGIN)
 
-# portaudio plugin
-pkg_check_modules(portaudio REQUIRED portaudio-2.0 alsa)
-ADD_LIBRARY(portaudio SHARED portaudio.c)
-TARGET_COMPILE_OPTIONS(portaudio PRIVATE ${portaudio_CFLAGS})
-TARGET_LINK_LIBRARIES(portaudio ${pkgs_LDFLAGS} ${portaudio_LDFLAGS}
-	-L${CMAKE_BINARY_DIR}/src -lnugu -ldl)
-SET_TARGET_PROPERTIES(portaudio PROPERTIES PREFIX "" OUTPUT_NAME portaudio)
-INSTALL(TARGETS portaudio LIBRARY DESTINATION ${plugindir})
-ADD_DEPENDENCIES(portaudio libnugu)
+# PortAudio plugin
+IF(ENABLE_PORTAUDIO_PLUGIN)
+	pkg_check_modules(portaudio REQUIRED portaudio-2.0 alsa)
+	ADD_LIBRARY(portaudio SHARED portaudio.c)
+	TARGET_COMPILE_OPTIONS(portaudio PRIVATE ${portaudio_CFLAGS})
+	TARGET_LINK_LIBRARIES(portaudio ${pkgs_LDFLAGS} ${portaudio_LDFLAGS}
+		-L${CMAKE_BINARY_DIR}/src -lnugu -ldl)
+	SET_TARGET_PROPERTIES(portaudio PROPERTIES PREFIX "" OUTPUT_NAME portaudio)
+	INSTALL(TARGETS portaudio LIBRARY DESTINATION ${plugindir})
+	ADD_DEPENDENCIES(portaudio libnugu)
+ENDIF(ENABLE_PORTAUDIO_PLUGIN)
 
 # gstreamer plugin
-pkg_check_modules(gstreamer REQUIRED gstreamer-1.0 gstreamer-pbutils-1.0)
-ADD_LIBRARY(gstreamer SHARED gstreamer.c)
-TARGET_COMPILE_OPTIONS(gstreamer PRIVATE ${gstreamer_CFLAGS})
-TARGET_LINK_LIBRARIES(gstreamer ${pkgs_LDFLAGS} ${gstreamer_LDFLAGS}
-	-L${CMAKE_BINARY_DIR}/src -lnugu -ldl)
-SET_TARGET_PROPERTIES(gstreamer PROPERTIES PREFIX "" OUTPUT_NAME gstreamer)
-INSTALL(TARGETS gstreamer LIBRARY DESTINATION ${plugindir})
-ADD_DEPENDENCIES(gstreamer libnugu)
+IF(ENABLE_GSTREAMER_PLUGIN)
+	ADD_LIBRARY(gstreamer SHARED gstreamer.c)
+	TARGET_LINK_LIBRARIES(gstreamer ${pkgs_LDFLAGS}
+		-L${CMAKE_BINARY_DIR}/src -lnugu -ldl)
+	SET_TARGET_PROPERTIES(gstreamer PROPERTIES PREFIX "" OUTPUT_NAME gstreamer)
+	INSTALL(TARGETS gstreamer LIBRARY DESTINATION ${plugindir})
+	ADD_DEPENDENCIES(gstreamer libnugu)
+ENDIF(ENABLE_GSTREAMER_PLUGIN)


### PR DESCRIPTION
Fix the build script to make configurable the NUGU plugin to be
included in the build through the build options.

In addition, GStreamer library does not support dynamic loading,
so it is forced to link to the NUGU SDK when enable the NUGU
GStreamer plugin.

Signed-off-by: Inho Oh <inho.oh@sk.com>