### PR TITLE
Pcm: fix the heap-use-after-free

### DIFF
--- a/src/base/nugu_pcm.c
+++ b/src/base/nugu_pcm.c
@@ -277,7 +277,6 @@ EXPORT_API int nugu_pcm_start(NuguPcm *pcm)
 		return -1;
 	}
 	nugu_pcm_clear_buffer(pcm);
-	nugu_pcm_set_userdata(pcm, NULL);
 
 	return pcm->driver->ops->start(pcm->driver, pcm, pcm->property);
 }


### PR DESCRIPTION
When calling 'nugu_pcm_start' function, userdata is not clearly
freed by calling 'nugu_pcm_set_userdata (pcm, NULL)'. Because of
this, Portaudio still uses the old value.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>