### PR TITLE
focus: add MEDIA_LOCK focus

### DIFF
--- a/include/base/nugu_focus.h
+++ b/include/base/nugu_focus.h
@@ -43,6 +43,7 @@ enum nugu_focus_type {
 	NUGU_FOCUS_TYPE_ASR, /**< ASR */
 	NUGU_FOCUS_TYPE_TTS, /**< TTS */
 	NUGU_FOCUS_TYPE_ASR_EXPECT, /**< ASR Expect speech */
+	NUGU_FOCUS_TYPE_MEDIA_LOCK, /**< Media lock control */
 	NUGU_FOCUS_TYPE_MEDIA, /**< Media player */
 	NUGU_FOCUS_TYPE_CUSTOM /**< Custom type */
 };

--- a/src/base/nugu_focus.c
+++ b/src/base/nugu_focus.c
@@ -22,8 +22,11 @@
 #include "base/nugu_log.h"
 #include "base/nugu_focus.h"
 
-static const char *const _type_str[] = { "CALL",       "ALERT", "ASR",   "TTS",
-					 "ASR_EXPECT", "MEDIA", "CUSTOM" };
+static const char *const _type_str[] = {
+	/* focus type string */
+	"CALL",	      "ALERT",	    "ASR",   "TTS",
+	"ASR_EXPECT", "MEDIA_LOCK", "MEDIA", "CUSTOM"
+};
 
 struct _nugu_focus {
 	char *name;


### PR DESCRIPTION
Add MEDIA_LOCK focus to enable media control manually in the
application.

The application can control the playback of the current media
through get or release for MEDIA_LOCK focus.

Signed-off-by: Inho Oh <inho.oh@sk.com>