### PR TITLE
update play context policy

### DIFF
--- a/include/clientkit/playsync_manager_interface.hh
+++ b/include/clientkit/playsync_manager_interface.hh
@@ -135,9 +135,9 @@ public:
     virtual void setExpectSpeech(bool expect_speech) = 0;
 
     /**
-     * @brief Notify mic on as starting listening speech.
+     * @brief Hold to maintain current context in stack
      */
-    virtual void onMicOn() = 0;
+    virtual void holdContext() = 0;
 
     /**
      * @brief Clear holding context.

--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -491,7 +491,7 @@ void ASRAgent::onListeningState(ListeningState state)
         rec_event = new CapabilityEvent("Recognize", this);
         rec_event->setType(NUGU_EVENT_TYPE_WITH_ATTACHMENT);
 
-        playsync_manager->onMicOn();
+        playsync_manager->holdContext();
 
         sendEventRecognize(NULL, 0, false);
 

--- a/src/capability/text_agent.cc
+++ b/src/capability/text_agent.cc
@@ -182,6 +182,8 @@ void TextAgent::sendEventTextInput(const std::string& text, const std::string& t
 
     cur_dialog_id = event.getDialogMessageId();
 
+    playsync_manager->holdContext();
+
     sendEvent(&event, capa_helper->makeAllContextInfoStack(), payload);
 }
 

--- a/src/core/capability_manager.cc
+++ b/src/core/capability_manager.cc
@@ -184,16 +184,16 @@ void CapabilityManager::preprocessDirective(NuguDirective* ndir)
 {
     std::string name_space = nugu_directive_peek_namespace(ndir);
     std::string dname = nugu_directive_peek_name(ndir);
+    std::string groups = nugu_directive_peek_groups(ndir);
 
     sendCommandAll("directive_dialog_id", nugu_directive_peek_dialog_id(ndir));
+    playsync_manager->setDirectiveGroups(groups);
 
     if (name_space == "ASR" && dname == "NotifyResult") {
         check_asr_focus_release = true;
         asr_dialog_id = nugu_directive_peek_dialog_id(ndir);
     } else {
         if (check_asr_focus_release && asr_dialog_id == nugu_directive_peek_dialog_id(ndir)) {
-            std::string groups = nugu_directive_peek_groups(ndir);
-
             nugu_info("Check ASR Focus Release: %s", groups.c_str());
             if (groups.find("TTS") == std::string::npos && groups.find("AudioPlayer") == std::string::npos) {
                 nugu_info("ASR Focus Release by CapabilityManager");


### PR DESCRIPTION
It update to reset context hold timer
when asr failed.

It update to hold media pause timer when user
is doing some action. If the action is completed,
it restart context hold timer.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>