### PR TITLE
ASR, KWD: Fix the multi-thread issue

### DIFF
--- a/examples/standalone/capability/speech_operator.cc
+++ b/examples/standalone/capability/speech_operator.cc
@@ -178,6 +178,9 @@ void SpeechOperator::onState(ASRState state, const std::string& dialog_id)
     }
     case ASRState::LISTENING: {
         msg::asr::state(dialog_id, "LISTENING");
+        // need to stop wakeup when asr state is changed from idle to listening
+        // without wakeup detected
+        stopWakeup();
         break;
     }
     case ASRState::RECOGNIZING: {

--- a/include/clientkit/speech_recognizer_interface.hh
+++ b/include/clientkit/speech_recognizer_interface.hh
@@ -56,8 +56,9 @@ public:
     /**
      * @brief Report to the user listening state changed.
      * @param[in] state listening state
+     * @param[in] id listening id
      */
-    virtual void onListeningState(ListeningState state) = 0;
+    virtual void onListeningState(ListeningState state, const std::string& id) = 0;
 
     /**
      * @brief Get current audio input stream
@@ -83,9 +84,10 @@ public:
 
     /**
      * @brief Start listening speech
+     * @param[in] id listening id
      * @return result of start listening
      */
-    virtual bool startListening() = 0;
+    virtual bool startListening(const std::string& id) = 0;
 
     /**
      * @brief Stop listening speech

--- a/src/capability/asr_agent.hh
+++ b/src/capability/asr_agent.hh
@@ -82,19 +82,20 @@ public:
 
     void setASRState(ASRState state);
     ASRState getASRState();
+    void setListeningId(const std::string& id);
 
 private:
     void sendEventCommon(const std::string& ename, EventResultCallback cb = nullptr);
 
     // implements ISpeechRecognizerListener
-    void onListeningState(ListeningState state) override;
+    void onListeningState(ListeningState state, const std::string& id) override;
     void onRecordData(unsigned char* buf, int length) override;
 
     // parsing directive
     void parsingExpectSpeech(const char* message);
     void parsingNotifyResult(const char* message);
 
-    void releaseASRFocus(bool is_cancel, ASRError error);
+    void releaseASRFocus(bool is_cancel, ASRError error, bool release_focus = true);
 
     ExpectSpeechAttr es_attr;
     CapabilityEvent* rec_event;
@@ -108,6 +109,7 @@ private:
     ListeningState prev_listening_state = ListeningState::DONE;
     AsrRecognizeCallback rec_callback;
     ASRState cur_state;
+    std::string request_listening_id;
 
     // attribute
     std::string model_path;

--- a/src/core/audio_input_processor.hh
+++ b/src/core/audio_input_processor.hh
@@ -39,17 +39,19 @@ protected:
     void init(std::string name, std::string& sample, std::string& format, std::string& channel);
     bool start(const std::function<void()>& extra_func = nullptr);
     void stop();
-    void sendSyncEvent(const std::function<void()>& action = nullptr);
+    void sendEvent(const std::function<void()>& action = nullptr);
 
     virtual void loop() = 0;
 
     bool is_initialized = false;
     bool is_running = false;
+    bool is_started = false;
     bool thread_created = false;
     gint destroy;
     std::thread thread;
     std::condition_variable cond;
     std::mutex mutex;
+    std::string listening_id;
     IAudioRecorder* recorder = nullptr;
 };
 

--- a/src/core/speech_recognizer.hh
+++ b/src/core/speech_recognizer.hh
@@ -46,7 +46,7 @@ public:
 
     // implements ISpeechRecognizer
     void setListener(ISpeechRecognizerListener* listener) override;
-    bool startListening() override;
+    bool startListening(const std::string& id) override;
     void stopListening() override;
     bool isMute() override;
     int getEpdPauseLength() override;
@@ -54,7 +54,7 @@ public:
 private:
     void initialize(Attribute&& attribute);
     void loop() override;
-    void sendSyncListeningEvent(ListeningState state);
+    void sendListeningEvent(ListeningState state, const std::string& id);
 
     const unsigned int OUT_DATA_SIZE = 1024 * 9;
     int epd_ret = -1;

--- a/src/core/wakeup_detector.hh
+++ b/src/core/wakeup_detector.hh
@@ -36,7 +36,7 @@ public:
     virtual ~IWakeupDetectorListener() = default;
 
     /* The callback is invoked in the main context. */
-    virtual void onWakeupState(WakeupState state) = 0;
+    virtual void onWakeupState(WakeupState state, const std::string& id) = 0;
 };
 
 class WakeupDetector : public AudioInputProcessor {
@@ -54,13 +54,13 @@ public:
     virtual ~WakeupDetector();
 
     void setListener(IWakeupDetectorListener* listener);
-    bool startWakeup();
+    bool startWakeup(const std::string& id);
     void stopWakeup();
 
 private:
     void initialize(Attribute&& attribute);
     void loop() override;
-    void sendSyncWakeupEvent(WakeupState state);
+    void sendWakeupEvent(WakeupState state, const std::string& id);
 
     IWakeupDetectorListener* listener = nullptr;
 

--- a/src/core/wakeup_handler.hh
+++ b/src/core/wakeup_handler.hh
@@ -37,11 +37,15 @@ public:
     void setListener(IWakeupListener* listener) override;
     bool startWakeup() override;
     void stopWakeup() override;
-    void onWakeupState(WakeupState state) override;
+    void onWakeupState(WakeupState state, const std::string& id) override;
+
+    void setWakeupId(const std::string& id);
 
 private:
     IWakeupListener* listener = nullptr;
     std::unique_ptr<WakeupDetector> wakeup_detector;
+    std::string request_wakeup_id;
+    int uniq;
 };
 } // NuguCore
 


### PR DESCRIPTION
StartRecognition does not work normally when stopRecognition
and startRecognition are repeated continuously #250. StartWakeup is
also similar. To solve this problem, added the ID to request listening
and checked the ID when receiving event.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>