### PR TITLE
Implements capability suspend/restore

### DIFF
--- a/examples/capability_injection/battery_agent.cc
+++ b/examples/capability_injection/battery_agent.cc
@@ -47,14 +47,27 @@ void BatteryAgent::deInitialize()
     // TODO : implements service logic
 }
 
+void BatteryAgent::setSuspendPolicy(SuspendPolicy policy)
+{
+    suspend_policy = policy;
+}
+
 void BatteryAgent::suspend()
 {
-    // TODO : implements service logic
+    if (suspend_policy == SuspendPolicy::PAUSE) {
+        // TODO : implements when SuspendPolicy is pause
+    } else {
+        // TODO : implements when SuspendPolicy is stop
+    }
 }
 
 void BatteryAgent::restore()
 {
-    // TODO : implements service logic
+    if (suspend_policy == SuspendPolicy::PAUSE) {
+        // TODO : implements when SuspendPolicy is pause
+    } else {
+        // TODO : implements when SuspendPolicy is stop
+    }
 }
 
 std::string BatteryAgent::getName()

--- a/examples/capability_injection/battery_agent.hh
+++ b/examples/capability_injection/battery_agent.hh
@@ -37,6 +37,7 @@ public:
     void setNuguCoreContainer(INuguCoreContainer* core_container) override;
     void initialize() override;
     void deInitialize() override;
+    void setSuspendPolicy(SuspendPolicy policy = SuspendPolicy::STOP) override;
     void suspend() override;
     void restore() override;
     std::string getName() override;
@@ -52,6 +53,7 @@ public:
 private:
     std::string battery_level = "10";
     bool battery_charging = false;
+    SuspendPolicy suspend_policy = SuspendPolicy::STOP;
 
     INuguCoreContainer* core_container = nullptr;
     IBatteryListener* battery_listener = nullptr;

--- a/examples/standalone/nugu_sample.cc
+++ b/examples/standalone/nugu_sample.cc
@@ -139,6 +139,9 @@ void registerCapabilities()
     mic_handler = std::shared_ptr<IMicHandler>(
         CapabilityFactory::makeCapability<MicAgent, IMicHandler>(mic_listener.get()));
 
+    // set AudioPlayerAgent
+    audio_player_handler->setSuspendPolicy(ICapabilityInterface::SuspendPolicy::PAUSE);
+
     // set MicAgent
     mic_handler->enable();
 

--- a/include/clientkit/capability.hh
+++ b/include/clientkit/capability.hh
@@ -129,6 +129,12 @@ public:
     void deInitialize() override;
 
     /**
+     * @brief Set capability suspend policy
+     * @param[in] policy suspend policy
+     */
+    void setSuspendPolicy(SuspendPolicy policy = SuspendPolicy::STOP) override;
+
+    /**
      * @brief Suspend current action
      */
     void suspend() override;
@@ -294,6 +300,9 @@ protected:
 
     /** @brief IPlaySyncManager instance for using play context sync */
     IPlaySyncManager* playsync_manager = nullptr;
+
+    /** @brief SuspendPolicy variable for deciding suspend action (default:STOP) */
+    SuspendPolicy suspend_policy = SuspendPolicy::STOP;
 
 private:
     struct Impl;

--- a/include/clientkit/capability_interface.hh
+++ b/include/clientkit/capability_interface.hh
@@ -53,6 +53,15 @@ public:
  */
 class ICapabilityInterface {
 public:
+    /**
+     * @brief Capability suspend policy
+     */
+    enum class SuspendPolicy {
+        STOP, /**< Stop current action unconditionally */
+        PAUSE /**< Pause current action. It could resume later */
+    };
+
+public:
     virtual ~ICapabilityInterface() = default;
 
     /**
@@ -67,9 +76,15 @@ public:
     virtual void initialize() = 0;
 
     /**
-     * @brief deinitialize the current object.
+     * @brief Deinitialize the current object.
      */
     virtual void deInitialize() = 0;
+
+    /**
+     * @brief Set capability suspend policy
+     * @param[in] policy suspend policy
+     */
+    virtual void setSuspendPolicy(SuspendPolicy policy = SuspendPolicy::STOP) = 0;
 
     /**
      * @brief Suspend current action

--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -210,7 +210,7 @@ void ASRAgent::deInitialize()
 
 void ASRAgent::suspend()
 {
-    // TODO : implements related suspend action
+    stopRecognition();
 }
 
 bool ASRAgent::startRecognition()

--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -76,12 +76,19 @@ void AudioPlayerAgent::deInitialize()
 
 void AudioPlayerAgent::suspend()
 {
-    // TODO : implements related suspend action
+    if (suspend_policy == SuspendPolicy::PAUSE) {
+        if (cur_aplayer_state == AudioPlayerState::PLAYING)
+            capa_helper->releaseFocus("cap_audio");
+    } else {
+        if (cur_aplayer_state == AudioPlayerState::PLAYING || cur_aplayer_state == AudioPlayerState::PAUSED)
+            stop();
+    }
 }
 
 void AudioPlayerAgent::restore()
 {
-    // TODO : implements related restore action
+    if (suspend_policy == SuspendPolicy::PAUSE && cur_aplayer_state == AudioPlayerState::PAUSED)
+        capa_helper->requestFocus("cap_audio", NULL);
 }
 
 void AudioPlayerAgent::onFocus(void* event)

--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -104,7 +104,8 @@ void TTSAgent::deInitialize()
 
 void TTSAgent::suspend()
 {
-    // TODO : implements related suspend action
+    if (speak_status == NUGU_MEDIA_STATUS_PLAYING)
+        stopTTS();
 }
 
 void TTSAgent::pcmStatusCallback(enum nugu_media_status status, void* userdata)

--- a/src/clientkit/capability.cc
+++ b/src/clientkit/capability.cc
@@ -155,6 +155,11 @@ void Capability::deInitialize()
 {
 }
 
+void Capability::setSuspendPolicy(SuspendPolicy policy)
+{
+    suspend_policy = policy;
+}
+
 void Capability::suspend()
 {
 }


### PR DESCRIPTION
It implements suspend, restore methods in capability agents
which are required.

In ASRAgent, it implements suspend() for stopRecognition.
In TTSAgent, it implements suspend() for stopTTS.
In AudioPlayerAgent, it implements suspend() for pause/stop
and restore() for resume.

Also, it apply suspend policy which is possible to select
pause or resume action in each capability agent.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>