### PR TITLE
Capability: fix the suspend/restore issue

### DIFF
--- a/include/clientkit/capability.hh
+++ b/include/clientkit/capability.hh
@@ -339,6 +339,9 @@ protected:
     /** @brief whether has attachment */
     bool has_attachment = false;
 
+    /** @brief whether capability suspend */
+    bool suspended = false;
+
     /** @brief INuguCoreContainer instance for using NuguCore functions */
     INuguCoreContainer* core_container = nullptr;
 

--- a/plugins/gstreamer.c
+++ b/plugins/gstreamer.c
@@ -230,7 +230,8 @@ void _cb_message(GstBus *bus, GstMessage *msg, GstreamerHandle *gh)
 			gh->seek_reserve = 0;
 		}
 
-		NOTIFY_STATUS_CHANGED(NUGU_MEDIA_STATUS_PLAYING);
+		if (gh->status != NUGU_MEDIA_STATUS_PAUSED)
+			NOTIFY_STATUS_CHANGED(NUGU_MEDIA_STATUS_PLAYING);
 		break;
 	}
 	case GST_MESSAGE_EOS:

--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -759,7 +759,7 @@ void AudioPlayerAgent::parsingPlay(const char* message)
     is_steal_focus = false;
 
     if (speak_dir) {
-        nugu_directive_set_data_callback(speak_dir, NULL, NULL);
+        nugu_directive_remove_data_callback(speak_dir);
         destroyDirective(speak_dir);
         speak_dir = nullptr;
     }
@@ -874,7 +874,7 @@ void AudioPlayerAgent::parsingStop(const char* message)
             return;
 
         if (speak_dir) {
-            nugu_directive_set_data_callback(speak_dir, NULL, NULL);
+            nugu_directive_remove_data_callback(speak_dir);
             destroyDirective(speak_dir);
             speak_dir = nullptr;
         }

--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -90,8 +90,16 @@ void TTSAgent::deInitialize()
 
 void TTSAgent::suspend()
 {
-    if (cur_state == MediaPlayerState::PLAYING)
+    nugu_dbg("suspend_policy[%d], cur_state => %d, speak_dir => %p", suspend_policy, cur_state, speak_dir);
+    if (cur_state == MediaPlayerState::PLAYING) {
+        if (speak_dir) {
+            nugu_directive_remove_data_callback(speak_dir);
+            destroyDirective(speak_dir);
+            speak_dir = NULL;
+        }
+        // TODO: need to manage the context
         capa_helper->releaseFocus("cap_tts");
+    }
 }
 
 void TTSAgent::directiveDataCallback(NuguDirective* ndir, void* userdata)

--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -74,7 +74,7 @@ void TTSAgent::initialize()
 void TTSAgent::deInitialize()
 {
     if (speak_dir) {
-        nugu_directive_set_data_callback(speak_dir, NULL, NULL);
+        nugu_directive_remove_data_callback(speak_dir);
         destroyDirective(speak_dir);
         speak_dir = NULL;
     }
@@ -175,7 +175,7 @@ void TTSAgent::stopTTS()
     MediaPlayerState pre_state = cur_state;
 
     if (speak_dir) {
-        nugu_directive_set_data_callback(speak_dir, NULL, NULL);
+        nugu_directive_remove_data_callback(speak_dir);
         destroyDirective(speak_dir);
         speak_dir = NULL;
     }


### PR DESCRIPTION
There is a bug in audio focus and playeback when suspending
 and restoring agents.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>