### PR TITLE
Event result callback

### DIFF
--- a/include/clientkit/capability.hh
+++ b/include/clientkit/capability.hh
@@ -61,6 +61,12 @@ public:
     bool isUserAction(const std::string& name);
 
     /**
+     * @brief Get event name
+     * @return event name
+     */
+    std::string getName();
+
+    /**
      * @brief Get dialog message id
      * @return dialog message id
      */
@@ -145,6 +151,25 @@ public:
     void restore() override;
 
     /**
+     * @brief Add event result callback for error handling
+     * @param[in] ename event name
+     * @param[in] callback event result callback
+     */
+    void addEventResultCallback(const std::string& ename, EventResultCallback callback) override;
+
+    /**
+     * @brief Remove event result callback
+     * @param[in] ename event name
+     */
+    void removeEventResultCallback(const std::string& ename) override;
+
+    /**
+     * @brief Notift event result
+     * @param[in] event_desc event result description (format: 'cname.ename.msgid.dialogid.success.code')
+     */
+    void notifyEventResult(const std::string& event_desc) override;
+
+    /**
      * @brief Get referred dialog request id.
      * @return referred dialog request id
      */
@@ -211,7 +236,7 @@ public:
      * @param[in] payload payload info
      * @param[in] is_sync whether synchronized blocking event
      */
-    void sendEvent(const std::string& name, const std::string& context, const std::string& payload, bool is_sync = false);
+    void sendEvent(const std::string& name, const std::string& context, const std::string& payload, EventResultCallback cb = nullptr, bool is_sync = false);
 
     /**
      * @brief Send event to server.
@@ -220,7 +245,7 @@ public:
      * @param[in] payload payload info
      * @param[in] is_sync whether synchronized blocking event
      */
-    void sendEvent(CapabilityEvent* event, const std::string& context, const std::string& payload, bool is_sync = false);
+    void sendEvent(CapabilityEvent* event, const std::string& context, const std::string& payload, EventResultCallback cb = nullptr, bool is_sync = false);
 
     /**
      * @brief Send attachment event to server.
@@ -230,6 +255,18 @@ public:
      * @param[in] data attachment data
      */
     void sendAttachmentEvent(CapabilityEvent* event, bool is_end, size_t size, unsigned char* data);
+
+    /**
+     * @brief Parse the event result description.
+     * @param[in] desc event result description (format: 'cname.ename.msgid.dialogid.success.code')
+     * @param[out] ename event name
+     * @param[out] msg_id event message id
+     * @param[out] dialog_id event request dialog id
+     * @param[out] success event result
+     * @param[out] code event result code (similar to http status code)
+     * @return parsing result
+     */
+    bool parseEventResultDesc(const std::string& desc, std::string& ename, std::string& msg_id, std::string& dialog_id, bool& success, int& code);
 
     /**
      * @brief It is possible to share own property value among objects.
@@ -307,6 +344,7 @@ protected:
 private:
     struct Impl;
     std::unique_ptr<Impl> pimpl;
+    std::map<std::string, EventResultCallback> event_result_cbs;
 };
 
 /**

--- a/include/clientkit/capability_helper_interface.hh
+++ b/include/clientkit/capability_helper_interface.hh
@@ -20,6 +20,7 @@
 #include <json/json.h>
 #include <list>
 
+#include <base/nugu_event.h>
 #include <base/nugu_focus.h>
 #include <clientkit/playsync_manager_interface.hh>
 
@@ -95,6 +96,12 @@ public:
      * @param[in] param parameter
      */
     virtual void sendCommand(const std::string& from, const std::string& to, const std::string& command, const std::string& param) = 0;
+
+    /**
+     * @brief Request to send event result via CapabilityManager.
+     * @param[in] event event for monitoring result
+     */
+    virtual void requestEventResult(NuguEvent* event) = 0;
 
     /**
      * @brief Suspend all current capability action

--- a/include/clientkit/capability_interface.hh
+++ b/include/clientkit/capability_interface.hh
@@ -20,6 +20,7 @@
 #include <json/json.h>
 #include <list>
 #include <string>
+#include <functional>
 
 #include <base/nugu_directive.h>
 #include <clientkit/nugu_core_container_interface.hh>
@@ -61,6 +62,16 @@ public:
         PAUSE /**< Pause current action. It could resume later */
     };
 
+    /**
+     * @brief Event result callback for error handling
+     * @param[in] ename event name
+     * @param[in] msg_id event message id
+     * @param[in] dialog_id event request dialog id
+     * @param[in] success event result
+     * @param[in] code event result code (similar to http status code)
+     */
+    using EventResultCallback = std::function<void(const std::string&, const std::string&, const std::string&, int, int)>;
+
 public:
     virtual ~ICapabilityInterface() = default;
 
@@ -95,6 +106,25 @@ public:
      * @brief Restore previous suspended action
      */
     virtual void restore() = 0;
+
+    /**
+     * @brief Add event result callback for error handling
+     * @param[in] ename event name
+     * @param[in] callback event result callback
+     */
+    virtual void addEventResultCallback(const std::string& ename, EventResultCallback callback) = 0;
+
+    /**
+     * @brief Remove event result callback
+     * @param[in] ename event name
+     */
+    virtual void removeEventResultCallback(const std::string& ename) = 0;
+
+    /**
+     * @brief Notift event result
+     * @param[in] event_desc event result description (format: 'cname.ename.msgid.dialogid.success.code')
+     */
+    virtual void notifyEventResult(const std::string& event_desc) = 0;
 
     /**
      * @brief Get the capability name of the current object.

--- a/src/capability/asr_agent.hh
+++ b/src/capability/asr_agent.hh
@@ -61,11 +61,11 @@ public:
     void checkResponseTimeout();
     void clearResponseTimeout();
 
-    void sendEventRecognize(unsigned char* data, size_t length, bool is_end);
-    void sendEventResponseTimeout();
-    void sendEventListenTimeout();
-    void sendEventListenFailed();
-    void sendEventStopRecognize();
+    void sendEventRecognize(unsigned char* data, size_t length, bool is_end, EventResultCallback cb = nullptr);
+    void sendEventResponseTimeout(EventResultCallback cb = nullptr);
+    void sendEventListenTimeout(EventResultCallback cb = nullptr);
+    void sendEventListenFailed(EventResultCallback cb = nullptr);
+    void sendEventStopRecognize(EventResultCallback cb = nullptr);
 
     void setCapabilityListener(ICapabilityListener* clistener) override;
     void addListener(IASRListener* listener) override;
@@ -76,7 +76,7 @@ public:
     bool isExpectSpeechState();
 
 private:
-    void sendEventCommon(const std::string& ename);
+    void sendEventCommon(const std::string& ename, EventResultCallback cb = nullptr);
 
     // implements ISpeechRecognizerListener
     void onListeningState(ListeningState state) override;

--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -346,62 +346,62 @@ void AudioPlayerAgent::removeListener(IAudioPlayerListener* listener)
         aplayer_listeners.erase(iterator);
 }
 
-void AudioPlayerAgent::sendEventPlaybackStarted()
+void AudioPlayerAgent::sendEventPlaybackStarted(EventResultCallback cb)
 {
-    sendEventCommon("PlaybackStarted");
+    sendEventCommon("PlaybackStarted", std::move(cb));
 }
 
-void AudioPlayerAgent::sendEventPlaybackFinished()
+void AudioPlayerAgent::sendEventPlaybackFinished(EventResultCallback cb)
 {
-    sendEventCommon("PlaybackFinished");
+    sendEventCommon("PlaybackFinished", std::move(cb));
 }
 
-void AudioPlayerAgent::sendEventPlaybackStopped()
+void AudioPlayerAgent::sendEventPlaybackStopped(EventResultCallback cb)
 {
-    sendEventCommon("PlaybackStopped");
+    sendEventCommon("PlaybackStopped", std::move(cb));
 }
 
-void AudioPlayerAgent::sendEventPlaybackPaused()
+void AudioPlayerAgent::sendEventPlaybackPaused(EventResultCallback cb)
 {
-    sendEventCommon("PlaybackPaused");
+    sendEventCommon("PlaybackPaused", std::move(cb));
 }
 
-void AudioPlayerAgent::sendEventPlaybackResumed()
+void AudioPlayerAgent::sendEventPlaybackResumed(EventResultCallback cb)
 {
-    sendEventCommon("PlaybackResumed");
+    sendEventCommon("PlaybackResumed", std::move(cb));
 }
 
-void AudioPlayerAgent::sendEventShowLyricsSucceeded()
+void AudioPlayerAgent::sendEventShowLyricsSucceeded(EventResultCallback cb)
 {
-    sendEventCommon("ShowLyricsSucceeded");
+    sendEventCommon("ShowLyricsSucceeded", std::move(cb));
 }
 
-void AudioPlayerAgent::sendEventShowLyricsFailed()
+void AudioPlayerAgent::sendEventShowLyricsFailed(EventResultCallback cb)
 {
-    sendEventCommon("EventShowLyricsFailed");
+    sendEventCommon("EventShowLyricsFailed", std::move(cb));
 }
 
-void AudioPlayerAgent::sendEventHideLyricsSucceeded()
+void AudioPlayerAgent::sendEventHideLyricsSucceeded(EventResultCallback cb)
 {
-    sendEventCommon("HideLyricsSucceeded");
+    sendEventCommon("HideLyricsSucceeded", std::move(cb));
 }
 
-void AudioPlayerAgent::sendEventHideLyricsFailed()
+void AudioPlayerAgent::sendEventHideLyricsFailed(EventResultCallback cb)
 {
-    sendEventCommon("HideLyricsFailed");
+    sendEventCommon("HideLyricsFailed", std::move(cb));
 }
 
-void AudioPlayerAgent::sendEventControlLyricsPageSucceeded()
+void AudioPlayerAgent::sendEventControlLyricsPageSucceeded(EventResultCallback cb)
 {
-    sendEventCommon("ControlLyricsPageSucceeded");
+    sendEventCommon("ControlLyricsPageSucceeded", std::move(cb));
 }
 
-void AudioPlayerAgent::sendEventControlLyricsPageFailed()
+void AudioPlayerAgent::sendEventControlLyricsPageFailed(EventResultCallback cb)
 {
-    sendEventCommon("ControlLyricsPageFailed");
+    sendEventCommon("ControlLyricsPageFailed", std::move(cb));
 }
 
-void AudioPlayerAgent::sendEventPlaybackFailed(PlaybackError err, const std::string& reason)
+void AudioPlayerAgent::sendEventPlaybackFailed(PlaybackError err, const std::string& reason, EventResultCallback cb)
 {
     std::string ename = "PlaybackFailed";
     std::string payload = "";
@@ -424,27 +424,27 @@ void AudioPlayerAgent::sendEventPlaybackFailed(PlaybackError err, const std::str
     root["currentPlaybackState.playActivity"] = playerActivity(cur_aplayer_state);
     payload = writer.write(root);
 
-    sendEvent(ename, getContextInfo(), payload);
+    sendEvent(ename, getContextInfo(), payload, std::move(cb));
 }
 
-void AudioPlayerAgent::sendEventProgressReportDelayElapsed()
+void AudioPlayerAgent::sendEventProgressReportDelayElapsed(EventResultCallback cb)
 {
     nugu_dbg("report_delay_time: %d, position: %d", report_delay_time / 1000, player->position());
-    sendEventCommon("ProgressReportDelayElapsed");
+    sendEventCommon("ProgressReportDelayElapsed", std::move(cb));
 }
 
-void AudioPlayerAgent::sendEventProgressReportIntervalElapsed()
+void AudioPlayerAgent::sendEventProgressReportIntervalElapsed(EventResultCallback cb)
 {
     nugu_dbg("report_interval_time: %d, position: %d", report_interval_time / 1000, player->position());
-    sendEventCommon("ProgressReportIntervalElapsed");
+    sendEventCommon("ProgressReportIntervalElapsed", std::move(cb));
 }
 
-void AudioPlayerAgent::sendEventByDisplayInterface(const std::string& command)
+void AudioPlayerAgent::sendEventByDisplayInterface(const std::string& command, EventResultCallback cb)
 {
-    sendEventCommon(command);
+    sendEventCommon(command, std::move(cb));
 }
 
-void AudioPlayerAgent::sendEventCommon(const std::string& ename)
+void AudioPlayerAgent::sendEventCommon(const std::string& ename, EventResultCallback cb)
 {
     std::string payload = "";
     Json::StyledWriter writer;
@@ -461,7 +461,7 @@ void AudioPlayerAgent::sendEventCommon(const std::string& ename)
     root["offsetInMilliseconds"] = std::to_string(offset);
     payload = writer.write(root);
 
-    sendEvent(ename, getContextInfo(), payload);
+    sendEvent(ename, getContextInfo(), payload, std::move(cb));
 }
 
 bool AudioPlayerAgent::isContentCached(const std::string& key, std::string& playurl)

--- a/src/capability/audio_player_agent.hh
+++ b/src/capability/audio_player_agent.hh
@@ -67,21 +67,21 @@ public:
     bool setVolume(int volume) override;
     bool setMute(bool mute) override;
 
-    void sendEventPlaybackStarted();
-    void sendEventPlaybackFinished();
-    void sendEventPlaybackStopped();
-    void sendEventPlaybackPaused();
-    void sendEventPlaybackResumed();
-    void sendEventPlaybackFailed(PlaybackError err, const std::string& reason);
-    void sendEventProgressReportDelayElapsed();
-    void sendEventProgressReportIntervalElapsed();
-    void sendEventByDisplayInterface(const std::string& command);
-    void sendEventShowLyricsSucceeded();
-    void sendEventShowLyricsFailed();
-    void sendEventHideLyricsSucceeded();
-    void sendEventHideLyricsFailed();
-    void sendEventControlLyricsPageSucceeded();
-    void sendEventControlLyricsPageFailed();
+    void sendEventPlaybackStarted(EventResultCallback cb = nullptr);
+    void sendEventPlaybackFinished(EventResultCallback cb = nullptr);
+    void sendEventPlaybackStopped(EventResultCallback cb = nullptr);
+    void sendEventPlaybackPaused(EventResultCallback cb = nullptr);
+    void sendEventPlaybackResumed(EventResultCallback cb = nullptr);
+    void sendEventPlaybackFailed(PlaybackError err, const std::string& reason, EventResultCallback cb = nullptr);
+    void sendEventProgressReportDelayElapsed(EventResultCallback cb = nullptr);
+    void sendEventProgressReportIntervalElapsed(EventResultCallback cb = nullptr);
+    void sendEventByDisplayInterface(const std::string& command, EventResultCallback cb = nullptr);
+    void sendEventShowLyricsSucceeded(EventResultCallback cb = nullptr);
+    void sendEventShowLyricsFailed(EventResultCallback cb = nullptr);
+    void sendEventHideLyricsSucceeded(EventResultCallback cb = nullptr);
+    void sendEventHideLyricsFailed(EventResultCallback cb = nullptr);
+    void sendEventControlLyricsPageSucceeded(EventResultCallback cb = nullptr);
+    void sendEventControlLyricsPageFailed(EventResultCallback cb = nullptr);
 
     void mediaStateChanged(MediaPlayerState state) override;
     void mediaEventReport(MediaPlayerEvent event) override;
@@ -95,7 +95,7 @@ public:
     void muteChanged(int mute) override;
 
 private:
-    void sendEventCommon(const std::string& ename);
+    void sendEventCommon(const std::string& ename, EventResultCallback cb = nullptr);
 
     AudioPlayerState audioPlayerState();
 

--- a/src/capability/delegation_agent.cc
+++ b/src/capability/delegation_agent.cc
@@ -116,7 +116,7 @@ bool DelegationAgent::request()
     return sendEventRequest();
 }
 
-bool DelegationAgent::sendEventRequest()
+bool DelegationAgent::sendEventRequest(EventResultCallback cb)
 {
     std::string context_info = getContextInfo();
 
@@ -128,7 +128,7 @@ bool DelegationAgent::sendEventRequest()
     std::string ename = "Request";
     std::string payload = "";
 
-    sendEvent(ename, context_info, payload);
+    sendEvent(ename, context_info, payload, std::move(cb));
     return true;
 }
 

--- a/src/capability/delegation_agent.hh
+++ b/src/capability/delegation_agent.hh
@@ -36,7 +36,7 @@ public:
 
 private:
     void parsingDelegate(const char* message);
-    bool sendEventRequest();
+    bool sendEventRequest(EventResultCallback cb = nullptr);
 
     IDelegationListener* delegation_listener = nullptr;
 };

--- a/src/capability/extension_agent.cc
+++ b/src/capability/extension_agent.cc
@@ -82,33 +82,40 @@ void ExtensionAgent::setCapabilityListener(ICapabilityListener* clistener)
         extension_listener = dynamic_cast<IExtensionListener*>(clistener);
 }
 
-void ExtensionAgent::sendEventActionSucceeded()
+void ExtensionAgent::sendEventActionSucceeded(EventResultCallback cb)
 {
-    sendEventCommon("ActionSucceeded");
+    sendEventCommon("ActionSucceeded", std::move(cb));
 }
 
-void ExtensionAgent::sendEventActionFailed()
+void ExtensionAgent::sendEventActionFailed(EventResultCallback cb)
 {
-    sendEventCommon("ActionFailed");
+    sendEventCommon("ActionFailed", std::move(cb));
 }
 
-void ExtensionAgent::sendEventCommandIssued(const std::string& data)
+void ExtensionAgent::sendEventCommandIssued(const std::string& data, EventResultCallback cb)
 {
-    sendEventCommon("CommandIssued", data);
+    std::string ename = "CommandIssued";
+    std::string payload = "";
+    Json::Value root;
+    Json::StyledWriter writer;
+
+    root["playServiceId"] = ps_id;
+    root["data"] = data;
+    payload = writer.write(root);
+
+    sendEvent(ename, getContextInfo(), payload, std::move(cb));
 }
 
-void ExtensionAgent::sendEventCommon(const std::string& ename, const std::string& data)
+void ExtensionAgent::sendEventCommon(const std::string& ename, EventResultCallback cb)
 {
     std::string payload = "";
     Json::Value root;
     Json::StyledWriter writer;
 
     root["playServiceId"] = ps_id;
-    if (data.length())
-        root["data"] = data;
     payload = writer.write(root);
 
-    sendEvent(ename, getContextInfo(), payload);
+    sendEvent(ename, getContextInfo(), payload, std::move(cb));
 }
 
 void ExtensionAgent::parsingAction(const char* message)

--- a/src/capability/extension_agent.hh
+++ b/src/capability/extension_agent.hh
@@ -34,10 +34,10 @@ public:
     void sendCommandToPlay(const std::string& data) override;
 
 private:
-    void sendEventCommon(const std::string& ename, const std::string& data = "");
-    void sendEventActionSucceeded();
-    void sendEventActionFailed();
-    void sendEventCommandIssued(const std::string& data);
+    void sendEventCommon(const std::string& ename, EventResultCallback cb = nullptr);
+    void sendEventActionSucceeded(EventResultCallback cb = nullptr);
+    void sendEventActionFailed(EventResultCallback cb = nullptr);
+    void sendEventCommandIssued(const std::string& data, EventResultCallback cb = nullptr);
 
     void parsingAction(const char* message);
 

--- a/src/capability/mic_agent.cc
+++ b/src/capability/mic_agent.cc
@@ -77,17 +77,17 @@ void MicAgent::disable()
     control(false);
 }
 
-void MicAgent::sendEventSetMicSucceeded()
+void MicAgent::sendEventSetMicSucceeded(EventResultCallback cb)
 {
-    sendEventCommon("SetMicSucceeded");
+    sendEventCommon("SetMicSucceeded", std::move(cb));
 }
 
-void MicAgent::sendEventSetMicFailed()
+void MicAgent::sendEventSetMicFailed(EventResultCallback cb)
 {
-    sendEventCommon("SetMicFailed");
+    sendEventCommon("SetMicFailed", std::move(cb));
 }
 
-void MicAgent::sendEventCommon(const std::string& ename)
+void MicAgent::sendEventCommon(const std::string& ename, EventResultCallback cb)
 {
     std::string payload = "";
     Json::Value root;
@@ -100,7 +100,7 @@ void MicAgent::sendEventCommon(const std::string& ename)
         root["micStatus"] = "OFF";
     payload = writer.write(root);
 
-    sendEvent(ename, getContextInfo(), payload);
+    sendEvent(ename, getContextInfo(), payload, std::move(cb));
 }
 
 void MicAgent::parsingSetMic(const char* message)

--- a/src/capability/mic_agent.hh
+++ b/src/capability/mic_agent.hh
@@ -35,9 +35,9 @@ public:
     void disable() override;
 
 private:
-    void sendEventCommon(const std::string& ename);
-    void sendEventSetMicSucceeded();
-    void sendEventSetMicFailed();
+    void sendEventCommon(const std::string& ename, EventResultCallback cb = nullptr);
+    void sendEventSetMicSucceeded(EventResultCallback cb = nullptr);
+    void sendEventSetMicFailed(EventResultCallback cb = nullptr);
 
     void control(bool enable, bool send_event = false);
 

--- a/src/capability/speaker_agent.cc
+++ b/src/capability/speaker_agent.cc
@@ -187,27 +187,27 @@ std::string SpeakerAgent::getSpeakerName(SpeakerType& type)
         return "NUGU";
 }
 
-void SpeakerAgent::sendEventSetVolumeSucceeded(const std::string& ps_id)
+void SpeakerAgent::sendEventSetVolumeSucceeded(const std::string& ps_id, EventResultCallback cb)
 {
-    sendEventCommon(ps_id, "SetVolumeSucceeded");
+    sendEventCommon(ps_id, "SetVolumeSucceeded", std::move(cb));
 }
 
-void SpeakerAgent::sendEventSetVolumeFailed(const std::string& ps_id)
+void SpeakerAgent::sendEventSetVolumeFailed(const std::string& ps_id, EventResultCallback cb)
 {
-    sendEventCommon(ps_id, "SetVolumeFailed");
+    sendEventCommon(ps_id, "SetVolumeFailed", std::move(cb));
 }
 
-void SpeakerAgent::sendEventSetMuteSucceeded(const std::string& ps_id)
+void SpeakerAgent::sendEventSetMuteSucceeded(const std::string& ps_id, EventResultCallback cb)
 {
-    sendEventCommon(ps_id, "SetMuteSucceeded");
+    sendEventCommon(ps_id, "SetMuteSucceeded", std::move(cb));
 }
 
-void SpeakerAgent::sendEventSetMuteFailed(const std::string& ps_id)
+void SpeakerAgent::sendEventSetMuteFailed(const std::string& ps_id, EventResultCallback cb)
 {
-    sendEventCommon(ps_id, "SetMuteFailed");
+    sendEventCommon(ps_id, "SetMuteFailed", std::move(cb));
 }
 
-void SpeakerAgent::sendEventCommon(const std::string& ps_id, const std::string& ename)
+void SpeakerAgent::sendEventCommon(const std::string& ps_id, const std::string& ename, EventResultCallback cb)
 {
     std::string payload = "";
     Json::Value root;
@@ -216,7 +216,7 @@ void SpeakerAgent::sendEventCommon(const std::string& ps_id, const std::string& 
     root["playServiceId"] = ps_id;
     payload = writer.write(root);
 
-    sendEvent(ename, getContextInfo(), payload);
+    sendEvent(ename, getContextInfo(), payload, std::move(cb));
 }
 
 void SpeakerAgent::parsingSetVolume(const char* message)

--- a/src/capability/speaker_agent.hh
+++ b/src/capability/speaker_agent.hh
@@ -41,11 +41,11 @@ public:
     void sendEventMuteChanged(const std::string& ps_id, bool result) override;
 
 private:
-    void sendEventCommon(const std::string& ps_id, const std::string& ename);
-    void sendEventSetVolumeSucceeded(const std::string& ps_id);
-    void sendEventSetVolumeFailed(const std::string& ps_id);
-    void sendEventSetMuteSucceeded(const std::string& ps_id);
-    void sendEventSetMuteFailed(const std::string& ps_id);
+    void sendEventCommon(const std::string& ps_id, const std::string& ename, EventResultCallback cb = nullptr);
+    void sendEventSetVolumeSucceeded(const std::string& ps_id, EventResultCallback cb = nullptr);
+    void sendEventSetVolumeFailed(const std::string& ps_id, EventResultCallback cb = nullptr);
+    void sendEventSetMuteSucceeded(const std::string& ps_id, EventResultCallback cb = nullptr);
+    void sendEventSetMuteFailed(const std::string& ps_id, EventResultCallback cb = nullptr);
 
     void parsingSetVolume(const char* message);
     void parsingSetMute(const char* message);

--- a/src/capability/system_agent.cc
+++ b/src/capability/system_agent.cc
@@ -140,7 +140,7 @@ void SystemAgent::receiveCommand(const std::string& from, const std::string& com
     }
 }
 
-void SystemAgent::synchronizeState(void)
+void SystemAgent::synchronizeState()
 {
     if (timer)
         timer->start();
@@ -148,7 +148,7 @@ void SystemAgent::synchronizeState(void)
     sendEventSynchronizeState();
 }
 
-void SystemAgent::disconnect(void)
+void SystemAgent::disconnect()
 {
     if (timer)
         timer->stop();
@@ -156,21 +156,21 @@ void SystemAgent::disconnect(void)
     sendEventDisconnect();
 }
 
-void SystemAgent::updateUserActivity(void)
+void SystemAgent::updateUserActivity()
 {
     if (timer)
         timer->start();
 }
 
-void SystemAgent::sendEventSynchronizeState(void)
+void SystemAgent::sendEventSynchronizeState(EventResultCallback cb)
 {
     std::string ename = "SynchronizeState";
     std::string payload = "";
 
-    sendEvent(ename, capa_helper->makeAllContextInfo(), payload);
+    sendEvent(ename, capa_helper->makeAllContextInfo(), payload, std::move(cb));
 }
 
-void SystemAgent::sendEventUserInactivityReport(int seconds)
+void SystemAgent::sendEventUserInactivityReport(int seconds, EventResultCallback cb)
 {
     std::string ename = "UserInactivityReport";
     std::string payload = "";
@@ -179,23 +179,23 @@ void SystemAgent::sendEventUserInactivityReport(int seconds)
     snprintf(buf, 64, "{\"inactiveTimeInSeconds\": %d}", seconds);
     payload = buf;
 
-    sendEvent(ename, getContextInfo(), payload);
+    sendEvent(ename, getContextInfo(), payload, std::move(cb));
 }
 
-void SystemAgent::sendEventDisconnect(void)
+void SystemAgent::sendEventDisconnect(EventResultCallback cb)
 {
     std::string ename = "Disconnect";
     std::string payload = "";
 
-    sendEvent(ename, getContextInfo(), payload, nullptr, true);
+    sendEvent(ename, getContextInfo(), payload, std::move(cb), true);
 }
 
-void SystemAgent::sendEventEcho(void)
+void SystemAgent::sendEventEcho(EventResultCallback cb)
 {
     std::string ename = "Echo";
     std::string payload = "";
 
-    sendEvent(ename, getContextInfo(), payload);
+    sendEvent(ename, getContextInfo(), payload, std::move(cb));
 }
 
 void SystemAgent::parsingResetUserInactivity(const char* message)

--- a/src/capability/system_agent.cc
+++ b/src/capability/system_agent.cc
@@ -187,7 +187,7 @@ void SystemAgent::sendEventDisconnect(void)
     std::string ename = "Disconnect";
     std::string payload = "";
 
-    sendEvent(ename, getContextInfo(), payload, true);
+    sendEvent(ename, getContextInfo(), payload, nullptr, true);
 }
 
 void SystemAgent::sendEventEcho(void)

--- a/src/capability/system_agent.hh
+++ b/src/capability/system_agent.hh
@@ -37,14 +37,14 @@ public:
 
     void receiveCommand(const std::string& from, const std::string& command, const std::string& param) override;
 
-    void synchronizeState(void) override;
-    void disconnect(void) override;
-    void updateUserActivity(void) override;
+    void synchronizeState() override;
+    void disconnect() override;
+    void updateUserActivity() override;
 
-    void sendEventSynchronizeState(void);
-    void sendEventUserInactivityReport(int seconds);
-    void sendEventDisconnect(void);
-    void sendEventEcho(void);
+    void sendEventSynchronizeState(EventResultCallback cb = nullptr);
+    void sendEventUserInactivityReport(int seconds, EventResultCallback cb = nullptr);
+    void sendEventDisconnect(EventResultCallback cb = nullptr);
+    void sendEventEcho(EventResultCallback cb = nullptr);
 
 private:
     // parsing directive

--- a/src/capability/text_agent.cc
+++ b/src/capability/text_agent.cc
@@ -147,7 +147,7 @@ void TextAgent::notifyResponseTimeout()
         text_listener->onState(cur_state);
 }
 
-void TextAgent::sendEventTextInput(const std::string& text, const std::string& token)
+void TextAgent::sendEventTextInput(const std::string& text, const std::string& token, EventResultCallback cb)
 {
     CapabilityEvent event("TextInput", this);
     std::string payload = "";
@@ -184,10 +184,10 @@ void TextAgent::sendEventTextInput(const std::string& text, const std::string& t
 
     playsync_manager->holdContext();
 
-    sendEvent(&event, capa_helper->makeAllContextInfoStack(), payload);
+    sendEvent(&event, capa_helper->makeAllContextInfoStack(), payload, std::move(cb));
 }
 
-void TextAgent::sendEventTextSourceFailed(const std::string& text, const std::string& token)
+void TextAgent::sendEventTextSourceFailed(const std::string& text, const std::string& token, EventResultCallback cb)
 {
     std::string ename = "TextSourceFailed";
     std::string payload = "";
@@ -198,7 +198,7 @@ void TextAgent::sendEventTextSourceFailed(const std::string& text, const std::st
     root["token"] = token;
     payload = writer.write(root);
 
-    sendEvent(ename, getContextInfo(), payload);
+    sendEvent(ename, getContextInfo(), payload, std::move(cb));
 }
 
 void TextAgent::parsingTextSource(const char* message)

--- a/src/capability/text_agent.hh
+++ b/src/capability/text_agent.hh
@@ -41,8 +41,8 @@ public:
     void notifyResponseTimeout();
 
 private:
-    void sendEventTextInput(const std::string& text, const std::string& token);
-    void sendEventTextSourceFailed(const std::string& text, const std::string& token);
+    void sendEventTextInput(const std::string& text, const std::string& token, EventResultCallback cb = nullptr);
+    void sendEventTextSourceFailed(const std::string& text, const std::string& token, EventResultCallback cb = nullptr);
     void parsingTextSource(const char* message);
 
     ITextListener* text_listener;

--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -311,31 +311,31 @@ void TTSAgent::updateInfoForContext(Json::Value& ctx)
     ctx[getName()] = tts;
 }
 
-void TTSAgent::sendEventSpeechStarted(const std::string& token)
+void TTSAgent::sendEventSpeechStarted(const std::string& token, EventResultCallback cb)
 {
     if (ps_id.size())
-        sendEventCommon("SpeechStarted", token);
+        sendEventCommon("SpeechStarted", token, std::move(cb));
 
     if (tts_listener)
         tts_listener->onTTSState(TTSState::TTS_SPEECH_START, dialog_id);
 }
 
-void TTSAgent::sendEventSpeechFinished(const std::string& token)
+void TTSAgent::sendEventSpeechFinished(const std::string& token, EventResultCallback cb)
 {
     if (ps_id.size())
-        sendEventCommon("SpeechFinished", token);
+        sendEventCommon("SpeechFinished", token, std::move(cb));
 
     if (tts_listener)
         tts_listener->onTTSState(TTSState::TTS_SPEECH_FINISH, dialog_id);
 }
 
-void TTSAgent::sendEventSpeechStopped(const std::string& token)
+void TTSAgent::sendEventSpeechStopped(const std::string& token, EventResultCallback cb)
 {
     if (ps_id.size())
-        sendEventCommon("SpeechStopped", token);
+        sendEventCommon("SpeechStopped", token, std::move(cb));
 }
 
-void TTSAgent::sendEventSpeechPlay(const std::string& token, const std::string& text, const std::string& play_service_id)
+void TTSAgent::sendEventSpeechPlay(const std::string& token, const std::string& text, const std::string& play_service_id, EventResultCallback cb)
 {
     std::string ename = "SpeechPlay";
     std::string payload = "";
@@ -358,10 +358,10 @@ void TTSAgent::sendEventSpeechPlay(const std::string& token, const std::string& 
         root["playServiceId"] = ps_id;
     payload = writer.write(root);
 
-    sendEvent(ename, getContextInfo(), payload);
+    sendEvent(ename, getContextInfo(), payload, std::move(cb));
 }
 
-void TTSAgent::sendEventCommon(const std::string& ename, const std::string& token)
+void TTSAgent::sendEventCommon(const std::string& ename, const std::string& token, EventResultCallback cb)
 {
     std::string payload = "";
     Json::StyledWriter writer;
@@ -371,7 +371,7 @@ void TTSAgent::sendEventCommon(const std::string& ename, const std::string& toke
     root["playServiceId"] = ps_id;
     payload = writer.write(root);
 
-    sendEvent(ename, getContextInfo(), payload);
+    sendEvent(ename, getContextInfo(), payload, std::move(cb));
 }
 
 void TTSAgent::parsingSpeak(const char* message)

--- a/src/capability/tts_agent.hh
+++ b/src/capability/tts_agent.hh
@@ -44,10 +44,10 @@ public:
     void requestTTS(const std::string& text, const std::string& play_service_id) override;
     bool setVolume(int volume) override;
 
-    void sendEventSpeechStarted(const std::string& token);
-    void sendEventSpeechFinished(const std::string& token);
-    void sendEventSpeechStopped(const std::string& token);
-    void sendEventSpeechPlay(const std::string& token, const std::string& text, const std::string& play_service_id = "");
+    void sendEventSpeechStarted(const std::string& token, EventResultCallback cb = nullptr);
+    void sendEventSpeechFinished(const std::string& token, EventResultCallback cb = nullptr);
+    void sendEventSpeechStopped(const std::string& token, EventResultCallback cb = nullptr);
+    void sendEventSpeechPlay(const std::string& token, const std::string& text, const std::string& play_service_id = "", EventResultCallback cb = nullptr);
     void setCapabilityListener(ICapabilityListener* clistener) override;
 
     static void pcmStatusCallback(enum nugu_media_status status, void* userdata);
@@ -60,7 +60,7 @@ public:
     bool finish;
 
 private:
-    void sendEventCommon(const std::string& ename, const std::string& token);
+    void sendEventCommon(const std::string& ename, const std::string& token, EventResultCallback cb = nullptr);
     // parsing directive
     void parsingSpeak(const char* message);
     void parsingStop(const char* message);

--- a/src/core/capability_helper.cc
+++ b/src/core/capability_helper.cc
@@ -62,6 +62,11 @@ void CapabilityHelper::sendCommand(const std::string& from, const std::string& t
     CapabilityManager::getInstance()->sendCommand(from, to, command, param);
 }
 
+void CapabilityHelper::requestEventResult(NuguEvent* event)
+{
+    CapabilityManager::getInstance()->requestEventResult(event);
+}
+
 void CapabilityHelper::suspendAll()
 {
     CapabilityManager::getInstance()->suspendAll();

--- a/src/core/capability_helper.hh
+++ b/src/core/capability_helper.hh
@@ -33,6 +33,7 @@ public:
 
     bool setMute(bool mute) override;
     void sendCommand(const std::string& from, const std::string& to, const std::string& command, const std::string& param) override;
+    void requestEventResult(NuguEvent* event) override;
     void suspendAll() override;
     void restoreAll() override;
     void getCapabilityProperty(const std::string& cap, const std::string& property, std::string& value) override;

--- a/src/core/capability_manager.hh
+++ b/src/core/capability_manager.hh
@@ -21,6 +21,7 @@
 #include <memory>
 
 #include "base/nugu_directive_sequencer.h"
+#include "base/nugu_event.h"
 #include "base/nugu_focus.h"
 #include "clientkit/capability_interface.hh"
 #include "playsync_manager.hh"
@@ -38,9 +39,13 @@ public:
     PlaySyncManager* getPlaySyncManager();
 
     static NuguDirseqReturn dirseqCallback(NuguDirective* ndir, void* userdata);
+    static void eventResultCallback(int success, const char* msg_id, const char* dialog_id, int code, void* userdata);
 
     void addCapability(const std::string& cname, ICapabilityInterface* cap);
     void removeCapability(const std::string& cname);
+
+    void requestEventResult(NuguEvent* event);
+    void reportEventResult(const char* msg_id, int success, int code);
 
     void setWakeupWord(const std::string& word);
 
@@ -70,6 +75,7 @@ private:
     static CapabilityManager* instance;
     std::map<std::string, ICapabilityInterface*> caps;
     std::map<std::string, NuguFocus*> focusmap;
+    std::map<std::string, std::string> events;
     std::string wword;
     std::unique_ptr<PlaySyncManager> playsync_manager = nullptr;
     bool check_asr_focus_release = false;


### PR DESCRIPTION
#### Clientkit: Add EventResultCallback

Depending on the network connection status and server status,
event transmission may cause an error, and it should be able to
control it. CapabilityManager collects the event's result
from network manager and forward them to each CapabilityAgent.