### PR TITLE
network: add directive parser callback

### DIFF
--- a/src/base/network/http2/directives_parser.h
+++ b/src/base/network/http2/directives_parser.h
@@ -18,6 +18,8 @@
 #define __HTTP2_DIRECTIVES_PARSER_H__
 
 #include "http2/http2_request.h"
+#include "base/nugu_directive.h"
+#include "base/nugu_buffer.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,12 +32,30 @@ enum dir_parser_type {
 
 typedef struct _dir_parser DirParser;
 
+typedef void (*DirParserDirectiveCallback)(DirParser *dp, NuguDirective *dir,
+					   void *userdata);
+typedef void (*DirParserJsonCallback)(DirParser *dp, const char *json,
+					  void *userdata);
+typedef void (*DirParserEndCallback)(DirParser *dp, void *userdata);
+
 DirParser *dir_parser_new(enum dir_parser_type type);
 void dir_parser_free(DirParser *dp);
 
 int dir_parser_add_header(DirParser *dp, const char *buffer, size_t buffer_len);
 int dir_parser_parse(DirParser *dp, const char *buffer, size_t buffer_len);
 int dir_parser_set_debug_message(DirParser *dp, const char *msg);
+
+int dir_parser_set_directive_callback(DirParser *dp,
+				      DirParserDirectiveCallback cb,
+				      void *userdata);
+int dir_parser_set_json_callback(DirParser *dp,
+				     DirParserJsonCallback cb,
+				     void *userdata);
+int dir_parser_set_end_callback(DirParser *dp, DirParserEndCallback cb,
+				void *userdata);
+
+int dir_parser_set_json_buffer(DirParser *dp, NuguBuffer *buf);
+NuguBuffer *dir_parser_get_json_buffer(DirParser *dp);
 
 #ifdef __cplusplus
 }

--- a/src/base/network/http2/multipart_parser.h
+++ b/src/base/network/http2/multipart_parser.h
@@ -25,6 +25,7 @@ typedef struct _multipart_parser MultipartParser;
 
 typedef void (*ParserCallback)(MultipartParser *parser, const char *data,
 			       size_t length, void *userdata);
+typedef void (*ParserEndCallback)(MultipartParser *parser, void *userdata);
 
 MultipartParser *multipart_parser_new();
 void multipart_parser_free(MultipartParser *parser);
@@ -33,7 +34,8 @@ void multipart_parser_set_boundary(MultipartParser *parser, const char *src,
 				   size_t length);
 int multipart_parser_parse(MultipartParser *parser, const char *src,
 			   size_t length, ParserCallback onFoundHeader,
-			   ParserCallback onFoundBody, void *userdata);
+			   ParserCallback onFoundBody,
+			   ParserEndCallback onEndBoundary, void *userdata);
 void multipart_parser_reset(MultipartParser *parser);
 
 void multipart_parser_set_data(MultipartParser *parser, void *data);


### PR DESCRIPTION
add directive and multipart end-boundary(`--{boundary}--`) detect
callback to multipart parser.

Signed-off-by: Inho Oh <inho.oh@sk.com>