### PR TITLE
clientkit: add loadPlugins() API

### DIFF
--- a/examples/standalone/nugu_sample.cc
+++ b/examples/standalone/nugu_sample.cc
@@ -153,10 +153,15 @@ int main(int argc, char** argv)
 
     nugu_client = make_unique<NuguClient>();
     capa_collection = make_unique<CapabilityCollection>();
-    auto network_manager_listener(make_unique<NetworkManagerListener>());
 
     registerCapabilities();
 
+    if (!nugu_client->initialize()) {
+        msg_error("< It failed to initialize NUGU SDK. Please Check authorization.");
+        return EXIT_FAILURE;
+    }
+
+    auto network_manager_listener(make_unique<NetworkManagerListener>());
     auto network_manager(nugu_client->getNetworkManager());
     network_manager->addListener(network_manager_listener.get());
     network_manager->setToken(getenv("NUGU_TOKEN"));
@@ -164,11 +169,6 @@ int main(int argc, char** argv)
 
     if (!network_manager->connect()) {
         msg_error("< Cannot connect to NUGU Platform.");
-        return EXIT_FAILURE;
-    }
-
-    if (!nugu_client->initialize()) {
-        msg_error("< It failed to initialize NUGU SDK. Please Check authorization.");
         return EXIT_FAILURE;
     }
 

--- a/include/base/nugu_plugin.h
+++ b/include/base/nugu_plugin.h
@@ -200,16 +200,16 @@ const struct nugu_plugin_desc *nugu_plugin_get_description(NuguPlugin *p);
 /**
  * @brief Load all plugin files from directory
  * @param[in] dirpath directory path
- * @return result
- * @retval 0 success
+ * @return Number of plugins loaded
  * @retval -1 failure
  */
 int nugu_plugin_load_directory(const char *dirpath);
 
 /**
  * @brief Initialize plugin
+ * @return Number of plugins initialized
  */
-void nugu_plugin_initialize(void);
+int nugu_plugin_initialize(void);
 
 /**
  * @brief De-initialize plugin

--- a/include/clientkit/nugu_client.hh
+++ b/include/clientkit/nugu_client.hh
@@ -31,8 +31,8 @@ namespace NuguClientKit {
  * @ingroup SDKNuguClientKit
  * @brief Nugu Client
  *
- * The nugu client has access to the capability builder, config management,
- * and handler for each capability agent, making it easier to use the nugu sdk.
+ * The NUGU client has access to the capability builder, config management,
+ * and handler for each capability agent, making it easier to use the NUGU SDK.
  *
  * @{
  */
@@ -88,12 +88,24 @@ public:
     CapabilityBuilder* getCapabilityBuilder();
 
     /**
-     * @brief Request nugu sdk initialization
+     * @brief Request NUGU SDK to load all plugins from directory.
+     * If this function is not called directly, it is called automatically by initialize().
+     * @param[in] path Plugin directory path. If empty, the default directory is used.
+     */
+    bool loadPlugins(const std::string& path = "");
+
+    /**
+     * @brief Request NUGU SDK to unload all plugins
+     */
+    void unloadPlugins(void);
+
+    /**
+     * @brief Request NUGU SDK initialization
      */
     bool initialize(void);
 
     /**
-     * @brief Request nugu sdk deinitialization
+     * @brief Request NUGU SDK deinitialization
      */
     void deInitialize(void);
 

--- a/src/base/nugu_plugin.c
+++ b/src/base/nugu_plugin.c
@@ -198,7 +198,10 @@ EXPORT_API int nugu_plugin_load_directory(const char *dirpath)
 	// NOLINTNEXTLINE (clang-analyzer-unix.Malloc)
 	g_dir_close(dir);
 
-	return 0;
+	if (!_plugin_list)
+		return 0;
+	else
+		return g_list_length(_plugin_list);
 }
 
 static gint _sort_priority_cmp(gconstpointer a, gconstpointer b)
@@ -207,9 +210,12 @@ static gint _sort_priority_cmp(gconstpointer a, gconstpointer b)
 	       ((NuguPlugin *)b)->desc->priority;
 }
 
-EXPORT_API void nugu_plugin_initialize(void)
+EXPORT_API int nugu_plugin_initialize(void)
 {
 	GList *cur;
+
+	if (!_plugin_list)
+		return 0;
 
 	_plugin_list = g_list_sort(_plugin_list, _sort_priority_cmp);
 
@@ -236,6 +242,11 @@ EXPORT_API void nugu_plugin_initialize(void)
 
 		cur = _plugin_list = g_list_remove_link(_plugin_list, cur);
 	}
+
+	if (!_plugin_list)
+		return 0;
+	else
+		return g_list_length(_plugin_list);
 }
 
 EXPORT_API void nugu_plugin_deinitialize(void)

--- a/src/clientkit/nugu_client.cc
+++ b/src/clientkit/nugu_client.cc
@@ -61,6 +61,16 @@ NuguClient::CapabilityBuilder* NuguClient::getCapabilityBuilder()
     return cap_builder;
 }
 
+bool NuguClient::loadPlugins(const std::string& path)
+{
+    return impl->loadPlugins(path);
+}
+
+void NuguClient::unloadPlugins(void)
+{
+    impl->unloadPlugins();
+}
+
 bool NuguClient::initialize(void)
 {
     return impl->initialize();

--- a/src/clientkit/nugu_client_impl.hh
+++ b/src/clientkit/nugu_client_impl.hh
@@ -35,6 +35,8 @@ public:
     void setWakeupWord(const std::string& wakeup_word);
     void registerCapability(ICapabilityInterface* capability);
     int create(void);
+    bool loadPlugins(const std::string& path = "");
+    void unloadPlugins(void);
     bool initialize(void);
     void deInitialize(void);
 
@@ -56,6 +58,7 @@ private:
     std::unique_ptr<INetworkManager> network_manager = nullptr;
     std::unique_ptr<NuguCoreContainer> nugu_core_container = nullptr;
     bool initialized = false;
+    bool plugin_loaded = false;
 };
 
 } // NuguClientKit


### PR DESCRIPTION
Add `loadPlugins()` API to client kit to distinguish Capability
initialization and Plugin initialization.

This API can be omitted. Therefore, if `initialize()` is called
without calling `loadPlugins()` first, the `loadPlugins()` is
automatically called using the default directory by `initialize()`.

Signed-off-by: Inho Oh <inho.oh@sk.com>