### PR TITLE
base: fix driver custom data API naming

### DIFF
--- a/include/base/nugu_decoder.h
+++ b/include/base/nugu_decoder.h
@@ -85,23 +85,23 @@ int nugu_decoder_free(NuguDecoder *dec);
 int nugu_decoder_play(NuguDecoder *dec, const void *data, size_t data_len);
 
 /**
- * @brief Set private userdata for driver
+ * @brief Set custom data for driver
  * @param[in] dec decoder object
- * @param[in] userdata userdata managed by driver
+ * @param[in] data custom data managed by driver
  * @return result
  * @retval 0 success
  * @retval -1 failure
- * @see nugu_decoder_get_userdata()
+ * @see nugu_decoder_get_driver_data()
  */
-int nugu_decoder_set_userdata(NuguDecoder *dec, void *userdata);
+int nugu_decoder_set_driver_data(NuguDecoder *dec, void *data);
 
 /**
- * @brief Get private userdata for driver
+ * @brief Get custom data for driver
  * @param[in] dec decoder object
- * @return userdata
- * @see nugu_decoder_set_userdata()
+ * @return data
+ * @see nugu_decoder_set_driver_data()
  */
-void *nugu_decoder_get_userdata(NuguDecoder *dec);
+void *nugu_decoder_get_driver_data(NuguDecoder *dec);
 
 /**
  * @brief Decode the encoded data

--- a/include/base/nugu_pcm.h
+++ b/include/base/nugu_pcm.h
@@ -220,20 +220,23 @@ void nugu_pcm_set_event_callback(NuguPcm *pcm, NuguMediaEventCallback cb,
 void nugu_pcm_emit_event(NuguPcm *pcm, enum nugu_media_event event);
 
 /**
- * @brief Set private userdata for driver
+ * @brief Set custom data for driver
  * @param[in] pcm pcm object
- * @param[in] userdata userdata managed by driver
- * @see nugu_pcm_get_userdata()
+ * @param[in] data custom data managed by driver
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ * @see nugu_pcm_get_driver_data()
  */
-void nugu_pcm_set_userdata(NuguPcm *pcm, void *userdata);
+int nugu_pcm_set_driver_data(NuguPcm *pcm, void *data);
 
 /**
- * @brief Get private userdata for driver
+ * @brief Get custom data for driver
  * @param[in] pcm pcm object
- * @return userdata
- * @see nugu_pcm_set_userdata()
+ * @return data
+ * @see nugu_pcm_set_driver_data()
  */
-void *nugu_pcm_get_userdata(NuguPcm *pcm);
+void *nugu_pcm_get_driver_data(NuguPcm *pcm);
 
 /**
  * @brief Clear pcm buffer

--- a/include/base/nugu_player.h
+++ b/include/base/nugu_player.h
@@ -238,6 +238,26 @@ void nugu_player_set_event_callback(NuguPlayer *player,
  */
 void nugu_player_emit_event(NuguPlayer *player, enum nugu_media_event event);
 
+
+/**
+ * @brief Set custom data for driver
+ * @param[in] player player object
+ * @param[in] data custom data managed by driver
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ * @see nugu_player_get_driver_data()
+ */
+int nugu_player_set_driver_data(NuguPlayer *player, void *data);
+
+/**
+ * @brief Get custom data for driver
+ * @param[in] player player object
+ * @return data
+ * @see nugu_player_set_driver_data()
+ */
+void *nugu_player_get_driver_data(NuguPlayer *player);
+
 /**
  * @}
  */
@@ -262,67 +282,69 @@ struct nugu_player_driver_ops {
 	 * @brief Called when player is created
 	 * @see nugu_player_new()
 	 */
-	void *(*create)(NuguPlayer *player);
+	int (*create)(NuguPlayerDriver *driver, NuguPlayer *player);
 
 	/**
 	 * @brief Called when player is destroyed
 	 * @see nugu_player_free()
 	 */
-	void (*destroy)(void *device, NuguPlayer *player);
+	void (*destroy)(NuguPlayerDriver *driver, NuguPlayer *player);
 
 	/**
 	 * @brief Called when set the player source
 	 * @see nugu_player_set_source()
 	 */
-	int (*set_source)(void *device, NuguPlayer *player, const char *url);
+	int (*set_source)(NuguPlayerDriver *driver, NuguPlayer *player,
+			  const char *url);
 
 	/**
 	 * @brief Called when player is started
 	 * @see nugu_player_start()
 	 */
-	int (*start)(void *device, NuguPlayer *player);
+	int (*start)(NuguPlayerDriver *driver, NuguPlayer *player);
 
 	/**
 	 * @brief Called when player is stopped
 	 * @see nugu_player_stop()
 	 */
-	int (*stop)(void *device, NuguPlayer *player);
+	int (*stop)(NuguPlayerDriver *driver, NuguPlayer *player);
 
 	/**
 	 * @brief Called when player is paused
 	 * @see nugu_player_pause()
 	 */
-	int (*pause)(void *device, NuguPlayer *player);
+	int (*pause)(NuguPlayerDriver *driver, NuguPlayer *player);
 
 	/**
 	 * @brief Called when player is resumed
 	 * @see nugu_player_resume()
 	 */
-	int (*resume)(void *device, NuguPlayer *player);
+	int (*resume)(NuguPlayerDriver *driver, NuguPlayer *player);
 
 	/**
 	 * @brief Called when playback position is changed by seek
 	 * @see nugu_player_seek()
 	 */
-	int (*seek)(void *device, NuguPlayer *player, int sec);
+	int (*seek)(NuguPlayerDriver *driver, NuguPlayer *player, int sec);
 
 	/**
 	 * @brief Called when volume is changed
 	 * @see nugu_player_set_volume()
 	 */
-	int (*set_volume)(void *device, NuguPlayer *player, int vol);
+	int (*set_volume)(NuguPlayerDriver *driver, NuguPlayer *player,
+			  int vol);
 
 	/**
 	 * @brief Called when a playback duration is requested.
 	 * @see nugu_player_get_duration()
 	 */
-	int (*get_duration)(void *device, NuguPlayer *player);
+	int (*get_duration)(NuguPlayerDriver *driver, NuguPlayer *player);
 
 	/**
 	 * @brief Called when a playback position is requested.
 	 * @see nugu_player_get_position()
 	 */
-	int (*get_position)(void *device, NuguPlayer *player);
+	int (*get_position)(NuguPlayerDriver *driver, NuguPlayer *player);
 };
 
 /**

--- a/include/base/nugu_recorder.h
+++ b/include/base/nugu_recorder.h
@@ -160,20 +160,23 @@ int nugu_recorder_clear(NuguRecorder *rec);
 int nugu_recorder_is_recording(NuguRecorder *rec);
 
 /**
- * @brief Set private userdata for driver
+ * @brief Set custom data for driver
  * @param[in] rec recorder object
- * @param[in] userdata userdata managed by driver
- * @see nugu_recorder_get_userdata()
+ * @param[in] data custom data managed by driver
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ * @see nugu_recorder_get_driver_data()
  */
-void nugu_recorder_set_userdata(NuguRecorder *rec, void *userdata);
+int nugu_recorder_set_driver_data(NuguRecorder *rec, void *data);
 
 /**
- * @brief Get private userdata for driver
+ * @brief Get custom data for driver
  * @param[in] rec recorder object
- * @return userdata
- * @see nugu_recorder_set_userdata()
+ * @return data
+ * @see nugu_recorder_set_driver_data()
  */
-void *nugu_recorder_get_userdata(NuguRecorder *rec);
+void *nugu_recorder_get_driver_data(NuguRecorder *rec);
 
 /**
  * @brief Get frame size

--- a/plugins/filedump.c
+++ b/plugins/filedump.c
@@ -40,7 +40,7 @@ static int _decoder_create(NuguDecoderDriver *driver, NuguDecoder *dec)
 	if (fd < 0)
 		return -1;
 
-	nugu_decoder_set_userdata(dec, GINT_TO_POINTER(fd));
+	nugu_decoder_set_driver_data(dec, GINT_TO_POINTER(fd));
 
 	return 0;
 }
@@ -50,7 +50,7 @@ static int _decoder_decode(NuguDecoderDriver *driver, NuguDecoder *dec,
 {
 	int fd;
 
-	fd = GPOINTER_TO_INT(nugu_decoder_get_userdata(dec));
+	fd = GPOINTER_TO_INT(nugu_decoder_get_driver_data(dec));
 	if (write(fd, data, data_len) < 0)
 		return -1;
 
@@ -61,7 +61,7 @@ static int _decoder_destroy(NuguDecoderDriver *driver, NuguDecoder *dec)
 {
 	int fd;
 
-	fd = GPOINTER_TO_INT(nugu_decoder_get_userdata(dec));
+	fd = GPOINTER_TO_INT(nugu_decoder_get_driver_data(dec));
 	close(fd);
 
 	return 0;
@@ -94,7 +94,7 @@ static int _pcm_start(NuguPcmDriver *driver, NuguPcm *pcm)
 
 	nugu_dbg("pcm filedump open: name=%s, fd=%d", buf, fd);
 
-	nugu_pcm_set_userdata(pcm, GINT_TO_POINTER(fd));
+	nugu_pcm_set_driver_data(pcm, GINT_TO_POINTER(fd));
 
 	return 0;
 }
@@ -104,7 +104,7 @@ static int _pcm_push_data(NuguPcmDriver *driver, NuguPcm *pcm, const char *data,
 {
 	int fd;
 
-	fd = GPOINTER_TO_INT(nugu_pcm_get_userdata(pcm));
+	fd = GPOINTER_TO_INT(nugu_pcm_get_driver_data(pcm));
 
 	if (data != NULL && size > 0) {
 		if (write(fd, data, size) < 0)
@@ -118,7 +118,7 @@ static int _pcm_stop(NuguPcmDriver *driver, NuguPcm *pcm)
 {
 	int fd;
 
-	fd = GPOINTER_TO_INT(nugu_pcm_get_userdata(pcm));
+	fd = GPOINTER_TO_INT(nugu_pcm_get_driver_data(pcm));
 
 	nugu_dbg("pcm filedump close: fd=%d", fd);
 

--- a/plugins/opus.c
+++ b/plugins/opus.c
@@ -67,7 +67,7 @@ static int _decoder_create(NuguDecoderDriver *driver, NuguDecoder *dec)
 		return -1;
 	}
 
-	nugu_decoder_set_userdata(dec, handle);
+	nugu_decoder_set_driver_data(dec, handle);
 
 	nugu_dbg("new opus 22K decoder (16bit mono pcm) created");
 
@@ -95,7 +95,7 @@ static int _decoder_decode(NuguDecoderDriver *driver, NuguDecoder *dec,
 	char plain_pcm[PCM_SAMPLES * CHANNELS * 2];
 	int i;
 
-	handle = nugu_decoder_get_userdata(dec);
+	handle = nugu_decoder_get_driver_data(dec);
 
 	/**
 	 * opus 1 frame
@@ -152,7 +152,7 @@ static int _decoder_destroy(NuguDecoderDriver *driver, NuguDecoder *dec)
 {
 	OpusDecoder *handle;
 
-	handle = nugu_decoder_get_userdata(dec);
+	handle = nugu_decoder_get_driver_data(dec);
 
 	opus_decoder_destroy(handle);
 

--- a/plugins/portaudio.c
+++ b/plugins/portaudio.c
@@ -224,8 +224,7 @@ static int _rec_start(NuguRecorderDriver *driver, NuguRecorder *rec,
 {
 	PaStreamParameters input_param;
 	PaError err = paNoError;
-	struct pa_audio_param *rec_param =
-		(struct pa_audio_param *)nugu_recorder_get_userdata(rec);
+	struct pa_audio_param *rec_param = nugu_recorder_get_driver_data(rec);
 	int rec_5sec;
 	int rec_100ms;
 
@@ -281,7 +280,7 @@ static int _rec_start(NuguRecorderDriver *driver, NuguRecorder *rec,
 		return -1;
 	}
 
-	nugu_recorder_set_userdata(rec, rec_param);
+	nugu_recorder_set_driver_data(rec, rec_param);
 
 	nugu_dbg("start done");
 	return 0;
@@ -290,8 +289,7 @@ static int _rec_start(NuguRecorderDriver *driver, NuguRecorder *rec,
 static int _rec_stop(NuguRecorderDriver *driver, NuguRecorder *rec)
 {
 	PaError err = paNoError;
-	struct pa_audio_param *rec_param =
-		(struct pa_audio_param *)nugu_recorder_get_userdata(rec);
+	struct pa_audio_param *rec_param = nugu_recorder_get_driver_data(rec);
 
 	if (rec_param == NULL) {
 		nugu_dbg("already stop");
@@ -307,7 +305,7 @@ static int _rec_stop(NuguRecorderDriver *driver, NuguRecorder *rec)
 		nugu_error("Pa_CloseStream return fail");
 
 	g_free(rec_param);
-	nugu_recorder_set_userdata(rec, NULL);
+	nugu_recorder_set_driver_data(rec, NULL);
 
 	nugu_dbg("stop done");
 
@@ -359,7 +357,7 @@ static int _pcm_create(NuguPcmDriver *driver, NuguPcm *pcm,
 		return -1;
 	}
 
-	nugu_pcm_set_userdata(pcm, pcm_param);
+	nugu_pcm_set_driver_data(pcm, pcm_param);
 
 	return 0;
 }
@@ -367,14 +365,14 @@ static int _pcm_create(NuguPcmDriver *driver, NuguPcm *pcm,
 static void _pcm_destroy(NuguPcmDriver *driver, NuguPcm *pcm)
 {
 	PaError err = paNoError;
-	struct pa_audio_param *pcm_param = nugu_pcm_get_userdata(pcm);
+	struct pa_audio_param *pcm_param = nugu_pcm_get_driver_data(pcm);
 
 	err = Pa_CloseStream(pcm_param->stream);
 	if (err != paNoError)
 		nugu_error("Pa_CloseStream return fail(%d)", err);
 
 	free(pcm_param);
-	nugu_pcm_set_userdata(pcm, NULL);
+	nugu_pcm_set_driver_data(pcm, NULL);
 
 #ifdef DEBUG_PCM
 	nugu_info("#### pcm(%p) param is destroyed(%p) ####", pcm, pcm_param);
@@ -384,8 +382,7 @@ static void _pcm_destroy(NuguPcmDriver *driver, NuguPcm *pcm)
 static int _pcm_start(NuguPcmDriver *driver, NuguPcm *pcm)
 {
 	PaError err = paNoError;
-	struct pa_audio_param *pcm_param =
-		(struct pa_audio_param *)nugu_pcm_get_userdata(pcm);
+	struct pa_audio_param *pcm_param = nugu_pcm_get_driver_data(pcm);
 #ifdef DUMP_PCM
 	char buf[255] = DECODER_FILENAME_TPL;
 #endif
@@ -435,8 +432,7 @@ static int _pcm_start(NuguPcmDriver *driver, NuguPcm *pcm)
 static int _pcm_stop(NuguPcmDriver *driver, NuguPcm *pcm)
 {
 	PaError err = paNoError;
-	struct pa_audio_param *pcm_param =
-		(struct pa_audio_param *)nugu_pcm_get_userdata(pcm);
+	struct pa_audio_param *pcm_param = nugu_pcm_get_driver_data(pcm);
 
 	g_return_val_if_fail(pcm != NULL, -1);
 
@@ -476,7 +472,7 @@ static int _pcm_stop(NuguPcmDriver *driver, NuguPcm *pcm)
 
 static int _pcm_pause(NuguPcmDriver *driver, NuguPcm *pcm)
 {
-	struct pa_audio_param *pcm_param = nugu_pcm_get_userdata(pcm);
+	struct pa_audio_param *pcm_param = nugu_pcm_get_driver_data(pcm);
 
 	g_return_val_if_fail(pcm != NULL, -1);
 
@@ -500,7 +496,7 @@ static int _pcm_pause(NuguPcmDriver *driver, NuguPcm *pcm)
 
 static int _pcm_resume(NuguPcmDriver *driver, NuguPcm *pcm)
 {
-	struct pa_audio_param *pcm_param = nugu_pcm_get_userdata(pcm);
+	struct pa_audio_param *pcm_param = nugu_pcm_get_driver_data(pcm);
 
 	g_return_val_if_fail(pcm != NULL, -1);
 
@@ -524,7 +520,7 @@ static int _pcm_resume(NuguPcmDriver *driver, NuguPcm *pcm)
 
 static int _pcm_get_position(NuguPcmDriver *driver, NuguPcm *pcm)
 {
-	struct pa_audio_param *pcm_param =nugu_pcm_get_userdata(pcm);
+	struct pa_audio_param *pcm_param = nugu_pcm_get_driver_data(pcm);
 
 	g_return_val_if_fail(pcm != NULL, -1);
 
@@ -559,8 +555,7 @@ static void snd_error_log(const char *file, int line, const char *function,
 static int _pcm_push_data(NuguPcmDriver *driver, NuguPcm *pcm, const char *data,
 			  size_t size, int is_last)
 {
-	struct pa_audio_param *pcm_param =
-		(struct pa_audio_param *)nugu_pcm_get_userdata(pcm);
+	struct pa_audio_param *pcm_param = nugu_pcm_get_driver_data(pcm);
 
 	if (pcm_param == NULL)
 		nugu_error("pcm is not started");

--- a/src/base/nugu_decoder.c
+++ b/src/base/nugu_decoder.c
@@ -27,9 +27,10 @@
 
 struct _nugu_decoder {
 	NuguDecoderDriver *driver;
+	void *driver_data;
+
 	NuguPcm *pcm;
 	NuguBuffer *buf;
-	void *userdata;
 };
 
 struct _nugu_decoder_driver {
@@ -146,6 +147,7 @@ EXPORT_API NuguDecoder *nugu_decoder_new(NuguDecoderDriver *driver,
 	dec->driver = driver;
 	dec->pcm = sink;
 	dec->buf = nugu_buffer_new(DEFAULT_DECODE_BUFFER_SIZE);
+	dec->driver_data = NULL;
 
 	driver->ref_count++;
 
@@ -259,18 +261,18 @@ EXPORT_API void *nugu_decoder_decode(NuguDecoder *dec, const void *data,
 	return out;
 }
 
-EXPORT_API int nugu_decoder_set_userdata(NuguDecoder *dec, void *userdata)
+EXPORT_API int nugu_decoder_set_driver_data(NuguDecoder *dec, void *data)
 {
 	g_return_val_if_fail(dec != NULL, -1);
 
-	dec->userdata = userdata;
+	dec->driver_data = data;
 
 	return 0;
 }
 
-EXPORT_API void *nugu_decoder_get_userdata(NuguDecoder *dec)
+EXPORT_API void *nugu_decoder_get_driver_data(NuguDecoder *dec)
 {
 	g_return_val_if_fail(dec != NULL, NULL);
 
-	return dec->userdata;
+	return dec->driver_data;
 }

--- a/src/base/nugu_pcm.c
+++ b/src/base/nugu_pcm.c
@@ -33,13 +33,14 @@ struct _nugu_pcm_driver {
 struct _nugu_pcm {
 	char *name;
 	NuguPcmDriver *driver;
+	void *driver_data;
+
 	enum nugu_media_status status;
 	NuguAudioProperty property;
 	NuguMediaEventCallback ecb;
 	NuguMediaStatusCallback scb;
 	void *eud; /* user data for event callback */
 	void *sud; /* user data for status callback */
-	void *dud; /* user data for driver */
 	NuguBuffer *buf;
 	int is_last;
 	int volume;
@@ -194,7 +195,7 @@ EXPORT_API NuguPcm *nugu_pcm_new(const char *name, NuguPcmDriver *driver,
 	pcm->ecb = NULL;
 	pcm->sud = NULL;
 	pcm->eud = NULL;
-	pcm->dud = NULL;
+	pcm->driver_data = NULL;
 	pcm->status = NUGU_MEDIA_STATUS_STOPPED;
 	pcm->volume = NUGU_SET_VOLUME_MAX;
 	pcm->total_size = 0;
@@ -449,18 +450,20 @@ EXPORT_API void nugu_pcm_emit_event(NuguPcm *pcm, enum nugu_media_event event)
 		pcm->ecb(event, pcm->eud);
 }
 
-EXPORT_API void nugu_pcm_set_userdata(NuguPcm *pcm, void *userdata)
+EXPORT_API int nugu_pcm_set_driver_data(NuguPcm *pcm, void *data)
 {
-	g_return_if_fail(pcm != NULL);
+	g_return_val_if_fail(pcm != NULL, -1);
 
-	pcm->dud = userdata;
+	pcm->driver_data = data;
+
+	return 0;
 }
 
-EXPORT_API void *nugu_pcm_get_userdata(NuguPcm *pcm)
+EXPORT_API void *nugu_pcm_get_driver_data(NuguPcm *pcm)
 {
 	g_return_val_if_fail(pcm != NULL, NULL);
 
-	return pcm->dud;
+	return pcm->driver_data;
 }
 
 EXPORT_API void nugu_pcm_clear_buffer(NuguPcm *pcm)

--- a/src/base/nugu_recorder.c
+++ b/src/base/nugu_recorder.c
@@ -38,10 +38,11 @@ struct _nugu_recorder_driver {
 struct _nugu_recorder {
 	char *name;
 	NuguRecorderDriver *driver;
+	void *driver_data;
+
 	NuguAudioProperty property;
 	NuguRingBuffer *buf;
 	int is_recording;
-	void *userdata;
 	pthread_cond_t cond;
 	pthread_mutex_t lock;
 #ifdef RECORDER_FILE_DUMP
@@ -322,18 +323,20 @@ EXPORT_API int nugu_recorder_is_recording(NuguRecorder *rec)
 	return rec->is_recording;
 }
 
-EXPORT_API void nugu_recorder_set_userdata(NuguRecorder *rec, void *userdata)
+EXPORT_API int nugu_recorder_set_driver_data(NuguRecorder *rec, void *data)
 {
-	g_return_if_fail(rec != NULL);
+	g_return_val_if_fail(rec != NULL, -1);
 
-	rec->userdata = userdata;
+	rec->driver_data = data;
+
+	return 0;
 }
 
-EXPORT_API void *nugu_recorder_get_userdata(NuguRecorder *rec)
+EXPORT_API void *nugu_recorder_get_driver_data(NuguRecorder *rec)
 {
 	g_return_val_if_fail(rec != NULL, NULL);
 
-	return rec->userdata;
+	return rec->driver_data;
 }
 
 EXPORT_API int nugu_recorder_get_frame_size(NuguRecorder *rec, int *size,

--- a/tests/test-nugu-decoder.c
+++ b/tests/test-nugu-decoder.c
@@ -139,16 +139,16 @@ static void test_decoder_default(void)
 	g_assert(nugu_decoder_new(NULL, NULL) == NULL);
 	g_assert(nugu_decoder_decode(NULL, NULL, 0, NULL) == NULL);
 	g_assert(nugu_decoder_decode(NULL, "", 0, NULL) == NULL);
-	g_assert(nugu_decoder_set_userdata(NULL, NULL) < 0);
-	g_assert(nugu_decoder_get_userdata(NULL) == NULL);
+	g_assert(nugu_decoder_set_driver_data(NULL, NULL) < 0);
+	g_assert(nugu_decoder_get_driver_data(NULL) == NULL);
 
 	dec = nugu_decoder_new(driver, NULL);
 	g_assert(dec != NULL);
 	g_assert(nugu_decoder_driver_free(driver) == -1);
 
 	g_assert(nugu_decoder_get_pcm(dec) == NULL);
-	g_assert(nugu_decoder_set_userdata(dec, mydata) == 0);
-	g_assert(nugu_decoder_get_userdata(dec) == mydata);
+	g_assert(nugu_decoder_set_driver_data(dec, mydata) == 0);
+	g_assert(nugu_decoder_get_driver_data(dec) == mydata);
 
 	g_assert(nugu_decoder_decode(dec, NULL, 0, &result_length) == NULL);
 	g_assert(result_length == 999);

--- a/tests/test-nugu-player.c
+++ b/tests/test-nugu-player.c
@@ -52,19 +52,24 @@ static const char *_playurl;
 #define DUMMY_SEEK_ONE_THIRD (DUMMY_DURATION / 3)
 #define DUMMY_VOLUME NUGU_SET_VOLUME_MAX
 
-static void *dummy_create(NuguPlayer *player)
+static int dummy_create(NuguPlayerDriver *driver, NuguPlayer *player)
 {
+	(void)driver;
 	(void)player;
-	return NULL;
+
+	return 0;
 }
-static void dummy_destroy(void *device, NuguPlayer *player)
+
+static void dummy_destroy(NuguPlayerDriver *driver, NuguPlayer *player)
 {
-	(void)device;
+	(void)driver;
 	(void)player;
 }
-static int dummy_start(void *device, NuguPlayer *player)
+
+static int dummy_start(NuguPlayerDriver *driver, NuguPlayer *player)
 {
-	(void)device;
+	(void)driver;
+
 	if (g_strcmp0(_playurl, WRONG_PLAYURL) == 0)
 		nugu_player_emit_event(player,
 				       NUGU_MEDIA_EVENT_MEDIA_LOAD_FAILED);
@@ -72,31 +77,42 @@ static int dummy_start(void *device, NuguPlayer *player)
 		nugu_player_emit_event(player, NUGU_MEDIA_EVENT_MEDIA_LOADED);
 		nugu_player_emit_status(player, NUGU_MEDIA_STATUS_PLAYING);
 	}
+
 	_seek_pos = 0;
 	_position = 0;
+
 	return 0;
 }
-static int dummy_stop(void *device, NuguPlayer *player)
+
+static int dummy_stop(NuguPlayerDriver *driver, NuguPlayer *player)
 {
-	(void)device;
+	(void)driver;
+
 	nugu_player_emit_status(player, NUGU_MEDIA_STATUS_STOPPED);
+
 	return 0;
 }
-static int dummy_pause(void *device, NuguPlayer *player)
+
+static int dummy_pause(NuguPlayerDriver *driver, NuguPlayer *player)
 {
-	(void)device;
+	(void)driver;
+
 	nugu_player_emit_status(player, NUGU_MEDIA_STATUS_PAUSED);
 	return 0;
 }
-static int dummy_resume(void *device, NuguPlayer *player)
+
+static int dummy_resume(NuguPlayerDriver *driver, NuguPlayer *player)
 {
-	(void)device;
+	(void)driver;
+
 	nugu_player_emit_status(player, NUGU_MEDIA_STATUS_PLAYING);
+
 	return 0;
 }
-static int dummy_seek(void *device, NuguPlayer *player, int sec)
+
+static int dummy_seek(NuguPlayerDriver *driver, NuguPlayer *player, int sec)
 {
-	(void)device;
+	(void)driver;
 
 	_seek_pos += sec;
 
@@ -109,26 +125,32 @@ static int dummy_seek(void *device, NuguPlayer *player, int sec)
 
 	return 0;
 }
-static int dummy_set_source(void *device, NuguPlayer *player, const char *url)
+static int dummy_set_source(NuguPlayerDriver *driver, NuguPlayer *player,
+			    const char *url)
 {
 	nugu_player_emit_event(player, NUGU_MEDIA_EVENT_MEDIA_SOURCE_CHANGED);
-	dummy_stop(device, player);
+	dummy_stop(driver, player);
 
 	_playurl = url;
+
 	return 0;
 }
-static int dummy_set_volume(void *device, NuguPlayer *player, int vol)
+static int dummy_set_volume(NuguPlayerDriver *driver, NuguPlayer *player,
+			    int vol)
 {
-	(void)device;
+	(void)driver;
 	(void)player;
+
 	g_assert(vol == _volume);
+
 	return 0;
 }
 
-static int dummy_get_duration(void *device, NuguPlayer *player)
+static int dummy_get_duration(NuguPlayerDriver *driver, NuguPlayer *player)
 {
-	(void)device;
+	(void)driver;
 	(void)player;
+
 	if (_status == NUGU_MEDIA_STATUS_STOPPED)
 		_duration = -1;
 	else
@@ -137,10 +159,11 @@ static int dummy_get_duration(void *device, NuguPlayer *player)
 	return _duration;
 }
 
-static int dummy_get_position(void *device, NuguPlayer *player)
+static int dummy_get_position(NuguPlayerDriver *driver, NuguPlayer *player)
 {
-	(void)device;
+	(void)driver;
 	(void)player;
+
 	if (_status == NUGU_MEDIA_STATUS_STOPPED)
 		_position = -1;
 	else if (_seek_pos)


### PR DESCRIPTION
Some of the drivers' custom data configuration APIs are not unified,
so they have been modified as follows:

    int nugu_XXX_set_driver_data(XXX *xxx, void *data);
    void *nugu_XXX_get_driver_data(XXX *xxx);

So if the driver needs to store or load the device handle in an object,
please use the above API.

Signed-off-by: Inho Oh <inho.oh@sk.com>