### PR TITLE
network: fix request resume bug

### DIFF
--- a/src/base/network/http2/directives_parser.cc
+++ b/src/base/network/http2/directives_parser.cc
@@ -215,7 +215,7 @@ static void _body_opus(const char* parent_msg_id, int is_end, const char* data,
     item->data = (unsigned char*)malloc(length);
     memcpy(item->data, data, length);
 
-    nugu_log_print(NUGU_LOG_MODULE_NETWORK_TRACE, NUGU_LOG_LEVEL_INFO, NULL,
+    nugu_log_print(NUGU_LOG_MODULE_NETWORK, NUGU_LOG_LEVEL_DEBUG, NULL,
         NULL, -1, "<-- Attachment: parent=%s (%zd bytes, is_end=%d)",
         parent_msg_id, length, is_end);
 

--- a/src/base/network/http2/http2_network.h
+++ b/src/base/network/http2/http2_network.h
@@ -30,8 +30,10 @@ void http2_network_free(HTTP2Network *net);
 
 int http2_network_add_request(HTTP2Network *net, HTTP2Request *req);
 int http2_network_remove_request_sync(HTTP2Network *net, HTTP2Request *req);
+int http2_network_resume_request(HTTP2Network *net, HTTP2Request *req);
 
 int http2_network_start(HTTP2Network *net);
+int http2_network_wakeup(HTTP2Network *net);
 
 int http2_network_set_token(HTTP2Network *net, const char *token);
 

--- a/src/base/network/http2/http2_request.c
+++ b/src/base/network/http2/http2_request.c
@@ -142,8 +142,8 @@ static size_t _request_body_cb(char *buffer, size_t size, size_t nitems,
 	else if (length == 0) {
 		if (req->send_body_closed == 0) {
 			/* Pause the current uploading */
+			nugu_dbg("request paused until resume (req=%p)", req);
 			http2_request_unlock_send_data(req);
-			nugu_dbg("request paused until resume (req=%x)", req);
 			return CURL_READFUNC_PAUSE;
 		}
 
@@ -360,16 +360,6 @@ void http2_request_unlock_send_data(HTTP2Request *req)
 	g_return_if_fail(req != NULL);
 
 	pthread_mutex_unlock(&req->lock_send_body);
-}
-
-int http2_request_resume(HTTP2Request *req)
-{
-	g_return_val_if_fail(req != NULL, -1);
-
-	nugu_dbg("resume the paused request (req=%p)", req);
-	curl_easy_pause(req->easy, CURLPAUSE_CONT);
-
-	return 0;
 }
 
 int http2_request_set_method(HTTP2Request *req,

--- a/src/base/network/http2/http2_request.h
+++ b/src/base/network/http2/http2_request.h
@@ -106,7 +106,7 @@ int http2_request_add_header(HTTP2Request *req, const char *header);
  *   http2_request_add_send_data(... 100 bytes) - Additional data to send
  *   http2_request_close_send_data()
  *   http2_request_unlock_send_data()
- *   http2_request_resume()
+ *   http2_network_resume_request()
  *
  *   Additional 100 bytes will be sent. And the upload will be finished
  *   because http2_request_close_send_data()
@@ -114,7 +114,6 @@ int http2_request_add_header(HTTP2Request *req, const char *header);
 int http2_request_add_send_data(HTTP2Request *req, const unsigned char *data,
 				size_t length);
 int http2_request_close_send_data(HTTP2Request *req);
-int http2_request_resume(HTTP2Request *req);
 
 void http2_request_lock_send_data(HTTP2Request *req);
 void http2_request_unlock_send_data(HTTP2Request *req);

--- a/src/base/network/http2/v1_directives.c
+++ b/src/base/network/http2/v1_directives.c
@@ -22,7 +22,6 @@
 
 #include "base/nugu_equeue.h"
 #include "base/nugu_log.h"
-#include "base/nugu_network_manager.h"
 
 #include "directives_parser.h"
 #include "http2_request.h"


### PR DESCRIPTION
Move the request resume API to http2_network module to resolve thread
issue. (curl_easy_pause is not thread safety)

Signed-off-by: Inho Oh <inho.oh@sk.com>