### PR TITLE
build: add log message ansicolor option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ SET(bindir "${prefix}/${CMAKE_INSTALL_BINDIR}")
 SET(plugindir "${CMAKE_INSTALL_FULL_LIBDIR}/nugu")
 
 # Set default build options
+OPTION(ENABLE_LOG_ANSICOLOR "Enable ansicolor to log message" ON)
 OPTION(ENABLE_GSTREAMER_PLUGIN "Enable the GStreamer plugin" ON)
 OPTION(ENABLE_OPUS_PLUGIN "Enable the OPUS plugin" ON)
 OPTION(ENABLE_PORTAUDIO_PLUGIN "Enable the PortAudio plugin" ON)
@@ -142,13 +143,15 @@ ENDIF()
 SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__='\"$(subst $(realpath ${CMAKE_SOURCE_DIR})/,,$(abspath $<))\"'")
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__FILENAME__='\"$(subst $(realpath ${CMAKE_SOURCE_DIR})/,,$(abspath $<))\"'")
 
+IF(ENABLE_LOG_ANSICOLOR)
+	# Turn on the colorful log message
+	ADD_DEFINITIONS(-DNUGU_LOG_USE_ANSICOLOR)
+ENDIF()
+
 # Global definitions
 ADD_DEFINITIONS(
 	# Run-time buffer overflow detection
 	-D_FORTIFY_SOURCE=2
-
-	# Turn on the colorful log message
-	-DCONFIG_LOG_ANSICOLOR
 
 	# Environment variable names
 	# - Please comment out the following definition to avoid overwriting

--- a/include/base/nugu_log.h
+++ b/include/base/nugu_log.h
@@ -340,11 +340,19 @@ void nugu_hexdump(enum nugu_log_module module, const uint8_t *data,
 	nugu_log(NUGU_LOG_MODULE, NUGU_LOG_LEVEL_ERROR, fmt, ##__VA_ARGS__)
 
 #ifndef NUGU_ANSI_COLOR_SEND
+#ifdef NUGU_LOG_USE_ANSICOLOR
 #define NUGU_ANSI_COLOR_SEND NUGU_ANSI_COLOR_BROWN
+#else
+#define NUGU_ANSI_COLOR_SEND ""
+#endif
 #endif
 
 #ifndef NUGU_ANSI_COLOR_RECV
+#ifdef NUGU_LOG_USE_ANSICOLOR
 #define NUGU_ANSI_COLOR_RECV NUGU_ANSI_COLOR_GREEN
+#else
+#define NUGU_ANSI_COLOR_RECV ""
+#endif
 #endif
 
 #ifndef NUGU_LOG_MARK_SEND

--- a/src/base/nugu_log.c
+++ b/src/base/nugu_log.c
@@ -183,7 +183,7 @@ static int _log_make_prefix(char *prefix, enum nugu_log_level level,
 		tid = (pid_t)syscall(SYS_gettid);
 #endif
 
-#ifdef CONFIG_LOG_ANSICOLOR
+#ifdef NUGU_LOG_USE_ANSICOLOR
 #ifdef __APPLE__
 		if (len > 0 && pid != 0 && (uint64_t)pid != tid)
 #else
@@ -284,7 +284,7 @@ static void _log_formatted(enum nugu_log_module module,
 		pthread_mutex_lock(&_log_mutex);
 		if (len > 0)
 			fprintf(stderr, "%s ", prefix);
-#ifdef CONFIG_LOG_ANSICOLOR
+#ifdef NUGU_LOG_USE_ANSICOLOR
 		switch (level) {
 		case NUGU_LOG_LEVEL_DEBUG:
 			break;
@@ -302,7 +302,7 @@ static void _log_formatted(enum nugu_log_module module,
 		}
 #endif
 		vfprintf(stderr, format, arg);
-#ifdef CONFIG_LOG_ANSICOLOR
+#ifdef NUGU_LOG_USE_ANSICOLOR
 		fputs(NUGU_ANSI_COLOR_NORMAL, stderr);
 #endif
 		fputc('\n', stderr);


### PR DESCRIPTION
Add build option for log message ansicolor to support text only log
message system.

Signed-off-by: Inho Oh <inho.oh@sk.com>