### PR TITLE
clientkit: change log message for event result

### DIFF
--- a/src/clientkit/capability.cc
+++ b/src/clientkit/capability.cc
@@ -320,9 +320,10 @@ void Capability::sendEvent(CapabilityEvent* event, const std::string& context, c
 
     std::string ename = event->getName();
     if (cb == nullptr)
-        addEventResultCallback(ename, [&](const std::string& ename, const std::string& msg_id, const std::string& dialog_id, bool success, int code) {
-            nugu_warn("The %sAgent ignore the %s result %d(code:%d)", getName().c_str(), ename.c_str(), success, code);
-        });
+        addEventResultCallback(ename,
+            [&](const std::string& ename, const std::string& msg_id, const std::string& dialog_id, bool success, int code) {
+                nugu_warn("receive %s.%s(%s) result %d(code:%d) - ignored", getName().c_str(), ename.c_str(), msg_id.c_str(), success, code);
+            });
     else
         addEventResultCallback(ename, std::move(cb));
 


### PR DESCRIPTION
To make log analysis easier, changed the log message for the event
result where the event callback is not registered.

as is: The message-id is missing.

    receive ASR.Recognize({msg-id}) result 1(code:200)
    The ASRAgent ignore the StopRecognize result 1(code:200)

to be:

    receive ASR.Recognize({msg-id}) result 1(code:200)
    receive ASR.StopRecognize({msg-id}) result 1(code:200) - ignored

Signed-off-by: Inho Oh <inho.oh@sk.com>