### PR TITLE
AudioPlayerAgent: Update version 1.2

### DIFF
--- a/src/capability/audio_player_agent.hh
+++ b/src/capability/audio_player_agent.hh
@@ -85,6 +85,8 @@ public:
     void sendEventHideLyricsFailed(EventResultCallback cb = nullptr);
     void sendEventControlLyricsPageSucceeded(EventResultCallback cb = nullptr);
     void sendEventControlLyricsPageFailed(EventResultCallback cb = nullptr);
+    void sendEventByRequestDirective(const std::string& dname, EventResultCallback cb = nullptr);
+    void sendEventRequestPlayCommandIssued(const std::string& dname, const std::string& payload, EventResultCallback cb = nullptr);
 
     void mediaStateChanged(MediaPlayerState state) override;
     void mediaEventReport(MediaPlayerEvent event) override;
@@ -110,6 +112,7 @@ private:
     void parsingShowLyrics(const char* message);
     void parsingHideLyrics(const char* message);
     void parsingControlLyricsPage(const char* message);
+    void parsingRequestPlayCommand(const char* dname, const char* message);
 
     std::string playbackError(PlaybackError error);
     std::string playerActivity(AudioPlayerState state);


### PR DESCRIPTION
The AudioPlayerAgent supports to request play contents
in third party application now. For example, you can play
specific music with a NUGU device in the NUGU mobile app.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>