### PR TITLE
network: add notify callback for event send

### DIFF
--- a/include/base/nugu_network_manager.h
+++ b/include/base/nugu_network_manager.h
@@ -88,8 +88,17 @@ typedef void (*NuguNetworkManagerHandoffStatusCallback)(
 	NuguNetworkHandoffStatus status, void *userdata);
 
 /**
+ * @brief Callback prototype for notification of event sending requests
+ * @see nugu_network_manager_send_event()
+ * @see nugu_network_manager_set_event_send_notify_callback()
+ */
+typedef void (*NuguNetworkManagerEventSendNotifyCallback)(NuguEvent *nev,
+							  void *userdata);
+
+/**
  * @brief Callback prototype for result of event transfer request.
  * @see nugu_network_manager_send_event()
+ * @see nugu_network_manager_set_event_result_callback()
  */
 typedef void (*NuguNetworkManagerEventResultCallback)(int success,
 						      const char *msg_id,
@@ -145,6 +154,17 @@ int nugu_network_manager_set_status_callback(
  */
 int nugu_network_manager_set_handoff_status_callback(
 	NuguNetworkManagerHandoffStatusCallback callback, void *userdata);
+
+/**
+ * @brief Set event send notify callback
+ * @param[in] callback callback function
+ * @param[in] userdata data to pass to the user callback
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ */
+int nugu_network_manager_set_event_send_notify_callback(
+	NuguNetworkManagerEventSendNotifyCallback callback, void *userdata);
 
 /**
  * @brief Set event result callback


### PR DESCRIPTION
Add notify callback for event transmission to use for event sending
status monitoring. (e.g. log sender)

Signed-off-by: Inho Oh <inho.oh@sk.com>