### PR TITLE
add method about EpdSilenceInterval

### DIFF
--- a/include/capability/asr_interface.hh
+++ b/include/capability/asr_interface.hh
@@ -154,6 +154,12 @@ public:
      * @param[in] attribute attribute object
      */
     virtual void setAttribute(ASRAttribute&& attribute) = 0;
+
+    /**
+     * @brief Get epd silence interval
+     * @return Interval milliseconds
+     */
+    virtual long getEpdSilenceInterval() = 0;
 };
 
 /**

--- a/include/clientkit/speech_recognizer_interface.hh
+++ b/include/clientkit/speech_recognizer_interface.hh
@@ -97,6 +97,12 @@ public:
      * @return mute
      */
     virtual bool isMute() = 0;
+
+    /**
+     * @brief Get epd pause length
+     * @return Pause length
+     */
+    virtual int getEpdPauseLength() = 0;
 };
 
 /**

--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -403,6 +403,11 @@ void ASRAgent::removeListener(IASRListener* listener)
         asr_listeners.erase(iterator);
 }
 
+long ASRAgent::getEpdSilenceInterval()
+{
+    return static_cast<long>(speech_recognizer ? speech_recognizer->getEpdPauseLength() : 0);
+}
+
 std::vector<IASRListener*> ASRAgent::getListener()
 {
     return asr_listeners;

--- a/src/capability/asr_agent.hh
+++ b/src/capability/asr_agent.hh
@@ -70,6 +70,7 @@ public:
     void setCapabilityListener(ICapabilityListener* clistener) override;
     void addListener(IASRListener* listener) override;
     void removeListener(IASRListener* listener) override;
+    long getEpdSilenceInterval() override;
     std::vector<IASRListener*> getListener();
 
     void resetExpectSpeechState();

--- a/src/core/speech_recognizer.cc
+++ b/src/core/speech_recognizer.cc
@@ -32,7 +32,7 @@ static const int ASR_EPD_PAUSE_LENGTH_MSEC = 700;
 
 SpeechRecognizer::SpeechRecognizer()
 {
-    initialize(Attribute{});
+    initialize(Attribute {});
 }
 
 SpeechRecognizer::~SpeechRecognizer()
@@ -250,4 +250,8 @@ bool SpeechRecognizer::isMute()
     return recorder->isMute();
 }
 
+int SpeechRecognizer::getEpdPauseLength()
+{
+    return epd_pause_length;
+}
 } // NuguCore

--- a/src/core/speech_recognizer.hh
+++ b/src/core/speech_recognizer.hh
@@ -49,6 +49,7 @@ public:
     bool startListening() override;
     void stopListening() override;
     bool isMute() override;
+    int getEpdPauseLength() override;
 
 private:
     void initialize(Attribute&& attribute);


### PR DESCRIPTION
It add the method which is possible to get
epd silence interval (frankly, it's epd pause length).

Because, it's related to ASR, that method is added to ASRAgent.

Be careful, not to use that method before NuguClient initialized.
The reason is at that time, the required instance(SpeechRecognizer)
is not created, we can't retrieve correct value.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>