### PR TITLE
base: add missing push_data call to push_data_done

### DIFF
--- a/plugins/filedump.c
+++ b/plugins/filedump.c
@@ -97,8 +97,10 @@ static int _pcm_push_data(NuguPcmDriver *driver, NuguPcm *pcm, const char *data,
 
 	fd = GPOINTER_TO_INT(nugu_pcm_get_userdata(pcm));
 
-	if (write(fd, data, size) < 0)
-		return -1;
+	if (data != NULL && size > 0) {
+		if (write(fd, data, size) < 0)
+			return -1;
+	}
 
 	return 0;
 }

--- a/src/base/nugu_pcm.c
+++ b/src/base/nugu_pcm.c
@@ -506,6 +506,9 @@ EXPORT_API int nugu_pcm_push_data_done(NuguPcm *pcm)
 
 	pthread_mutex_unlock(&pcm->mutex);
 
+	if (pcm->driver->ops->push_data)
+		pcm->driver->ops->push_data(pcm->driver, pcm, NULL, 0, 1);
+
 	return 0;
 }
 


### PR DESCRIPTION
There is missing callback invocation for push_data in the
push_data_done function.

Signed-off-by: Inho Oh <inho.oh@sk.com>