### PR TITLE
base: add stdout to log system

### DIFF
--- a/include/base/nugu_log.h
+++ b/include/base/nugu_log.h
@@ -133,7 +133,8 @@ enum nugu_log_level {
  * @see nugu_log_set_handler()
  */
 enum nugu_log_system {
-	NUGU_LOG_SYSTEM_STDERR, /**< Standard error output */
+	NUGU_LOG_SYSTEM_STDERR, /**< Standard error */
+	NUGU_LOG_SYSTEM_STDOUT, /**< Standard output */
 	NUGU_LOG_SYSTEM_SYSLOG, /**< syslog */
 	NUGU_LOG_SYSTEM_NONE, /**< no log */
 	NUGU_LOG_SYSTEM_CUSTOM /**< custom log handler by log_set_handler() */


### PR DESCRIPTION
The 'stderr' standard output was provided as a log system to
separate from printf output, but 'stdout' was also added to be
selectable if necessary.

Usage:

    $ export NUGU_LOG=stdout

or

    nugu_log_set_system(NUGU_LOG_SYSTEM_STDOUT)

Signed-off-by: Inho Oh <inho.oh@sk.com>