### PR TITLE
clientkit: ignore the plugin loading result

### DIFF
--- a/src/clientkit/nugu_client_impl.cc
+++ b/src/clientkit/nugu_client_impl.cc
@@ -132,8 +132,7 @@ bool NuguClientImpl::initialize(void)
     }
 
     if (nugu_plugin_load_directory(NUGU_PLUGIN_DIR) < 0) {
-        nugu_error("Fail to load nugu_plugin ");
-        return false;
+        nugu_error("Fail to load nugu_plugin");
     }
 
     nugu_plugin_initialize();


### PR DESCRIPTION
If the plugin fails to load at client initialization, treat it as
success. This is because some systems don't have plug-ins.

Signed-off-by: Inho Oh <inho.oh@sk.com>