### PR TITLE
core: fix sync_event

### DIFF
--- a/src/core/audio_input_processor.cc
+++ b/src/core/audio_input_processor.cc
@@ -134,7 +134,7 @@ void AudioInputProcessor::sendSyncEvent(const std::function<void()>& action)
 
     std::unique_lock<std::mutex> lock(data->mutex);
 
-    g_main_context_invoke(NULL, invoke_sync_event, data);
+    g_idle_add(invoke_sync_event, data);
 
     data->cond.wait(lock);
     lock.unlock();


### PR DESCRIPTION
g_main_context_invoke() cause deadlock in some targets.
(gmainloop integrated ecore loop)

So change to g_idle_add().

Signed-off-by: Inho Oh <inho.oh@sk.com>