### PR TITLE
AudioPlayerAgent: Remove temporary code

### DIFF
--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -773,9 +773,7 @@ void AudioPlayerAgent::parsingPlay(const char* message)
     std::string dialog_id = nugu_directive_peek_dialog_id(getNuguDirective());
     std::string dname = nugu_directive_peek_name(getNuguDirective());
     // Different tokens mean different media play requests.
-    if (token != cur_token
-        /* Temporary add condition: Service(keyword news) is always same token on 2020/03/12 */
-        || has_attachment) {
+    if (token != cur_token) {
 
         if (pre_ref_dialog_id.size())
             setReferrerDialogRequestId(dname, pre_ref_dialog_id);

--- a/src/core/tts_player.cc
+++ b/src/core/tts_player.cc
@@ -253,6 +253,7 @@ bool TTSPlayer::setSource(const std::string& url)
 bool TTSPlayer::play()
 {
     nugu_dbg("request to play mediaplayer.attachment");
+    StopB4Start();
     return (nugu_pcm_start(d->player) >= 0);
 }
 
@@ -469,6 +470,16 @@ void TTSPlayer::clearContent()
 {
     d->position = d->duration = 0;
     d->seek_time = d->seek_size = 0;
+}
+
+void TTSPlayer::StopB4Start()
+{
+    // stop without reporting state changed
+    MediaPlayerState prev_state = state();
+
+    d->state = MediaPlayerState::STOPPED;
+    nugu_pcm_stop(d->player);
+    d->state = prev_state;
 }
 
 } // NuguCore

--- a/src/core/tts_player.hh
+++ b/src/core/tts_player.hh
@@ -70,6 +70,7 @@ public:
 
 private:
     void clearContent();
+    void StopB4Start();
 
     TTSPlayerPrivate* d;
 };


### PR DESCRIPTION
Integration of AudioPlayerAgent's attachment media is complete.
Therefore, it removes the temporary code.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>