### PR TITLE
fix ASR stop unexpected issue

### DIFF
--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -80,7 +80,7 @@ NuguFocusResult ASRFocusListener::onUnfocus(void* event, NuguUnFocusMode mode)
 
 NuguFocusStealResult ASRFocusListener::onStealRequest(void* event, NuguFocusType target_type)
 {
-    return NUGU_FOCUS_STEAL_ALLOW;
+    return (agent->getListeningState() == ListeningState::DONE) ? NUGU_FOCUS_STEAL_ALLOW : NUGU_FOCUS_STEAL_REJECT;
 }
 
 class ExpectFocusListener : public IFocusListener {
@@ -586,6 +586,11 @@ bool ASRAgent::isExpectSpeechState()
         return true;
     else
         return false;
+}
+
+ListeningState ASRAgent::getListeningState()
+{
+    return prev_listening_state;
 }
 
 void ASRAgent::resetExpectSpeechState()

--- a/src/capability/asr_agent.hh
+++ b/src/capability/asr_agent.hh
@@ -74,6 +74,7 @@ public:
 
     void resetExpectSpeechState();
     bool isExpectSpeechState();
+    ListeningState getListeningState();
 
 private:
     void sendEventCommon(const std::string& ename);


### PR DESCRIPTION
During the ASR has focus as startListening, if AudioPlayer
directive is sended to client, it steal focus from ASR.
As a result, ASR is stopped abnormally.

So, it fix to allow to steal ASR focus only ListenigState is done.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>