### PR TITLE
capability: remove 'Disconnect' from SystemAgent

### DIFF
--- a/include/capability/system_interface.hh
+++ b/include/capability/system_interface.hh
@@ -99,11 +99,6 @@ public:
     virtual void synchronizeState() = 0;
 
     /**
-     * @brief Send disconnect event to server.
-     */
-    virtual void disconnect() = 0;
-
-    /**
      * @brief Update a timer that measures the user's inactivity.
      */
     virtual void updateUserActivity() = 0;

--- a/src/capability/system_agent.cc
+++ b/src/capability/system_agent.cc
@@ -43,8 +43,7 @@ SystemAgent::SystemAgent()
                 nugu_error("handoff failed");
                 break;
             case NUGU_NETWORK_HANDOFF_READY:
-                nugu_dbg("handoff ready. send 'Disconnect' event");
-                sa->sendEventDisconnect();
+                nugu_dbg("handoff ready.");
                 break;
             case NUGU_NETWORK_HANDOFF_COMPLETED:
                 nugu_dbg("handoff completed. send 'SynchronizeState' event");
@@ -81,8 +80,6 @@ void SystemAgent::initialize()
 
 void SystemAgent::deInitialize()
 {
-    disconnect();
-
     if (timer) {
         delete timer;
         timer = nullptr;
@@ -148,14 +145,6 @@ void SystemAgent::synchronizeState()
     sendEventSynchronizeState();
 }
 
-void SystemAgent::disconnect()
-{
-    if (timer)
-        timer->stop();
-
-    sendEventDisconnect();
-}
-
 void SystemAgent::updateUserActivity()
 {
     if (timer)
@@ -180,14 +169,6 @@ void SystemAgent::sendEventUserInactivityReport(int seconds, EventResultCallback
     payload = buf;
 
     sendEvent(ename, getContextInfo(), payload, std::move(cb));
-}
-
-void SystemAgent::sendEventDisconnect(EventResultCallback cb)
-{
-    std::string ename = "Disconnect";
-    std::string payload = "";
-
-    sendEvent(ename, getContextInfo(), payload, std::move(cb), true);
 }
 
 void SystemAgent::sendEventEcho(EventResultCallback cb)

--- a/src/capability/system_agent.hh
+++ b/src/capability/system_agent.hh
@@ -38,12 +38,10 @@ public:
     void receiveCommand(const std::string& from, const std::string& command, const std::string& param) override;
 
     void synchronizeState() override;
-    void disconnect() override;
     void updateUserActivity() override;
 
     void sendEventSynchronizeState(EventResultCallback cb = nullptr);
     void sendEventUserInactivityReport(int seconds, EventResultCallback cb = nullptr);
-    void sendEventDisconnect(EventResultCallback cb = nullptr);
     void sendEventEcho(EventResultCallback cb = nullptr);
 
 private:


### PR DESCRIPTION
The 'Disconnect' event is deprecated in the V2 API.

Signed-off-by: Inho Oh <inho.oh@sk.com>