### PR TITLE
Change use to smart pointer

### DIFF
--- a/examples/standalone/capability_collection.cc
+++ b/examples/standalone/capability_collection.cc
@@ -85,14 +85,10 @@ void CapabilityCollection::composeCapabilityFactory()
             speaker_handler = makeCapability<SpeakerAgent, ISpeakerHandler>(speaker_listener.get());
 
             // compose SpeakerInfo
-            SpeakerInfo nugu_speaker = makeSpeakerInfo(SpeakerType::NUGU, true);
-            SpeakerInfo call_speaker = makeSpeakerInfo(SpeakerType::CALL);
-            SpeakerInfo alarm_speaker = makeSpeakerInfo(SpeakerType::ALARM);
-
-            std::map<SpeakerType, SpeakerInfo*> speakers = {
-                { SpeakerType::NUGU, &nugu_speaker },
-                { SpeakerType::CALL, &call_speaker },
-                { SpeakerType::ALARM, &alarm_speaker },
+            std::map<SpeakerType, SpeakerInfo> speakers {
+                { SpeakerType::NUGU, makeSpeakerInfo(SpeakerType::NUGU, true) },
+                { SpeakerType::CALL, makeSpeakerInfo(SpeakerType::CALL) },
+                { SpeakerType::ALARM, makeSpeakerInfo(SpeakerType::ALARM) },
             };
 
             speaker_handler->setSpeakerInfo(speakers);

--- a/include/capability/speaker_interface.hh
+++ b/include/capability/speaker_interface.hh
@@ -105,7 +105,7 @@ public:
      * @brief Set speaker information in SDK to be controlled by application.
      * @param[in] info speaker's information map
      */
-    virtual void setSpeakerInfo(std::map<SpeakerType, SpeakerInfo*> info) = 0;
+    virtual void setSpeakerInfo(const std::map<SpeakerType, SpeakerInfo>& info) = 0;
     /**
      * @brief Inform volume changed by application to the SDK
      * @param[in] type speaker type

--- a/src/capability/speaker_agent.hh
+++ b/src/capability/speaker_agent.hh
@@ -17,8 +17,8 @@
 #ifndef __NUGU_SPEAKER_AGENT_H__
 #define __NUGU_SPEAKER_AGENT_H__
 
-#include "clientkit/capability.hh"
 #include "capability/speaker_interface.hh"
+#include "clientkit/capability.hh"
 
 namespace NuguCapability {
 
@@ -34,7 +34,7 @@ public:
     void updateInfoForContext(Json::Value& ctx) override;
     void setCapabilityListener(ICapabilityListener* clistener) override;
 
-    void setSpeakerInfo(std::map<SpeakerType, SpeakerInfo*> info) override;
+    void setSpeakerInfo(const std::map<SpeakerType, SpeakerInfo>& info) override;
 
     void informVolumeChanged(SpeakerType type, int volume) override;
     void informMuteChanged(SpeakerType type, bool mute) override;
@@ -55,9 +55,9 @@ private:
     void updateSpeakerVolume(SpeakerType type, int volume);
     void updateSpeakerMute(SpeakerType type, bool mute);
     bool getSpeakerType(const std::string& name, SpeakerType& type);
-    std::string getSpeakerName(SpeakerType& type);
+    std::string getSpeakerName(const SpeakerType& type);
 
-    std::map<SpeakerType, SpeakerInfo*> speakers;
+    std::map<SpeakerType, std::unique_ptr<SpeakerInfo>> speakers;
     ISpeakerListener* speaker_listener;
 };
 

--- a/src/core/playsync_manager.cc
+++ b/src/core/playsync_manager.cc
@@ -84,23 +84,13 @@ PlaySyncManager::PlaySyncManager()
         { "MID", HOLD_TIME_MID },
         { "LONG", HOLD_TIME_LONG },
         { "LONGEST", HOLD_TIME_LONGEST } })
+    , timer(std::unique_ptr<NUGUTimer>(new NUGUTimer(DEFAULT_HOLD_TIME * NUGU_TIMER_UNIT_SEC, 1)))
+    , long_timer(std::unique_ptr<LongTimer>(new LongTimer(HOLD_TIME_LONGEST * NUGU_TIMER_UNIT_SEC, 1)))
 {
-    timer = new NUGUTimer(DEFAULT_HOLD_TIME * NUGU_TIMER_UNIT_SEC, 1);
-    long_timer = new LongTimer(HOLD_TIME_LONGEST * NUGU_TIMER_UNIT_SEC, 1);
 }
 
 PlaySyncManager::~PlaySyncManager()
 {
-    if (timer) {
-        delete timer;
-        timer = nullptr;
-    }
-
-    if (long_timer) {
-        delete long_timer;
-        long_timer = nullptr;
-    }
-
     renderer_map.clear();
     context_map.clear();
     context_stack.clear();

--- a/src/core/playsync_manager.hh
+++ b/src/core/playsync_manager.hh
@@ -19,6 +19,7 @@
 
 #include <functional>
 #include <map>
+#include <memory>
 
 #include "clientkit/playsync_manager_interface.hh"
 #include "nugu_timer.hh"
@@ -85,8 +86,9 @@ private:
     RendererMap renderer_map;
     LayerMap layer_map;
 
-    NUGUTimer* timer = nullptr;
-    LongTimer* long_timer = nullptr;
+    std::unique_ptr<NUGUTimer> timer = nullptr;
+    std::unique_ptr<LongTimer> long_timer = nullptr;
+
     bool is_expect_speech = false;
     PlaysyncLayer layer = PlaysyncLayer::Info;
 };


### PR DESCRIPTION
It change to use unique pointer about managing SpeakerType
and apply const reference parameters at methods
which are using map of SpeakerType.

Also, it work in PlaysyncManager too.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>