### PR TITLE
update TTSAgent suspend

### DIFF
--- a/examples/standalone/nugu_sample.cc
+++ b/examples/standalone/nugu_sample.cc
@@ -139,9 +139,6 @@ void registerCapabilities()
     mic_handler = std::shared_ptr<IMicHandler>(
         CapabilityFactory::makeCapability<MicAgent, IMicHandler>(mic_listener.get()));
 
-    // set AudioPlayerAgent
-    audio_player_handler->setSuspendPolicy(ICapabilityInterface::SuspendPolicy::PAUSE);
-
     // set MicAgent
     mic_handler->enable();
 

--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -105,7 +105,7 @@ void TTSAgent::deInitialize()
 void TTSAgent::suspend()
 {
     if (speak_status == NUGU_MEDIA_STATUS_PLAYING)
-        stopTTS();
+        capa_helper->releaseFocus("cap_tts");
 }
 
 void TTSAgent::pcmStatusCallback(enum nugu_media_status status, void* userdata)


### PR DESCRIPTION
It update to suspend TTSAgent from stopTTS to releaseFocus,
because, it needs to remove play context simultaneously.

And, it change SuspendPolicy of AudioPlayerAgent to default,
because, it seems right to customize policy in required application.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>