### PR TITLE
base: introduce profiling feature

### DIFF
--- a/examples/standalone/nugu_sample.cc
+++ b/examples/standalone/nugu_sample.cc
@@ -16,6 +16,7 @@
 
 #include <iostream>
 
+#include <base/nugu_prof.h>
 #include <clientkit/nugu_client.hh>
 
 #include "capability_collection.hh"
@@ -190,6 +191,8 @@ int main(int argc, char** argv)
 
             msg_info("de-initialization done");
         });
+
+    nugu_prof_dump(NUGU_PROF_TYPE_SDK_CREATED, NUGU_PROF_TYPE_MAX);
 
     return EXIT_SUCCESS;
 }

--- a/include/base/nugu_log.h
+++ b/include/base/nugu_log.h
@@ -173,8 +173,9 @@ enum nugu_log_module {
 	NUGU_LOG_MODULE_DEFAULT = 0x01, /**< Default module */
 	NUGU_LOG_MODULE_NETWORK = 0x02, /**< Network module */
 	NUGU_LOG_MODULE_NETWORK_TRACE = 0x04, /**< Network trace module */
-	NUGU_LOG_MODULE_PROTOCOL = 0x10, /**< Protocol module */
 	NUGU_LOG_MODULE_AUDIO = 0x08, /**< Audio module */
+	NUGU_LOG_MODULE_PROTOCOL = 0x10, /**< Protocol module */
+	NUGU_LOG_MODULE_PROFILING = 0x20, /**< Profiling module */
 	NUGU_LOG_MODULE_ALL = 0xFF /**< All modules */
 };
 

--- a/include/base/nugu_prof.h
+++ b/include/base/nugu_prof.h
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NUGU_PROF_H__
+#define __NUGU_PROF_H__
+
+#include <base/nugu_uuid.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file nugu_prof.h
+ * @defgroup Profiling Profiling
+ * @ingroup SDKBase
+ * @brief Profiling functions
+ *
+ * The profiling module provides notification and performance measurement
+ * for each condition.
+ *
+ * @{
+ */
+
+/**
+ * @brief Profiling type list
+ * @see nugu_prof_mark()
+ * @see nugu_prof_mark_data()
+ * @see nugu_prof_get_last_data()
+ */
+enum nugu_prof_type {
+	NUGU_PROF_TYPE_SDK_CREATED,
+	/**< SDK created. timestamp baseline */
+
+	NUGU_PROF_TYPE_SDK_PLUGIN_INIT_START,
+	/**< Plugin loading and init start */
+
+	NUGU_PROF_TYPE_SDK_PLUGIN_INIT_DONE,
+	/**< All plugin initialized */
+
+	NUGU_PROF_TYPE_SDK_INIT_DONE,
+	/**< SDK initialized and ready */
+
+	NUGU_PROF_TYPE_NETWORK_CONNECT_REQUEST,
+	/**< Network manager connect */
+
+	NUGU_PROF_TYPE_NETWORK_REGISTRY_REQUEST,
+	/**< HTTP/2 Request for GET /v1/policies */
+
+	NUGU_PROF_TYPE_NETWORK_REGISTRY_RESPONSE,
+	/**< HTTP/2 Response for GET /v1/policies */
+
+	NUGU_PROF_TYPE_NETWORK_REGISTRY_FAILED,
+	/**< HTTP/2 Failed for GET /v1/policies */
+
+	NUGU_PROF_TYPE_NETWORK_SERVER_ESTABLISH_REQUEST,
+	/**< HTTP/2 Request for GET /v2/directives */
+
+	NUGU_PROF_TYPE_NETWORK_SERVER_ESTABLISH_RESPONSE,
+	/**< HTTP/2 long polling established for /v2/directives */
+
+	NUGU_PROF_TYPE_NETWORK_SERVER_ESTABLISH_FAILED,
+	/**< HTTP/2 Failed for GET /v2/directives */
+
+	NUGU_PROF_TYPE_NETWORK_CONNECTED,
+	/**< Network manager connected */
+
+	NUGU_PROF_TYPE_NETWORK_DIRECTIVES_CLOSED,
+	/**< HTTP/2 /v2/directives stream closed by server */
+
+	NUGU_PROF_TYPE_NETWORK_DNS_FAILED,
+	/**< DNS Resolving failed */
+
+	NUGU_PROF_TYPE_NETWORK_SSL_FAILED,
+	/**< SSL failed */
+
+	NUGU_PROF_TYPE_NETWORK_INTERNAL_ERROR,
+	/**< Network internal error */
+
+	NUGU_PROF_TYPE_NETWORK_INVALID_TOKEN,
+	/**< Invalid token */
+
+	NUGU_PROF_TYPE_NETWORK_PING_REQUEST,
+	/**< HTTP/2 Request for GET /v2/ping */
+
+	NUGU_PROF_TYPE_NETWORK_PING_RESPONSE,
+	/**< HTTP/2 Response for GET /v2/ping */
+
+	NUGU_PROF_TYPE_NETWORK_PING_FAILED,
+	/**< HTTP/2 Failed for GET /v2/ping */
+
+	NUGU_PROF_TYPE_NETWORK_EVENT_REQUEST,
+	/**< HTTP/2 Request for POST /v2/events */
+
+	NUGU_PROF_TYPE_NETWORK_EVENT_RESPONSE,
+	/**< HTTP/2 Response for POST /v2/events */
+
+	NUGU_PROF_TYPE_NETWORK_EVENT_FAILED,
+	/**< HTTP/2 Failed for POST /v2/events */
+
+	NUGU_PROF_TYPE_NETWORK_EVENT_ATTACHMENT_REQUEST,
+	/**< HTTP/2 Request for POST /v2/events attachment */
+
+	NUGU_PROF_TYPE_NETWORK_EVENT_ATTACHMENT_RESPONSE,
+	/**< HTTP/2 Response for POST /v2/events attachment */
+
+	NUGU_PROF_TYPE_NETWORK_EVENT_ATTACHMENT_FAILED,
+	/**< HTTP/2 Failed for POST /v2/events attachment */
+
+	NUGU_PROF_TYPE_LAST_SERVER_INITIATIVE_DATA,
+	/**< Last received data from /v2/directives */
+
+	NUGU_PROF_TYPE_WAKEUP_KEYWORD_DETECTED,
+	/**< Wakeup keyword detected */
+
+	NUGU_PROF_TYPE_ASR_LISTENING_STARTED,
+	/**< ASR listening started */
+
+	NUGU_PROF_TYPE_ASR_RECOGNIZING_STARTED,
+	/**< ASR recognizing started */
+
+	NUGU_PROF_TYPE_ASR_END_POINT_DETECTED,
+	/**< ASR end point detected */
+
+	NUGU_PROF_TYPE_ASR_TIMEOUT,
+	/**< ASR listening timeout */
+
+	NUGU_PROF_TYPE_ASR_FIRST_ATTACHMENT,
+	/**< ASR first attachment */
+
+	NUGU_PROF_TYPE_ASR_LAST_ATTACHMENT,
+	/**< ASR last attachment */
+
+	NUGU_PROF_TYPE_ASR_RESULT,
+	/**< ASR result received */
+
+	NUGU_PROF_TYPE_TTS_STARTED,
+	/**< TTS started */
+
+	NUGU_PROF_TYPE_TTS_FIRST_ATTACHMENT,
+	/**< TTS receive first attachment */
+
+	NUGU_PROF_TYPE_TTS_LAST_ATTACHMENT,
+	/**< TTS receive last attachment */
+
+	NUGU_PROF_TYPE_TTS_FINISHED,
+	/**< TTS finished */
+
+	NUGU_PROF_TYPE_AUDIO_STARTED,
+	/**< AudioPlayer started */
+
+	NUGU_PROF_TYPE_AUDIO_FINISHED,
+	/**< AudioPlayer finished */
+
+	NUGU_PROF_TYPE_MAX
+	/**< Just last value */
+};
+
+/**
+ * @brief Profiling raw data
+ * @see NuguProfCallback
+ */
+struct nugu_prof_data {
+	enum nugu_prof_type type; /**< profiling type */
+	char dialog_id[NUGU_MAX_UUID_STRING_SIZE + 1]; /* dialog request id */
+	char msg_id[NUGU_MAX_UUID_STRING_SIZE + 1]; /* message id */
+	struct timespec timestamp; /* timestamp */
+	char *contents; /* additional contents */
+};
+
+/**
+ * @brief Callback prototype for receiving an attachment
+ * @see nugu_prof_set_callback()
+ */
+typedef void (*NuguProfCallback)(enum nugu_prof_type type,
+				 const struct nugu_prof_data *data,
+				 void *userdata);
+
+/**
+ * @brief clear all cached profiling data
+ */
+void nugu_prof_clear(void);
+
+/**
+ * @brief turn on the profiling trace log message
+ */
+void nugu_prof_enable_tracelog(void);
+
+/**
+ * @brief turn off the profiling trace log message
+ */
+void nugu_prof_disable_tracelog(void);
+
+/**
+ * @brief Set profiling callback
+ * @param[in] callback callback function
+ * @param[in] userdata data to pass to the user callback
+ */
+void nugu_prof_set_callback(NuguProfCallback callback, void *userdata);
+
+/**
+ * @brief Marking to profiling data and emit the callback
+ * @param[in] type profiling type
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ */
+int nugu_prof_mark(enum nugu_prof_type type);
+
+/**
+ * @brief Marking to profiling data with additional id and emit the callback
+ * @param[in] type profiling type
+ * @param[in] dialog_id dialog request id
+ * @param[in] msg_id message id
+ * @param[in] contents additional contents
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ */
+int nugu_prof_mark_data(enum nugu_prof_type type, const char *dialog_id,
+			const char *msg_id, const char *contents);
+
+/**
+ * @brief Get last cached data by profiling type
+ * @param[in] type profiling type
+ * @return memory allocated nugu_prof_data struct. developer must free the data.
+ */
+struct nugu_prof_data *nugu_prof_get_last_data(enum nugu_prof_type type);
+
+/**
+ * @brief Get the time difference(ts2 - ts1) value in milliseconds
+ * @param[in] ts1 time value
+ * @param[in] ts2 time value
+ * @return milliseconds
+ */
+int nugu_prof_get_diff_msec_timespec(const struct timespec *ts1,
+				     const struct timespec *ts2);
+
+/**
+ * @brief Get the time difference(prof2 - prof1) value in milliseconds
+ * @param[in] prof1 time value
+ * @param[in] prof2 time value
+ * @return milliseconds
+ */
+int nugu_prof_get_diff_msec(const struct nugu_prof_data *prof1,
+			    const struct nugu_prof_data *prof2);
+
+/**
+ * @brief Dump the profiling data between 'from' type to 'to' type
+ * @param[in] from start type to dump
+ * @param[in] to end type to dump
+ */
+void nugu_prof_dump(enum nugu_prof_type from, enum nugu_prof_type to);
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/base/nugu_uuid.h
+++ b/include/base/nugu_uuid.h
@@ -45,9 +45,14 @@ extern "C" {
 #define NUGU_BASE_TIMESTAMP_MSEC 1546300800000
 
 /**
- * @brief Maximum UUID size not base16 encoded.
+ * @brief Maximum byte array UUID size
  */
 #define NUGU_MAX_UUID_SIZE 16
+
+/**
+ * @brief Maximum base16 encoded UUID string size
+ */
+#define NUGU_MAX_UUID_STRING_SIZE (NUGU_MAX_UUID_SIZE * 2)
 
 /**
  * @brief Generate time based UUID

--- a/src/base/network/http2/http2_request.c
+++ b/src/base/network/http2/http2_request.c
@@ -73,6 +73,7 @@ struct _http2_request {
 	/* Optional information */
 	char *msg_id;
 	char *dialog_id;
+	char *profiling_contents;
 };
 
 static int _debug_callback(CURL *handle, curl_infotype type, char *data,
@@ -293,6 +294,9 @@ static void http2_request_free(HTTP2Request *req)
 
 	if (req->dialog_id)
 		free(req->dialog_id);
+
+	if (req->profiling_contents)
+		free(req->profiling_contents);
 
 	if (strlen(req->curl_errbuf) > 0)
 		nugu_error("CURL ERROR: %s", req->curl_errbuf);
@@ -695,4 +699,27 @@ const char *http2_request_peek_dialogid(HTTP2Request *req)
 	g_return_val_if_fail(req != NULL, NULL);
 
 	return req->dialog_id;
+}
+
+int http2_request_set_profiling_contents(HTTP2Request *req,
+					 const char *contents)
+{
+	g_return_val_if_fail(req != NULL, -1);
+
+	if (req->profiling_contents)
+		free(req->profiling_contents);
+
+	if (contents)
+		req->profiling_contents = strdup(contents);
+	else
+		req->profiling_contents = NULL;
+
+	return 0;
+}
+
+const char *http2_request_peek_profiling_contents(HTTP2Request *req)
+{
+	g_return_val_if_fail(req != NULL, NULL);
+
+	return req->profiling_contents;
 }

--- a/src/base/network/http2/http2_request.h
+++ b/src/base/network/http2/http2_request.h
@@ -94,6 +94,9 @@ int http2_request_set_msgid(HTTP2Request *req, const char *msgid);
 const char *http2_request_peek_msgid(HTTP2Request *req);
 int http2_request_set_dialogid(HTTP2Request *req, const char *dialogid);
 const char *http2_request_peek_dialogid(HTTP2Request *req);
+int http2_request_set_profiling_contents(HTTP2Request *req,
+					 const char *contents);
+const char *http2_request_peek_profiling_contents(HTTP2Request *req);
 
 /* Destroy notify callback */
 int http2_request_set_destroy_callback(HTTP2Request *req,

--- a/src/base/nugu_log.c
+++ b/src/base/nugu_log.c
@@ -123,6 +123,8 @@ static void _log_check_override_module(void)
 			bitset = bitset | NUGU_LOG_MODULE_NETWORK_TRACE;
 		if (!strncasecmp(modules[i], "protocol", 9))
 			bitset = bitset | NUGU_LOG_MODULE_PROTOCOL;
+		if (!strncasecmp(modules[i], "profiling", 10))
+			bitset = bitset | NUGU_LOG_MODULE_PROFILING;
 		if (!strncasecmp(modules[i], "audio", 6))
 			bitset = bitset | NUGU_LOG_MODULE_AUDIO;
 	}

--- a/src/base/nugu_prof.c
+++ b/src/base/nugu_prof.c
@@ -1,0 +1,390 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+
+#include <glib.h>
+
+#include "base/nugu_log.h"
+#include "base/nugu_prof.h"
+
+#define BUFSIZE_TIMESTR 19
+#define PAYLOAD_MAX 4096
+
+struct nugu_prof_hints {
+	const char *text;
+	enum nugu_prof_type relative_type;
+};
+
+/**
+ * Profiling data hints
+ */
+static const struct nugu_prof_hints _hints[NUGU_PROF_TYPE_MAX + 1] = {
+	/* sdk */
+	{ "Created", NUGU_PROF_TYPE_MAX },
+	{ "Plugin init", NUGU_PROF_TYPE_SDK_CREATED },
+	{ "Plugin done", NUGU_PROF_TYPE_SDK_PLUGIN_INIT_START },
+	{ "Initialized", NUGU_PROF_TYPE_SDK_CREATED },
+
+	/* network */
+	{ "Connect request", NUGU_PROF_TYPE_MAX },
+	{ "Registry request", NUGU_PROF_TYPE_NETWORK_CONNECT_REQUEST },
+	{ "Registry response", NUGU_PROF_TYPE_NETWORK_REGISTRY_REQUEST },
+	{ "Registry failed", NUGU_PROF_TYPE_NETWORK_REGISTRY_REQUEST },
+	{ "Server request", NUGU_PROF_TYPE_NETWORK_CONNECT_REQUEST },
+	{ "Server establish", NUGU_PROF_TYPE_NETWORK_SERVER_ESTABLISH_REQUEST },
+	{ "Server failed", NUGU_PROF_TYPE_NETWORK_SERVER_ESTABLISH_REQUEST },
+	{ "Connected", NUGU_PROF_TYPE_NETWORK_CONNECT_REQUEST },
+	{ "Directive closed", NUGU_PROF_TYPE_MAX },
+	{ "DNS failed", NUGU_PROF_TYPE_NETWORK_CONNECT_REQUEST },
+	{ "SSL failed", NUGU_PROF_TYPE_NETWORK_CONNECT_REQUEST },
+	{ "Internal network error", NUGU_PROF_TYPE_MAX },
+	{ "Invalid token", NUGU_PROF_TYPE_MAX },
+
+	/* /v2/ping */
+	{ "PING request", NUGU_PROF_TYPE_MAX },
+	{ "PING response", NUGU_PROF_TYPE_NETWORK_PING_REQUEST },
+	{ "PING failed", NUGU_PROF_TYPE_NETWORK_PING_REQUEST },
+
+	/* /v2/events event */
+	{ "Event request", NUGU_PROF_TYPE_MAX },
+	{ "Event response", NUGU_PROF_TYPE_NETWORK_EVENT_REQUEST },
+	{ "Event failed", NUGU_PROF_TYPE_NETWORK_EVENT_REQUEST },
+
+	/* /v2/events attachment */
+	{ "Attachment request", NUGU_PROF_TYPE_MAX },
+	{ "Attachment response", NUGU_PROF_TYPE_NETWORK_EVENT_REQUEST },
+	{ "Attachment failed", NUGU_PROF_TYPE_NETWORK_EVENT_REQUEST },
+
+	/* /v2/directives */
+	{ "Last push-data", NUGU_PROF_TYPE_MAX },
+
+	/* wakeup word */
+	{ "wakeup detected", NUGU_PROF_TYPE_MAX },
+
+	/* ASR */
+	{ "Listening started", NUGU_PROF_TYPE_WAKEUP_KEYWORD_DETECTED },
+	{ "Recognizing", NUGU_PROF_TYPE_ASR_LISTENING_STARTED },
+	{ "End detected", NUGU_PROF_TYPE_ASR_RECOGNIZING_STARTED },
+	{ "Timeout", NUGU_PROF_TYPE_ASR_LISTENING_STARTED },
+	{ "First attachment", NUGU_PROF_TYPE_ASR_RECOGNIZING_STARTED },
+	{ "Last attachment", NUGU_PROF_TYPE_ASR_FIRST_ATTACHMENT },
+	{ "ASR Result", NUGU_PROF_TYPE_ASR_RECOGNIZING_STARTED },
+
+	/* TTS */
+	{ "TTS started", NUGU_PROF_TYPE_ASR_RESULT },
+	{ "TTS first data", NUGU_PROF_TYPE_ASR_RESULT },
+	{ "TTS last data", NUGU_PROF_TYPE_TTS_FIRST_ATTACHMENT },
+	{ "TTS finished", NUGU_PROF_TYPE_ASR_RESULT },
+
+	/* Audio */
+	{ "Audio started", NUGU_PROF_TYPE_ASR_RESULT },
+	{ "Audio finished", NUGU_PROF_TYPE_AUDIO_STARTED },
+
+	/* end */
+	{ "END", NUGU_PROF_TYPE_MAX }
+};
+
+/**
+ * Profiling data store
+ */
+static struct nugu_prof_data _prof_data[NUGU_PROF_TYPE_MAX + 1];
+
+static NuguProfCallback _callback;
+static void *_callback_userdata;
+static pthread_mutex_t _lock;
+static gboolean _trace;
+
+static void _fill_timestr(char *dest_buf, size_t bufsize,
+			  const struct timespec *ts)
+{
+	struct tm tm_local;
+
+	memset(dest_buf, ' ', bufsize);
+	dest_buf[bufsize - 1] = '\0';
+
+	if (bufsize < BUFSIZE_TIMESTR)
+		return;
+
+	localtime_r(&(ts->tv_sec), &tm_local);
+
+	strftime(dest_buf, 15, "%m-%d %H:%M:%S", &tm_local);
+
+	snprintf(dest_buf + 14, bufsize - 14, ".%03d",
+		 (int)(ts->tv_nsec / 1000000));
+}
+
+EXPORT_API void nugu_prof_clear(void)
+{
+	pthread_mutex_lock(&_lock);
+	memset(_prof_data, 0, sizeof(_prof_data));
+	pthread_mutex_unlock(&_lock);
+}
+
+EXPORT_API void nugu_prof_enable_tracelog(void)
+{
+	pthread_mutex_lock(&_lock);
+	_trace = TRUE;
+	pthread_mutex_unlock(&_lock);
+}
+
+EXPORT_API void nugu_prof_disable_tracelog(void)
+{
+	pthread_mutex_lock(&_lock);
+	_trace = FALSE;
+	pthread_mutex_unlock(&_lock);
+}
+
+EXPORT_API void nugu_prof_set_callback(NuguProfCallback callback,
+				       void *userdata)
+{
+	pthread_mutex_lock(&_lock);
+	_callback = callback;
+	_callback_userdata = userdata;
+	pthread_mutex_unlock(&_lock);
+}
+
+/**
+ * Profiling callback is not time critical, so it is called in idle time.
+ */
+static gboolean _emit_in_idle(gpointer userdata)
+{
+	NuguProfCallback cb;
+	void *cb_userdata;
+	struct nugu_prof_data *data = userdata;
+
+	pthread_mutex_lock(&_lock);
+	cb = _callback;
+	cb_userdata = _callback_userdata;
+	pthread_mutex_unlock(&_lock);
+
+	if (_trace) {
+		char timestr[25];
+
+		_fill_timestr(timestr, sizeof(timestr), &data->timestamp);
+
+		nugu_log_print(NUGU_LOG_MODULE_PROFILING, NUGU_LOG_LEVEL_DEBUG,
+			       NULL, NULL, -1, "Profiling %d (%-20s) <%s>",
+			       data->type, _hints[data->type].text, timestr);
+
+		if (data->dialog_id[0] != '\0')
+			nugu_log_print(NUGU_LOG_MODULE_PROFILING,
+				       NUGU_LOG_LEVEL_DEBUG, NULL, NULL, -1,
+				       " - dialog-id: %s", data->dialog_id);
+		if (data->msg_id[0] != '\0')
+			nugu_log_print(NUGU_LOG_MODULE_PROFILING,
+				       NUGU_LOG_LEVEL_DEBUG, NULL, NULL, -1,
+				       " - message-id: %s", data->msg_id);
+		if (data->contents)
+			nugu_log_print(NUGU_LOG_MODULE_PROFILING,
+				       NUGU_LOG_LEVEL_DEBUG, NULL, NULL, -1,
+				       " - contents: %s", data->contents);
+	}
+
+	if (cb != NULL)
+		cb(data->type, data, cb_userdata);
+
+	if (data->contents)
+		free(data->contents);
+	free(data);
+
+	return FALSE;
+}
+
+static void _emit_callback(enum nugu_prof_type type, const char *contents)
+{
+	struct nugu_prof_data *data;
+
+	if (_callback == NULL && _trace == FALSE)
+		return;
+
+	data = malloc(sizeof(struct nugu_prof_data));
+	if (!data) {
+		nugu_error_nomem();
+		return;
+	}
+
+	memcpy(data, &_prof_data[type], sizeof(struct nugu_prof_data));
+
+	if (contents)
+		data->contents = strdup(contents);
+	else
+		data->contents = NULL;
+
+	g_idle_add(_emit_in_idle, data);
+}
+
+EXPORT_API int nugu_prof_mark_data(enum nugu_prof_type type,
+				   const char *dialog_id, const char *msg_id,
+				   const char *contents)
+{
+	struct nugu_prof_data *tmp;
+
+	g_return_val_if_fail(type < NUGU_PROF_TYPE_MAX, -1);
+
+	tmp = &_prof_data[type];
+
+	pthread_mutex_lock(&_lock);
+
+	memset(tmp, 0, sizeof(struct nugu_prof_data));
+	clock_gettime(CLOCK_REALTIME, &tmp->timestamp);
+	tmp->type = type;
+
+	if (dialog_id)
+		memcpy(tmp->dialog_id, dialog_id, NUGU_MAX_UUID_STRING_SIZE);
+	else
+		memset(tmp->dialog_id, 0, NUGU_MAX_UUID_STRING_SIZE);
+
+	if (msg_id)
+		memcpy(tmp->msg_id, msg_id, NUGU_MAX_UUID_STRING_SIZE);
+	else
+		memset(tmp->msg_id, 0, NUGU_MAX_UUID_STRING_SIZE);
+
+	if (_callback != NULL || _trace)
+		_emit_callback(type, contents);
+
+	pthread_mutex_unlock(&_lock);
+
+	return 0;
+}
+
+EXPORT_API int nugu_prof_mark(enum nugu_prof_type type)
+{
+	g_return_val_if_fail(type < NUGU_PROF_TYPE_MAX, -1);
+
+	pthread_mutex_lock(&_lock);
+
+	memset(&_prof_data[type], 0, sizeof(struct nugu_prof_data));
+	clock_gettime(CLOCK_REALTIME, &_prof_data[type].timestamp);
+	_prof_data[type].type = type;
+
+	if (_callback != NULL || _trace)
+		_emit_callback(type, NULL);
+
+	pthread_mutex_unlock(&_lock);
+
+	return 0;
+}
+
+EXPORT_API struct nugu_prof_data *
+nugu_prof_get_last_data(enum nugu_prof_type type)
+{
+	struct nugu_prof_data *tmp;
+
+	g_return_val_if_fail(type < NUGU_PROF_TYPE_MAX, NULL);
+
+	tmp = malloc(sizeof(struct nugu_prof_data));
+	if (!tmp) {
+		nugu_error_nomem();
+		return NULL;
+	}
+
+	pthread_mutex_lock(&_lock);
+	memcpy(tmp, &_prof_data[type], sizeof(struct nugu_prof_data));
+	pthread_mutex_unlock(&_lock);
+
+	return tmp;
+}
+
+EXPORT_API int nugu_prof_get_diff_msec_timespec(const struct timespec *ts1,
+						const struct timespec *ts2)
+{
+	int sec;
+	int nsec;
+
+	if ((ts2->tv_nsec - ts1->tv_nsec) < 0) {
+		sec = ts2->tv_sec - ts1->tv_sec - 1;
+		nsec = ts2->tv_nsec - ts1->tv_nsec + 1000000000L;
+	} else {
+		sec = ts2->tv_sec - ts1->tv_sec;
+		nsec = ts2->tv_nsec - ts1->tv_nsec;
+	}
+
+	return (nsec / 1000000) + (sec * 1000);
+}
+
+EXPORT_API int nugu_prof_get_diff_msec(const struct nugu_prof_data *prof1,
+				       const struct nugu_prof_data *prof2)
+{
+	if (prof1 == NULL || prof2 == NULL)
+		return 0;
+
+	/* profile item empty */
+	if (prof1->timestamp.tv_sec == 0 || prof2->timestamp.tv_sec == 0)
+		return 0;
+
+	return nugu_prof_get_diff_msec_timespec(&prof1->timestamp,
+						&prof2->timestamp);
+}
+
+EXPORT_API void nugu_prof_dump(enum nugu_prof_type from, enum nugu_prof_type to)
+{
+	enum nugu_prof_type cur;
+	enum nugu_prof_type rel;
+	const char *hint;
+	char timestr[255];
+	char relstr[22];
+	int diff_from;
+	int diff_rel;
+
+	nugu_log_print(NUGU_LOG_MODULE_PROFILING, NUGU_LOG_LEVEL_DEBUG, NULL,
+		       NULL, -1, "--------------------------");
+
+	nugu_log_print(NUGU_LOG_MODULE_PROFILING, NUGU_LOG_LEVEL_DEBUG, NULL,
+		       NULL, -1, "Profiling: %d(%s) ~ %d(%s)", from,
+		       _hints[from].text, to, _hints[to].text);
+
+	for (cur = from; cur <= to; cur++) {
+		const struct timespec *ts;
+
+		ts = &_prof_data[cur].timestamp;
+		if (ts->tv_sec == 0)
+			continue;
+
+		_fill_timestr(timestr, sizeof(timestr), ts);
+
+		diff_from = nugu_prof_get_diff_msec(&_prof_data[from],
+						    &_prof_data[cur]);
+
+		if (_hints[cur].text)
+			hint = _hints[cur].text;
+		else
+			hint = "";
+
+		rel = _hints[cur].relative_type;
+		if (rel != NUGU_PROF_TYPE_MAX) {
+			diff_rel = nugu_prof_get_diff_msec(&_prof_data[rel],
+							   &_prof_data[cur]);
+			snprintf(relstr, sizeof(relstr),
+				 "[%2d ~ %2d]: %5d msec", rel, cur, diff_rel);
+		} else {
+			memset(relstr, ' ', sizeof(relstr) - 1);
+		}
+
+		nugu_log_print(NUGU_LOG_MODULE_PROFILING, NUGU_LOG_LEVEL_DEBUG,
+			       NULL, NULL, -1,
+			       "[%2d] %20s: <%s> %5d msec %s %s %s", cur, hint,
+			       timestr, diff_from, relstr,
+			       _prof_data[cur].dialog_id,
+			       _prof_data[cur].msg_id);
+	}
+
+	nugu_log_print(NUGU_LOG_MODULE_PROFILING, NUGU_LOG_LEVEL_DEBUG, NULL,
+		       NULL, -1, "--------------------------");
+}

--- a/src/clientkit/nugu_client_impl.cc
+++ b/src/clientkit/nugu_client_impl.cc
@@ -21,6 +21,7 @@
 #include "base/nugu_equeue.h"
 #include "base/nugu_log.h"
 #include "base/nugu_plugin.h"
+#include "base/nugu_prof.h"
 #include "capability/system_interface.hh"
 
 #include "nugu_client_impl.hh"
@@ -32,6 +33,9 @@ using namespace NuguCapability;
 
 NuguClientImpl::NuguClientImpl()
 {
+    nugu_prof_clear();
+    nugu_prof_mark(NUGU_PROF_TYPE_SDK_CREATED);
+
     nugu_equeue_initialize();
 
     nugu_core_container = std::unique_ptr<NuguCoreContainer>(new NuguCoreContainer());
@@ -131,11 +135,14 @@ bool NuguClientImpl::initialize(void)
         return true;
     }
 
+    nugu_prof_mark(NUGU_PROF_TYPE_SDK_PLUGIN_INIT_START);
+
     if (nugu_plugin_load_directory(NUGU_PLUGIN_DIR) < 0) {
         nugu_error("Fail to load nugu_plugin");
     }
 
     nugu_plugin_initialize();
+    nugu_prof_mark(NUGU_PROF_TYPE_SDK_PLUGIN_INIT_DONE);
 
     nugu_core_container->createAudioRecorderManager();
 
@@ -150,6 +157,8 @@ bool NuguClientImpl::initialize(void)
         capability.second->initialize();
         nugu_dbg("'%s' capability initialized", cname.c_str());
     }
+
+    nugu_prof_mark(NUGU_PROF_TYPE_SDK_INIT_DONE);
 
     if (listener)
         listener->onInitialized(this);


### PR DESCRIPTION
The profiling module provides notification and performance measurement
for each condition.

When 'nugu_prof_mark()' or 'nugu_prof_mark_data()' is called, the
timestamp and additional data are stored in the internal cache, and
events can be received through callbacks.

Developers can fetch and analyze the profiled data at the moment they
want through a callback or 'nugu_prof_get_last_data()' API.

In addition, it is possible to simply output the profiling result of
a specific range through the 'nugu_prof_dump()' API.

e.g.

    --------------------------
    Profiling: 0(Created) ~ 38(END)
    [ 0]          Created: <date.msec>   0 msec
    [ 1]      Plugin init: <date.msec>  11 msec [ 0 ~  1]:  11 msec
    [ 2]      Plugin done: <date.msec> 114 msec [ 1 ~  2]: 102 msec
    [ 3]      Initialized: <date.msec> 120 msec [ 0 ~  3]: 120 msec
    --------------------------

Signed-off-by: Inho Oh <inho.oh@sk.com>