### PR TITLE
add suspend/restore command in nugu sample

### DIFF
--- a/examples/standalone/nugu_sample.cc
+++ b/examples/standalone/nugu_sample.cc
@@ -245,12 +245,17 @@ int main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
-    auto wakeup_handler(nugu_client->getNuguCoreContainer()->createWakeupHandler(nugu_sample_manager->getModelPath()));
+    auto nugu_core_container(nugu_client->getNuguCoreContainer());
+    auto wakeup_handler(nugu_core_container->createWakeupHandler(nugu_sample_manager->getModelPath()));
+
     speech_operator->setWakeupHandler(wakeup_handler);
     nugu_sample_manager->setSpeechOperator(speech_operator.get())
         ->setNetworkCallback(NuguSampleManager::NetworkCallback {
             [&]() { return network_manager->connect(); },
             [&]() { return network_manager->disconnect(); } })
+        ->setActionCallback(NuguSampleManager::ActionCallback {
+            [&]() { nugu_core_container->getCapabilityHelper()->suspendAll(); },
+            [&]() { nugu_core_container->getCapabilityHelper()->restoreAll(); } })
         ->setTextHandler(text_handler.get())
         ->setMicHandler(mic_handler.get())
         ->runLoop([&] {

--- a/examples/standalone/nugu_sample_manager.hh
+++ b/examples/standalone/nugu_sample_manager.hh
@@ -35,10 +35,17 @@ public:
         std::function<bool()> connect;
         std::function<bool()> disconnect;
     };
+
+    using ActionCallback = struct {
+        std::function<void()> suspend_all_func;
+        std::function<void()> restore_all_func;
+    };
+
     using Commander = struct {
         bool is_connected;
         int text_input;
         NetworkCallback network_callback;
+        ActionCallback action_callback;
         ITextHandler* text_handler;
         SpeechOperator* speech_operator;
         IMicHandler* mic_handler;
@@ -58,6 +65,7 @@ public:
     NuguSampleManager* setTextHandler(ITextHandler* text_handler);
     NuguSampleManager* setSpeechOperator(SpeechOperator* speech_operator);
     NuguSampleManager* setMicHandler(IMicHandler* mic_handler);
+    NuguSampleManager* setActionCallback(ActionCallback&& callback);
     void handleNetworkResult(bool is_connected, bool is_show_cmd = true);
 
 private:


### PR DESCRIPTION
In nugu sample, it add cli commands for testing
suspending/restoring capability actions.

It would implements the required action in each capability.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>