### PR TITLE
network: remove 'address' filed from policy

### DIFF
--- a/include/base/nugu_network_manager.h
+++ b/include/base/nugu_network_manager.h
@@ -125,7 +125,6 @@ enum nugu_network_protocol {
  */
 typedef struct nugu_network_server_policy {
 	enum nugu_network_protocol protocol; /**< protocol */
-	char address[NUGU_NETWORK_MAX_ADDRESS + 1]; /**< IP address */
 	char hostname[NUGU_NETWORK_MAX_ADDRESS + 1]; /**< dns name */
 	int port; /**< port number */
 	int retry_count_limit; /**< maximum number of connection retries */

--- a/src/base/network/http2/v1_policies.cc
+++ b/src/base/network/http2/v1_policies.cc
@@ -85,18 +85,6 @@ static void _parse_servers(const Json::Value& root)
             continue;
         }
 
-        if (server["address"].isString()) {
-            const char* tmp = server["address"].asCString();
-            if (tmp) {
-                int len = strlen(tmp);
-                memcpy(server_item->address, tmp, (len > NUGU_NETWORK_MAX_ADDRESS) ? NUGU_NETWORK_MAX_ADDRESS : len);
-            }
-        } else {
-            nugu_error("can't find 'address' string attribute in item-%d", i);
-            free(server_item);
-            continue;
-        }
-
         if (server["port"].isNumeric()) {
             server_item->port = server["port"].asInt();
         } else {

--- a/src/capability/system_agent.cc
+++ b/src/capability/system_agent.cc
@@ -224,17 +224,6 @@ void SystemAgent::parsingHandoffConnection(const char* message)
         return;
     }
 
-    if (root["address"].isString()) {
-        const char* tmp = root["address"].asCString();
-        if (tmp) {
-            int len = strlen(tmp);
-            memcpy(policy.address, tmp, (len > NUGU_NETWORK_MAX_ADDRESS) ? NUGU_NETWORK_MAX_ADDRESS : len);
-        }
-    } else {
-        nugu_error("can't find 'address' string attribute");
-        return;
-    }
-
     if (root["port"].isNumeric()) {
         policy.port = root["port"].asInt();
     } else {
@@ -265,8 +254,8 @@ void SystemAgent::parsingHandoffConnection(const char* message)
         nugu_error("can't find 'charge' attribute");
     }
 
-    nugu_dbg("%s:%d (%s:%d, protocol=%d)", policy.hostname, policy.port,
-        policy.address, policy.port, policy.protocol);
+    nugu_dbg("%s:%d (protocol=%d)", policy.hostname, policy.port,
+        policy.protocol);
     nugu_dbg(" - retryCountLimit: %d, connectionTimeout: %d, charge: %d",
         policy.retry_count_limit, policy.connection_timeout_ms, policy.is_charge);
 


### PR DESCRIPTION
The 'address' field is deprecated from the server policy object.
Only 'hostname' and 'port' fields are used to connect to server.

Signed-off-by: Inho Oh <inho.oh@sk.com>