### PR TITLE
fix asr expecting speech bug

### DIFF
--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -62,10 +62,8 @@ void ASRFocusListener::onFocus(void* event)
     agent->setListeningId(id);
     speech_recognizer->startListening(id);
 
-    if (agent->isExpectSpeechState()) {
-        agent->resetExpectSpeechState();
+    if (agent->isExpectSpeechState())
         agent->getCapabilityHelper()->releaseFocus("expect");
-    }
 }
 
 NuguFocusResult ASRFocusListener::onUnfocus(void* event, NuguUnFocusMode mode)


### PR DESCRIPTION
When asr has focus in expecting speech, it reset
expecting speech state, so, it cannot send that info to server.

So, it fix not to reset expecting speech state,
when asr has on focus.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>