### PR TITLE
network: add message-id to /v2/events attachment

### DIFF
--- a/src/base/network/dg_server.c
+++ b/src/base/network/dg_server.c
@@ -190,6 +190,7 @@ static int _send_v2_events_attachment(DGServer *server, NuguEvent *nev,
 				      unsigned char *data)
 {
 	V2Events *e;
+	char *msg_id;
 
 	/* find an active event from pending list */
 	e = g_hash_table_lookup(server->pending_events,
@@ -199,7 +200,10 @@ static int _send_v2_events_attachment(DGServer *server, NuguEvent *nev,
 		return -1;
 	}
 
-	v2_events_send_binary(e, nugu_event_get_seq(nev), is_end, length, data);
+	msg_id = nugu_uuid_generate_time();
+	v2_events_send_binary(e, msg_id, nugu_event_get_seq(nev), is_end,
+			      length, data);
+	free(msg_id);
 
 	if (is_end == 0)
 		return 0;

--- a/src/base/network/http2/v2_events.c
+++ b/src/base/network/http2/v2_events.c
@@ -40,7 +40,7 @@
 	"Content-Disposition: form-data; name=\"attachment\";"                 \
 	" filename=\"%d;%s\"" CRLF                                             \
 	"Content-Type: application/octet-stream" CRLF                          \
-	"Content-Length: %zd" CRLF CRLF
+	"Content-Length: %zd" CRLF "Message-Id: %s" CRLF CRLF
 
 struct _v2_events {
 	HTTP2Request *req;
@@ -260,16 +260,16 @@ int v2_events_send_json(V2Events *event, const char *data, size_t length)
 	return 0;
 }
 
-int v2_events_send_binary(V2Events *event, int seq, int is_end, size_t length,
-			  unsigned char *data)
+int v2_events_send_binary(V2Events *event, const char *msgid, int seq,
+			  int is_end, size_t length, unsigned char *data)
 {
 	char *part_header;
 
 	g_return_val_if_fail(event != NULL, -1);
 
-	part_header =
-		g_strdup_printf(PART_HEADER_BINARY_FMT, seq,
-				(is_end == 1) ? "end" : "continued", length);
+	part_header = g_strdup_printf(PART_HEADER_BINARY_FMT, seq,
+				      (is_end == 1) ? "end" : "continued",
+				      length, msgid);
 
 	http2_request_lock_send_data(event->req);
 	http2_request_add_send_data(event->req,

--- a/src/base/network/http2/v2_events.h
+++ b/src/base/network/http2/v2_events.h
@@ -31,8 +31,8 @@ void v2_events_free(V2Events *event);
 int v2_events_set_info(V2Events *event, const char *msg_id,
 		       const char *dialog_id);
 int v2_events_send_json(V2Events *event, const char *data, size_t length);
-int v2_events_send_binary(V2Events *event, int seq, int is_end, size_t length,
-			  unsigned char *data);
+int v2_events_send_binary(V2Events *event, const char *msgid, int seq,
+			  int is_end, size_t length, unsigned char *data);
 int v2_events_send_done(V2Events *event);
 
 #ifdef __cplusplus


### PR DESCRIPTION
The message-id header is required from latest API spec.

Signed-off-by: Inho Oh <inho.oh@sk.com>