### PR TITLE
core: fix media player default volume setting

### DIFF
--- a/src/core/media_player.cc
+++ b/src/core/media_player.cc
@@ -177,6 +177,7 @@ MediaPlayer::MediaPlayer(int volume)
     };
     d->timeout = g_timeout_add(POSITION_POLLING_TIMEOUT_500MS, tfunc, this);
     d->mp_map[this] = d;
+    setVolume(volume);
 }
 
 MediaPlayer::~MediaPlayer()


### PR DESCRIPTION
There is a mismatch in the player's volume setting.

1. Default volume of MediaPlayer is NUGU_SET_VOLUME_MAX(100).

media_player.hh line 32:

    explicit MediaPlayer(int volume = NUGU_SET_VOLUME_MAX);

2. Default volume of nugu_player is NUGU_SET_VOLUME_DEFAULT(50).

nugu_player.c line 177:

    player->volume = NUGU_SET_VOLUME_DEFAULT;

As a result, unlike the intention, the volume is always set to
NUGU_SET_VOLUME_DEFAULT(50).

This patch add the setVolume() API call to correct above mismatch
issue.

Signed-off-by: Inho Oh <inho.oh@sk.com>