### PR TITLE
ASRAgent: Fix status and event occurrence

### DIFF
--- a/include/capability/asr_interface.hh
+++ b/include/capability/asr_interface.hh
@@ -145,7 +145,7 @@ public:
      * @brief Turn on the microphone and start speech recognition
      * @param[in] callback asr recognize callback
      */
-    virtual void startRecognition(AsrRecognizeCallback callback) = 0;
+    virtual void startRecognition(AsrRecognizeCallback callback = nullptr) = 0;
 
     /**
      * @brief Turn off the microphone and stop speech recognition

--- a/src/capability/asr_agent.hh
+++ b/src/capability/asr_agent.hh
@@ -48,6 +48,7 @@ public:
     void suspend() override;
 
     void startRecognition(AsrRecognizeCallback callback = nullptr) override;
+    void startRecognition(bool expected);
     void stopRecognition() override;
 
     void parsingDirective(const char* dname, const char* message) override;
@@ -79,6 +80,9 @@ public:
     bool isExpectSpeechState();
     ListeningState getListeningState();
 
+    void setASRState(ASRState state);
+    ASRState getASRState();
+
 private:
     void sendEventCommon(const std::string& ename, EventResultCallback cb = nullptr);
 
@@ -103,6 +107,7 @@ private:
     std::vector<IASRListener*> asr_listeners;
     ListeningState prev_listening_state = ListeningState::DONE;
     AsrRecognizeCallback rec_callback;
+    ASRState cur_state;
 
     // attribute
     std::string model_path;

--- a/src/core/speech_recognizer.cc
+++ b/src/core/speech_recognizer.cc
@@ -127,6 +127,7 @@ void SpeechRecognizer::loop()
             continue;
 
         nugu_dbg("Listening Thread: asr_is_running=%d", is_running);
+        sendSyncListeningEvent(ListeningState::READY);
 
         if (epd_client_start(model_file.c_str(), epd_param) < 0) {
             nugu_error("epd_client_start() failed");
@@ -245,6 +246,8 @@ void SpeechRecognizer::loop()
             continue;
 
         nugu_dbg("Listening Thread: asr_is_running=%d", is_running);
+        sendSyncListeningEvent(ListeningState::READY);
+
         nugu_error("nugu_epd is not supported");
         sendSyncListeningEvent(ListeningState::FAILED);
         is_running = false;
@@ -255,9 +258,6 @@ void SpeechRecognizer::loop()
 bool SpeechRecognizer::startListening()
 {
     return AudioInputProcessor::start([&] {
-        if (listener)
-            listener->onListeningState(ListeningState::READY);
-
         epd_ret = 0;
     });
 }

--- a/src/core/wakeup_detector.cc
+++ b/src/core/wakeup_detector.cc
@@ -31,7 +31,7 @@ static const char* MODEL_PATH = "./";
 
 WakeupDetector::WakeupDetector()
 {
-    initialize(Attribute{});
+    initialize(Attribute {});
 }
 
 WakeupDetector::~WakeupDetector()
@@ -71,7 +71,6 @@ void WakeupDetector::initialize(Attribute&& attribute)
     AudioInputProcessor::init("kwd", sample, format, channel);
 }
 
-
 #ifdef ENABLE_VENDOR_LIBRARY
 void WakeupDetector::loop()
 {
@@ -105,6 +104,7 @@ void WakeupDetector::loop()
             continue;
 
         nugu_dbg("Wakeup Thread: kwd_is_running=%d", is_running);
+        sendSyncWakeupEvent(WakeupState::DETECTING);
 
         if (kwd_initialize(model_net_file.c_str(), model_search_file.c_str()) < 0) {
             nugu_error("kwd_initialize() failed");
@@ -183,6 +183,8 @@ void WakeupDetector::loop()
             continue;
 
         nugu_dbg("Wakeup Thread: kwd_is_running=%d", is_running);
+        sendSyncWakeupEvent(WakeupState::DETECTING);
+
         nugu_error("nugu_wwd is not supported");
         sendSyncWakeupEvent(WakeupState::FAIL);
         is_running = false;
@@ -192,10 +194,7 @@ void WakeupDetector::loop()
 
 bool WakeupDetector::startWakeup()
 {
-    return AudioInputProcessor::start([&] {
-        if (listener)
-            listener->onWakeupState(WakeupState::DETECTING);
-    });
+    return AudioInputProcessor::start();
 }
 
 void WakeupDetector::stopWakeup()

--- a/src/core/wakeup_handler.cc
+++ b/src/core/wakeup_handler.cc
@@ -65,8 +65,6 @@ void WakeupHandler::onWakeupState(WakeupState state)
     case WakeupState::DETECTED:
         nugu_dbg("WakeupState::DETECTED");
 
-        CapabilityManager::getInstance()->sendCommand("ASR", "ASR", "wakeup_detected", "");
-
         if (listener)
             listener->onWakeupState(WakeupDetectState::WAKEUP_DETECTED);
         break;


### PR DESCRIPTION
When timeout and fail occurred during Recognition, there was a bug
in which the state was changed first and the event was changed,
and this was fixed.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>