### PR TITLE
externals: update curl to v7.69.1

### DIFF
--- a/externals/0003_curl_ca_variables.patch
+++ b/externals/0003_curl_ca_variables.patch
@@ -1,6 +1,6 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -642,6 +642,10 @@ endif()
+@@ -685,6 +685,10 @@ endif()
  #
  # CA handling
  #


### PR DESCRIPTION
Update the curl library version v7.67.0 to v7.69.1
- Changelog: https://curl.haxx.se/changes.html

SDK Releated changes
- curl_easy_pause() improved
- cmake script updated
- conn, multi, http2 improved

Signed-off-by: Inho Oh <inho.oh@sk.com>