### PR TITLE
NetworkManager: Event Send/Result Listener

### DIFF
--- a/examples/standalone/nugu_sample.cc
+++ b/examples/standalone/nugu_sample.cc
@@ -86,6 +86,21 @@ public:
 
         nugu_sample_manager->handleNetworkResult(false);
     }
+
+    void onEventSent(const char* ename, const char* msg_id, const char* dialog_id, const char* referrer_id)
+    {
+        std::string msg = "send event(" + std::string(ename) + ") msg_id - " + std::string(msg_id);
+        msg += "\n\tdialog_id: " + std::string(dialog_id);
+        if (referrer_id)
+            msg += ", referrer_id: " + std::string(referrer_id);
+        msg_info(msg);
+    }
+
+    void onEventResult(const char* msg_id, bool success, int code)
+    {
+        std::string msg = "result event - " + std::string(msg_id) + "(" + std::to_string(success) + ", code: " + std::to_string(code) + ")";
+        msg_info(msg);
+    }
 };
 
 void registerCapabilities()

--- a/include/clientkit/capability_helper_interface.hh
+++ b/include/clientkit/capability_helper_interface.hh
@@ -104,6 +104,14 @@ public:
     virtual void requestEventResult(NuguEvent* event) = 0;
 
     /**
+     * @brief Notify to send event result to CapabilityManager.
+     * @param[in] msg_id event message id
+     * @param[in] success event result
+     * @param[in] code event result code (similar to http status code)
+     */
+    virtual void notifyEventResult(const char* msg_id, bool success, int code) = 0;
+
+    /**
      * @brief Suspend all current capability action
      */
     virtual void suspendAll() = 0;

--- a/include/clientkit/network_manager_interface.hh
+++ b/include/clientkit/network_manager_interface.hh
@@ -54,13 +54,32 @@ public:
 
     /**
      * @brief Report the connection status with the NUGU server.
+     * @param[in] status network status
      */
     virtual void onStatusChanged(NetworkStatus status);
 
     /**
      * @brief Report an error while communicating with the NUGU server.
+     * @param[in] error network error
      */
     virtual void onError(NetworkError error);
+
+    /**
+     * @brief Report that an event has been sent to the server.
+     * @param[in] ename event name
+     * @param[in] msg_id event message id
+     * @param[in] dialog_id event dialog request id
+     * @param[in] referrer_id event referrer dialog request id
+     */
+    virtual void onEventSent(const char* ename, const char* msg_id, const char* dialog_id, const char* referrer_id);
+
+    /**
+     * @brief Report the result of sending an event from the server.
+     * @param[in] msg_id event message id
+     * @param[in] success event result
+     * @param[in] code event result code (similar to http status code)
+     */
+    virtual void onEventResult(const char* msg_id, bool success, int code);
 };
 
 /**

--- a/src/clientkit/network_manager_interface.cc
+++ b/src/clientkit/network_manager_interface.cc
@@ -19,5 +19,7 @@ namespace NuguClientKit {
 
 void INetworkManagerListener::onStatusChanged(NetworkStatus status) {}
 void INetworkManagerListener::onError(NetworkError error) {}
+void INetworkManagerListener::onEventSent(const char* ename, const char* msg_id, const char* dialog_id, const char* referrer_id) {}
+void INetworkManagerListener::onEventResult(const char* msg_id, bool success, int code) {}
 
 } //NuguClientKit

--- a/src/clientkit/nugu_client_impl.cc
+++ b/src/clientkit/nugu_client_impl.cc
@@ -196,6 +196,11 @@ void NuguClientImpl::onStatusChanged(NetworkStatus status)
         sys_handler->synchronizeState();
 }
 
+void NuguClientImpl::onEventResult(const char* msg_id, bool success, int code)
+{
+    nugu_core_container->getCapabilityHelper()->notifyEventResult(msg_id, success, code);
+}
+
 INetworkManager* NuguClientImpl::getNetworkManager()
 {
     return network_manager.get();

--- a/src/clientkit/nugu_client_impl.hh
+++ b/src/clientkit/nugu_client_impl.hh
@@ -47,6 +47,7 @@ public:
 
     // overriding INetworkManagerListener
     void onStatusChanged(NetworkStatus status) override;
+    void onEventResult(const char* msg_id, bool success, int code) override;
 
 private:
     int createCapabilities(void);

--- a/src/core/capability_helper.cc
+++ b/src/core/capability_helper.cc
@@ -67,6 +67,11 @@ void CapabilityHelper::requestEventResult(NuguEvent* event)
     CapabilityManager::getInstance()->requestEventResult(event);
 }
 
+void CapabilityHelper::notifyEventResult(const char* msg_id, bool success, int code)
+{
+    CapabilityManager::getInstance()->reportEventResult(msg_id, success, code);
+}
+
 void CapabilityHelper::suspendAll()
 {
     CapabilityManager::getInstance()->suspendAll();

--- a/src/core/capability_helper.hh
+++ b/src/core/capability_helper.hh
@@ -34,6 +34,7 @@ public:
     bool setMute(bool mute) override;
     void sendCommand(const std::string& from, const std::string& to, const std::string& command, const std::string& param) override;
     void requestEventResult(NuguEvent* event) override;
+    void notifyEventResult(const char* msg_id, bool success, int code) override;
     void suspendAll() override;
     void restoreAll() override;
     void getCapabilityProperty(const std::string& cap, const std::string& property, std::string& value) override;

--- a/src/core/capability_manager.cc
+++ b/src/core/capability_manager.cc
@@ -53,7 +53,6 @@ static NuguFocusStealResult on_steal_request(NuguFocus* focus, void* event, Nugu
 CapabilityManager::CapabilityManager()
 {
     nugu_dirseq_set_callback(dirseqCallback, this);
-    nugu_network_manager_set_event_result_callback(eventResultCallback, this);
 
     wword = WAKEUP_WORD;
     playsync_manager = std::unique_ptr<PlaySyncManager>(new PlaySyncManager());
@@ -105,12 +104,6 @@ NuguDirseqReturn CapabilityManager::dirseqCallback(NuguDirective* ndir, void* us
 
     cap->processDirective(ndir);
     return NUGU_DIRSEQ_SUCCESS;
-}
-
-void CapabilityManager::eventResultCallback(int success, const char* msg_id, const char* dialog_id, int code, void* userdata)
-{
-    CapabilityManager* cap_manager = static_cast<CapabilityManager*>(userdata);
-    cap_manager->reportEventResult(msg_id, success, code);
 }
 
 void CapabilityManager::addCapability(const std::string& cname, ICapabilityInterface* cap)

--- a/src/core/capability_manager.hh
+++ b/src/core/capability_manager.hh
@@ -39,7 +39,6 @@ public:
     PlaySyncManager* getPlaySyncManager();
 
     static NuguDirseqReturn dirseqCallback(NuguDirective* ndir, void* userdata);
-    static void eventResultCallback(int success, const char* msg_id, const char* dialog_id, int code, void* userdata);
 
     void addCapability(const std::string& cname, ICapabilityInterface* cap);
     void removeCapability(const std::string& cname);


### PR DESCRIPTION
The application can know the events sent by the NUGU SDK and
the result of the sent events through the network manager listener.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>