### PR TITLE
network: add libcurl error code to http2_request

### DIFF
--- a/src/base/network/http2/http2_request.c
+++ b/src/base/network/http2/http2_request.c
@@ -36,6 +36,8 @@
 
 struct _http2_request {
 	CURL *easy;
+	enum http2_result result;
+
 	struct curl_slist *headers;
 	enum http2_request_content_type type;
 	char curl_errbuf[CURL_ERROR_SIZE];
@@ -342,6 +344,22 @@ int http2_request_unref(HTTP2Request *req)
 	http2_request_free(req);
 
 	return 0;
+}
+
+int http2_request_set_result(HTTP2Request *req, enum http2_result result)
+{
+	g_return_val_if_fail(req != NULL, -1);
+
+	req->result = result;
+
+	return 0;
+}
+
+enum http2_result http2_request_get_result(HTTP2Request *req)
+{
+	g_return_val_if_fail(req != NULL, HTTP2_RESULT_UNKNOWN);
+
+	return req->result;
 }
 
 int http2_request_add_header(HTTP2Request *req, const char *header)

--- a/src/base/network/http2/http2_request.h
+++ b/src/base/network/http2/http2_request.h
@@ -40,6 +40,17 @@ enum http2_request_content_type {
 	HTTP2_REQUEST_CONTENT_TYPE_MULTIPART
 };
 
+enum http2_result {
+	HTTP2_RESULT_OK,
+	HTTP2_RESULT_PROXY_FAIL,
+	HTTP2_RESULT_DNS_FAIL,
+	HTTP2_RESULT_CONNECT_FAIL,
+	HTTP2_RESULT_SSL_FAIL,
+	HTTP2_RESULT_HTTP_FAIL,
+	HTTP2_RESULT_HTTP2_FAIL,
+	HTTP2_RESULT_UNKNOWN
+};
+
 typedef struct _http2_request HTTP2Request;
 
 typedef size_t (*ResponseHeaderCallback)(HTTP2Request *req, char *buffer,
@@ -60,6 +71,9 @@ HTTP2Request *http2_request_new();
 
 int http2_request_ref(HTTP2Request *req);
 int http2_request_unref(HTTP2Request *req);
+
+int http2_request_set_result(HTTP2Request *req, enum http2_result result);
+enum http2_result http2_request_get_result(HTTP2Request *req);
 
 /* Configuration */
 int http2_request_disable_verify_peer(HTTP2Request *req);


### PR DESCRIPTION
Add libcurl error code to http2_request result to identify error
condition such as DNS error.

Signed-off-by: Inho Oh <inho.oh@sk.com>