### PR TITLE
base: fix network profiling

### DIFF
--- a/include/base/nugu_prof.h
+++ b/include/base/nugu_prof.h
@@ -82,10 +82,13 @@ enum nugu_prof_type {
 	/**< HTTP/2 /v2/directives stream closed by server */
 
 	NUGU_PROF_TYPE_NETWORK_DNS_FAILED,
-	/**< DNS Resolving failed */
+	/**< Network DNS Resolving failed */
 
 	NUGU_PROF_TYPE_NETWORK_SSL_FAILED,
-	/**< SSL failed */
+	/**< Network SSL failed */
+
+	NUGU_PROF_TYPE_NETWORK_TIMEOUT,
+	/**< Network timeout */
 
 	NUGU_PROF_TYPE_NETWORK_INTERNAL_ERROR,
 	/**< Network internal error */
@@ -114,11 +117,11 @@ enum nugu_prof_type {
 	NUGU_PROF_TYPE_NETWORK_EVENT_ATTACHMENT_REQUEST,
 	/**< HTTP/2 Request for POST /v2/events attachment */
 
-	NUGU_PROF_TYPE_NETWORK_EVENT_ATTACHMENT_RESPONSE,
-	/**< HTTP/2 Response for POST /v2/events attachment */
+	NUGU_PROF_TYPE_NETWORK_EVENT_DIRECTIVE_RESPONSE,
+	/**< HTTP/2 Directive response for POST /v2/events */
 
-	NUGU_PROF_TYPE_NETWORK_EVENT_ATTACHMENT_FAILED,
-	/**< HTTP/2 Failed for POST /v2/events attachment */
+	NUGU_PROF_TYPE_NETWORK_EVENT_DIRECTIVE_TIMEOUT,
+	/**< HTTP/2 Directive timeout for POST /v2/events */
 
 	NUGU_PROF_TYPE_LAST_SERVER_INITIATIVE_DATA,
 	/**< Last received data from /v2/directives */

--- a/src/base/network/dg_server.c
+++ b/src/base/network/dg_server.c
@@ -83,19 +83,19 @@ static int _send_v2_events(DGServer *server, NuguEvent *nev,
 {
 	V2Events *e;
 
-	e = v2_events_new(server->host, server->net, is_sync);
+	e = v2_events_new(server->host, server->net, is_sync,
+			  nugu_event_get_type(nev));
 	if (!e)
 		return -1;
 
 	v2_events_set_info(e, nugu_event_peek_msg_id(nev),
 			   nugu_event_peek_dialog_id(nev));
 
+	v2_events_send_json(e, payload, strlen(payload));
+
 	if (nugu_event_get_type(nev) == NUGU_EVENT_TYPE_DEFAULT) {
-		v2_events_send_single_json(e, payload, strlen(payload));
 		v2_events_free(e);
 		return 0;
-	} else {
-		v2_events_send_json(e, payload, strlen(payload));
 	}
 
 	if (server->pending_events == NULL) {

--- a/src/base/network/dg_types.h
+++ b/src/base/network/dg_types.h
@@ -38,6 +38,7 @@ struct equeue_data_attachment {
 	size_t length;
 	char *parent_msg_id;
 	char *media_type;
+	int seq;
 	int is_end;
 };
 

--- a/src/base/network/http2/directives_parser.h
+++ b/src/base/network/http2/directives_parser.h
@@ -23,9 +23,14 @@
 extern "C" {
 #endif
 
+enum dir_parser_type {
+	DIR_PARSER_TYPE_SERVER_INITIATIVE,
+	DIR_PARSER_TYPE_EVENT_RESPONSE
+};
+
 typedef struct _dir_parser DirParser;
 
-DirParser *dir_parser_new(void);
+DirParser *dir_parser_new(enum dir_parser_type type);
 void dir_parser_free(DirParser *dp);
 
 int dir_parser_add_header(DirParser *dp, const char *buffer, size_t buffer_len);

--- a/src/base/network/http2/http2_request.c
+++ b/src/base/network/http2/http2_request.c
@@ -637,9 +637,11 @@ void http2_request_emit_finished(HTTP2Request *req)
 	case HTTP2_RESULT_SSL_FAIL:
 		nugu_prof_mark(NUGU_PROF_TYPE_NETWORK_SSL_FAILED);
 		break;
+	case HTTP2_RESULT_TIMEOUT:
+		nugu_prof_mark(NUGU_PROF_TYPE_NETWORK_TIMEOUT);
+		break;
 	case HTTP2_RESULT_HTTP_FAIL:
 	case HTTP2_RESULT_HTTP2_FAIL:
-	case HTTP2_RESULT_TIMEOUT:
 	case HTTP2_RESULT_UNKNOWN:
 		nugu_prof_mark(NUGU_PROF_TYPE_NETWORK_INTERNAL_ERROR);
 		break;

--- a/src/base/network/http2/v1_directives.c
+++ b/src/base/network/http2/v1_directives.c
@@ -40,8 +40,6 @@ struct _v1_directives {
 static size_t _on_body(HTTP2Request *req, char *buffer, size_t size,
 		       size_t nitems, void *userdata)
 {
-	nugu_prof_mark(NUGU_PROF_TYPE_LAST_SERVER_INITIATIVE_DATA);
-
 	dir_parser_parse(userdata, buffer, size * nitems);
 
 	return size * nitems;
@@ -154,7 +152,7 @@ int v1_directives_establish(V1Directives *dir, HTTP2Network *net)
 	g_return_val_if_fail(dir != NULL, -1);
 	g_return_val_if_fail(net != NULL, -1);
 
-	parser = dir_parser_new();
+	parser = dir_parser_new(DIR_PARSER_TYPE_SERVER_INITIATIVE);
 	if (!parser) {
 		nugu_error_nomem();
 		return -1;

--- a/src/base/network/http2/v2_events.h
+++ b/src/base/network/http2/v2_events.h
@@ -25,14 +25,12 @@ extern "C" {
 
 typedef struct _v2_events V2Events;
 
-V2Events *v2_events_new(const char *host, HTTP2Network *net, int is_sync);
+V2Events *v2_events_new(const char *host, HTTP2Network *net, int is_sync,
+			enum nugu_event_type type);
 void v2_events_free(V2Events *event);
 
 int v2_events_set_info(V2Events *event, const char *msg_id,
 		       const char *dialog_id);
-
-int v2_events_send_single_json(V2Events *event, const char *data,
-			       size_t length);
 
 int v2_events_send_json(V2Events *event, const char *data, size_t length);
 int v2_events_send_binary(V2Events *event, const char *msgid, int seq,

--- a/src/base/nugu_network_manager.c
+++ b/src/base/nugu_network_manager.c
@@ -127,7 +127,7 @@ static void on_attachment(enum nugu_equeue_type type, void *data,
 	if (!ndir)
 		return;
 
-	if (nugu_directive_get_data_size(ndir) == 0)
+	if (item->seq == 0)
 		nugu_prof_mark_data(NUGU_PROF_TYPE_TTS_FIRST_ATTACHMENT,
 				    nugu_directive_peek_dialog_id(ndir),
 				    nugu_directive_peek_msg_id(ndir), NULL);

--- a/src/base/nugu_prof.c
+++ b/src/base/nugu_prof.c
@@ -54,6 +54,7 @@ static const struct nugu_prof_hints _hints[NUGU_PROF_TYPE_MAX + 1] = {
 	{ "Directive closed", NUGU_PROF_TYPE_MAX },
 	{ "DNS failed", NUGU_PROF_TYPE_NETWORK_CONNECT_REQUEST },
 	{ "SSL failed", NUGU_PROF_TYPE_NETWORK_CONNECT_REQUEST },
+	{ "Network timeout", NUGU_PROF_TYPE_MAX },
 	{ "Internal net-error", NUGU_PROF_TYPE_MAX },
 	{ "Invalid token", NUGU_PROF_TYPE_MAX },
 
@@ -69,8 +70,10 @@ static const struct nugu_prof_hints _hints[NUGU_PROF_TYPE_MAX + 1] = {
 
 	/* /v2/events attachment */
 	{ "Attachment request", NUGU_PROF_TYPE_MAX },
-	{ "Attachment response", NUGU_PROF_TYPE_NETWORK_EVENT_REQUEST },
-	{ "Attachment failed", NUGU_PROF_TYPE_NETWORK_EVENT_REQUEST },
+
+	/* /v2/events directive */
+	{ "Directive response", NUGU_PROF_TYPE_NETWORK_EVENT_REQUEST },
+	{ "Directive timeout", NUGU_PROF_TYPE_NETWORK_EVENT_REQUEST },
 
 	/* /v2/directives */
 	{ "Last push-data", NUGU_PROF_TYPE_MAX },


### PR DESCRIPTION
Add directive profiling for both event-response and server-initiative
points. And also add timeout for response directive data.

Signed-off-by: Inho Oh <inho.oh@sk.com>