### PR TITLE
profiling: fix TTS profiling point

### DIFF
--- a/examples/standalone/capability/tts_listener.cc
+++ b/examples/standalone/capability/tts_listener.cc
@@ -16,6 +16,8 @@
 
 #include <iostream>
 
+#include <base/nugu_prof.h>
+
 #include "tts_listener.hh"
 
 void TTSListener::onTTSState(TTSState state, const std::string& dialog_id)
@@ -29,6 +31,7 @@ void TTSListener::onTTSState(TTSState state, const std::string& dialog_id)
 
     case TTSState::TTS_SPEECH_FINISH:
         std::cout << "PLAYING FINISHED\n";
+        nugu_prof_dump(NUGU_PROF_TYPE_TTS_SPEAK_DIRECTIVE, NUGU_PROF_TYPE_TTS_FINISHED);
         break;
     }
 }

--- a/include/base/nugu_prof.h
+++ b/include/base/nugu_prof.h
@@ -150,6 +150,9 @@ enum nugu_prof_type {
 	NUGU_PROF_TYPE_ASR_RESULT,
 	/**< ASR result received */
 
+	NUGU_PROF_TYPE_TTS_SPEAK_DIRECTIVE,
+	/**< TTS.Speak directive received */
+
 	NUGU_PROF_TYPE_TTS_STARTED,
 	/**< TTS started */
 

--- a/src/base/nugu_prof.c
+++ b/src/base/nugu_prof.c
@@ -89,10 +89,11 @@ static const struct nugu_prof_hints _hints[NUGU_PROF_TYPE_MAX + 1] = {
 	{ "ASR Result", NUGU_PROF_TYPE_ASR_RECOGNIZE },
 
 	/* TTS */
-	{ "TTS started", NUGU_PROF_TYPE_ASR_RESULT },
-	{ "TTS first data", NUGU_PROF_TYPE_ASR_RESULT },
+	{ "TTS Speak directive", NUGU_PROF_TYPE_MAX },
+	{ "TTS started", NUGU_PROF_TYPE_TTS_SPEAK_DIRECTIVE },
+	{ "TTS first data", NUGU_PROF_TYPE_TTS_SPEAK_DIRECTIVE },
 	{ "TTS last data", NUGU_PROF_TYPE_TTS_FIRST_ATTACHMENT },
-	{ "TTS finished", NUGU_PROF_TYPE_ASR_RESULT },
+	{ "TTS finished", NUGU_PROF_TYPE_TTS_SPEAK_DIRECTIVE },
 
 	/* Audio */
 	{ "Audio started", NUGU_PROF_TYPE_ASR_RESULT },

--- a/src/capability/tts_agent.hh
+++ b/src/capability/tts_agent.hh
@@ -54,6 +54,7 @@ public:
 
 private:
     void sendEventCommon(const std::string& ename, const std::string& token, EventResultCallback cb = nullptr);
+    void sendEventCommon(CapabilityEvent *event, const std::string& token, EventResultCallback cb = nullptr);
     // parsing directive
     void parsingSpeak(const char* message);
     void parsingStop(const char* message);


### PR DESCRIPTION
Fix the TTS start/finish profiling point to the point at which the event
is sent. And add the point that received the TTS speak directive.

Signed-off-by: Inho Oh <inho.oh@sk.com>