### PR TITLE
Apply changed context maintenance policy

### DIFF
--- a/include/clientkit/playsync_manager_interface.hh
+++ b/include/clientkit/playsync_manager_interface.hh
@@ -165,8 +165,9 @@ public:
 
     /**
      * @brief Notify error occurred when ASR.
+     * @param[in] expect_speech whether expect speech situation or not
      */
-    virtual void onASRError() = 0;
+    virtual void onASRError(bool expect_speech) = 0;
 };
 
 /**

--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -657,11 +657,12 @@ void ASRAgent::releaseASRFocus(bool is_cancel, ASRError error, bool release_focu
             asr_listener->onError(error, getRecognizeDialogId());
     }
 
+    playsync_manager->onASRError(isExpectSpeechState());
+
     if (release_focus) {
         nugu_dbg("request to release focus");
         capa_helper->releaseFocus("asr");
     }
-    playsync_manager->onASRError();
 }
 
 bool ASRAgent::isExpectSpeechState()

--- a/src/core/playsync_manager.cc
+++ b/src/core/playsync_manager.cc
@@ -115,7 +115,7 @@ void PlaySyncManager::addContext(const std::string& ps_id, const std::string& ca
 void PlaySyncManager::addContext(const std::string& ps_id, const std::string& cap_name, DisplayRenderer&& renderer)
 {
     if (ps_id.empty()) {
-        nugu_error("Invalid PlayServiceId.");
+        nugu_warn("Invalid PlayServiceId.");
         return;
     }
 
@@ -172,7 +172,7 @@ void PlaySyncManager::removeContextAction(const std::string& ps_id, bool immedia
 void PlaySyncManager::removeContext(const std::string& ps_id, const std::string& cap_name, bool immediately)
 {
     if (ps_id.empty()) {
-        nugu_error("Invalid PlayServiceId.");
+        nugu_warn("Invalid PlayServiceId.");
         return;
     }
 
@@ -194,7 +194,12 @@ void PlaySyncManager::removeContext(const std::string& ps_id, const std::string&
 void PlaySyncManager::removeContextInnerly(const std::string& ps_id, const std::string& cap_name, bool immediately)
 {
     if (ps_id.empty()) {
-        nugu_error("Invalid PlayServiceId.");
+        nugu_warn("Invalid PlayServiceId.");
+        return;
+    }
+
+    if (context_map.find(ps_id) == context_map.end()) {
+        nugu_warn("There are not exist matched context.");
         return;
     }
 
@@ -360,12 +365,12 @@ void PlaySyncManager::clearContextHold()
         timer->start();
 }
 
-void PlaySyncManager::onASRError()
+void PlaySyncManager::onASRError(bool expect_speech)
 {
     is_expect_speech = false;
 
     if (!context_stack.empty())
-        removeContextInnerly(context_stack.back(), "TTS", false);
+        removeContextInnerly(context_stack.back(), "TTS", expect_speech);
 
     // reset pending long timer if exists
     if (long_timer && long_timer->hasPending())

--- a/src/core/playsync_manager.hh
+++ b/src/core/playsync_manager.hh
@@ -44,7 +44,7 @@ public:
     void setExpectSpeech(bool expect_speech) override;
     void holdContext() override;
     void clearContextHold() override;
-    void onASRError() override;
+    void onASRError(bool expect_speech) override;
 
     void setDirectiveGroups(const std::string& groups);
 


### PR DESCRIPTION
It change context hold policy in DM mode which to maintain
during DM listening time.

It remove context immediately after ending call,
even if the finish TTS has exist.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>