### PR TITLE
Update to handle Call focus

### DIFF
--- a/include/base/nugu_focus.h
+++ b/include/base/nugu_focus.h
@@ -38,6 +38,7 @@ extern "C" {
  * @brief Predefined focus types by priority
  */
 enum nugu_focus_type {
+	NUGU_FOCUS_TYPE_CALL, /**< Call */
 	NUGU_FOCUS_TYPE_ALERT, /**< Alerts */
 	NUGU_FOCUS_TYPE_ASR, /**< ASR */
 	NUGU_FOCUS_TYPE_TTS, /**< TTS */

--- a/include/clientkit/playsync_manager_interface.hh
+++ b/include/clientkit/playsync_manager_interface.hh
@@ -34,6 +34,16 @@ namespace NuguClientKit {
  */
 
 /**
+ * @brief Playsync Layer Type
+ */
+enum class PlaysyncLayer {
+    Info, /**< Info Layer */
+    Media, /**< Media Layer */
+    Alert, /**< Alert Layer */
+    Call /**< Call Layer */
+};
+
+/**
  * @brief PlayerSyncManagerListener interface
  * @see IPlaySyncManager
  */
@@ -119,14 +129,23 @@ public:
 
     /**
      * @brief Get all play service id list which exist in context stack.
+     * @return play service id list
      */
     virtual std::vector<std::string> getAllPlayStackItems() = 0;
 
     /**
      * @brief Get play service id of specific CapabilityAgent.
      * @param[in] cap_name CapabilityAgent name
+     * @return play service id about cap_name
      */
     virtual std::string getPlayStackItem(const std::string& cap_name) = 0;
+
+    /**
+     * @brief Get PlaysyncLayer type about play service id.
+     * @param[in] ps_id play service id
+     * @return PlaysyncLayer type
+     */
+    virtual PlaysyncLayer getLayerType(const std::string& ps_id) = 0;
 
     /**
      * @brief Set whether current ASR is expect speech situation.

--- a/src/base/nugu_focus.c
+++ b/src/base/nugu_focus.c
@@ -22,7 +22,7 @@
 #include "base/nugu_log.h"
 #include "base/nugu_focus.h"
 
-static const char *const _type_str[] = { "ALERT",      "ASR",   "TTS",
+static const char *const _type_str[] = { "CALL",       "ALERT", "ASR",   "TTS",
 					 "ASR_EXPECT", "MEDIA", "CUSTOM" };
 
 struct _nugu_focus {

--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -159,9 +159,13 @@ NuguFocusResult TTSAgent::onUnfocus(void* event, NuguUnFocusMode mode)
 
 NuguFocusStealResult TTSAgent::onStealRequest(void* event, NuguFocusType target_type)
 {
-    if (target_type <= NUGU_FOCUS_TYPE_TTS)
+    if (target_type <= NUGU_FOCUS_TYPE_TTS) {
+        // When the tts is about call, it just reject for finishing current tts speak.
+        if (target_type == NUGU_FOCUS_TYPE_CALL && playsync_manager->getLayerType(playstackctl_ps_id) == PlaysyncLayer::Call)
+            return NUGU_FOCUS_STEAL_REJECT;
+
         return NUGU_FOCUS_STEAL_ALLOW;
-    else
+    } else
         return NUGU_FOCUS_STEAL_REJECT;
 }
 
@@ -191,7 +195,7 @@ std::string TTSAgent::requestTTS(const std::string& text, const std::string& pla
     token = uuid;
     free(uuid);
 
-    if(referrer_id.size())
+    if (referrer_id.size())
         setReferrerDialogRequestId("TTSAgent.requestTTS", referrer_id);
 
     std::string id = sendEventSpeechPlay(token, text, play_service_id);

--- a/src/core/playsync_manager.cc
+++ b/src/core/playsync_manager.cc
@@ -179,7 +179,7 @@ void PlaySyncManager::removeContext(const std::string& ps_id, const std::string&
     // reset or stop pending long timer if exist
     if (long_timer && long_timer->hasPending() && !is_expect_speech) {
         try {
-            if (layer_map.at(ps_id) == Layer::Media)
+            if (layer_map.at(ps_id) == PlaysyncLayer::Media)
                 long_timer->stop();
             else
                 long_timer->start();
@@ -252,6 +252,15 @@ std::string PlaySyncManager::getPlayStackItem(const std::string& cap_name)
     }
 
     return "";
+}
+
+PlaysyncLayer PlaySyncManager::getLayerType(const std::string& ps_id)
+{
+    try {
+        return layer_map.at(ps_id);
+    } catch (std::out_of_range& exception) {
+        return PlaysyncLayer::Info; // It return Info layer defaults
+    }
 }
 
 void PlaySyncManager::addStackElement(const std::string& ps_id, const std::string& cap_name)
@@ -363,14 +372,13 @@ void PlaySyncManager::onASRError()
 
 void PlaySyncManager::setDirectiveGroups(const std::string& groups)
 {
-    if (groups.empty()) {
-        layer = Layer::Info;
-        return;
-    }
-
     if (groups.find("AudioPlayer") != std::string::npos)
-        layer = Layer::Media;
+        layer = PlaysyncLayer::Media;
+    else if (groups.find("NuguCall") != std::string::npos)
+        layer = PlaysyncLayer::Call;
+    else if (groups.find("Alerts") != std::string::npos)
+        layer = PlaysyncLayer::Alert;
     else
-        layer = Layer::Info;
+        layer = PlaysyncLayer::Info;
 }
 } // NuguCore

--- a/src/core/playsync_manager.hh
+++ b/src/core/playsync_manager.hh
@@ -39,6 +39,7 @@ public:
     void clearPendingContext(const std::string& ps_id) override;
     std::vector<std::string> getAllPlayStackItems() override;
     std::string getPlayStackItem(const std::string& cap_name) override;
+    PlaysyncLayer getLayerType(const std::string& ps_id) override;
 
     void setExpectSpeech(bool expect_speech) override;
     void holdContext() override;
@@ -50,13 +51,6 @@ public:
     using ContextMap = std::map<std::string, std::vector<std::string>>;
 
 private:
-    enum class Layer {
-        Info,
-        Media,
-        Alert,
-        Call
-    };
-
     class LongTimer final : public NUGUTimer {
     public:
         explicit LongTimer(int interval, int repeat = 0);
@@ -84,7 +78,7 @@ private:
     std::vector<std::string> getKeyOfMap(const std::map<T, V>& map);
 
     using RendererMap = std::map<std::string, DisplayRenderer>;
-    using LayerMap = std::map<std::string, Layer>;
+    using LayerMap = std::map<std::string, PlaysyncLayer>;
 
     ContextMap context_map;
     std::vector<std::string> context_stack;
@@ -94,7 +88,7 @@ private:
     NUGUTimer* timer = nullptr;
     LongTimer* long_timer = nullptr;
     bool is_expect_speech = false;
-    Layer layer = Layer::Info;
+    PlaysyncLayer layer = PlaysyncLayer::Info;
 };
 } // NuguCore
 


### PR DESCRIPTION
It add NUGU_FOCUS_TYPE_CALL type to nugu_focus for handling
focus about NuguCall Interface.

It update PlaySyncManager which is possible to retrieve
PlaysyncLayer Type about play service id.
 - PlaysyncLayer Type : Info, Media, Alert, Call.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>