### PR TITLE
Audioplayer: Fix the playback position bug

### DIFF
--- a/src/core/media_player.cc
+++ b/src/core/media_player.cc
@@ -289,6 +289,8 @@ bool MediaPlayer::seek(int sec)
     if (nugu_player_seek(d->player, sec) < 0)
         return false;
 
+    setPositionWithSeek(sec);
+
     return true;
 }
 
@@ -311,6 +313,13 @@ bool MediaPlayer::setPosition(int position)
     for (auto l : d->listeners)
         l->positionChanged(d->position);
     return true;
+}
+
+void MediaPlayer::setPositionWithSeek(int position)
+{
+    // Seek position is set in advance only when a seek request is sent to the media player before playback.
+    if (state() == MediaPlayerState::PREPARE)
+        d->position = position;
 }
 
 int MediaPlayer::duration()

--- a/src/core/media_player.hh
+++ b/src/core/media_player.hh
@@ -66,6 +66,8 @@ public:
     std::string url() override;
 
 private:
+    void setPositionWithSeek(int position);
+
     MediaPlayerPrivate* d;
 };
 


### PR DESCRIPTION
There is a bug where the playback position is always filled
with a value of 0 in `AudioPlayer.PlaybackStarted` even if
`AudioPlayer.Play` has an `offsetInMilliseconds` value.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>