### PR TITLE
AudioRecorderManager: Fix a bug

### DIFF
--- a/src/core/audio_recorder_manager.cc
+++ b/src/core/audio_recorder_manager.cc
@@ -152,8 +152,13 @@ bool AudioRecorderManager::start(IAudioRecorder* recorder)
     }
 
     nugu_dbg("start recorder: %p", recorder);
-
-    return (nugu_recorder_start(nugu_recorder) >= 0);
+    if (recorder_list.size() == 1) {
+        nugu_dbg("request to start recorder");
+        return (nugu_recorder_start(nugu_recorder) >= 0);
+    } else {
+        nugu_dbg("recorder already started");
+        return true;
+    }
 }
 
 bool AudioRecorderManager::stop(IAudioRecorder* recorder)
@@ -172,10 +177,13 @@ bool AudioRecorderManager::stop(IAudioRecorder* recorder)
     }
     nugu_dbg("stop recorder: %p, list's size: %d", recorder, recorder_list.size());
 
-    if (!recorder_list.size())
+    if (!recorder_list.size()) {
+        nugu_dbg("request to stop recorder because nobody use the recorder");
         return (nugu_recorder_stop(nugu_recorder) >= 0);
-
-    return true;
+    } else {
+        nugu_dbg("someone use the recorder");
+        return true;
+    }
 }
 
 bool AudioRecorderManager::isRecording(IAudioRecorder* recorder)


### PR DESCRIPTION
Even though the recorder was already started and used, there was
a bug that could cause the recorder to start over and fixed it.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>