### PR TITLE
externals: add tizen ca path patch to curl

### DIFF
--- a/externals/0004_tizen_ca_bundle_path.patch
+++ b/externals/0004_tizen_ca_bundle_path.patch
@@ -1,0 +1,10 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -725,6 +725,7 @@ elseif(CURL_CA_PATH_AUTODETECT OR CURL_CA_BUNDLE_AUTODETECT)
+ 
+   if(CURL_CA_BUNDLE_AUTODETECT)
+     set(SEARCH_CA_BUNDLE_PATHS
++        /opt/share/cert-svc/ca-certificate.crt
+         /etc/ssl/certs/ca-certificates.crt
+         /etc/pki/tls/certs/ca-bundle.crt
+         /usr/share/ssl/certs/ca-bundle.crt

--- a/externals/patch_curl.sh
+++ b/externals/patch_curl.sh
@@ -3,5 +3,6 @@
 patch -N --silent -p1 < ../0001_curl_find_nghttp2.patch
 patch -N --silent -p1 < ../0002_curl_have_poll_h.patch
 patch -N --silent -p1 < ../0003_curl_ca_variables.patch
+patch -N --silent -p1 < ../0004_tizen_ca_bundle_path.patch
 
 echo "Patched!"


### PR DESCRIPTION
Add tizen CA bundle path patch to curl build.

Signed-off-by: Inho Oh <inho.oh@sk.com>