### PR TITLE
Capability:add method for receiving event response

### DIFF
--- a/include/clientkit/capability.hh
+++ b/include/clientkit/capability.hh
@@ -169,6 +169,14 @@ public:
     void notifyEventResult(const std::string& event_desc) override;
 
     /**
+     * @brief Notify event response info.
+     * @param[in] msg_id message id which is sent with event
+     * @param[in] json raw data which is received from server about event
+     * @param[in] success whether receive event response
+     */
+    void notifyEventResponse(const char* msg_id, const char* json, bool success);
+
+    /**
      * @brief Add event name and directive name for referred dialog request id.
      * @param[in] ename event name
      * @param[in] dname directive name

--- a/include/clientkit/capability_interface.hh
+++ b/include/clientkit/capability_interface.hh
@@ -127,6 +127,14 @@ public:
     virtual void notifyEventResult(const std::string& event_desc) = 0;
 
     /**
+     * @brief Notify event response info.
+     * @param[in] msg_id message id which is sent with event
+     * @param[in] json raw data which is received from server about event
+     * @param[in] success whether receive event response
+     */
+    virtual void notifyEventResponse(const char* msg_id, const char* json, bool success) = 0;
+
+    /**
      * @brief Get the capability name of the current object.
      * @return capability name of the object
      */

--- a/src/clientkit/capability.cc
+++ b/src/clientkit/capability.cc
@@ -15,7 +15,6 @@
  */
 
 #include <cstring>
-#include <iostream>
 #include <string.h>
 
 #include "base/nugu_directive_sequencer.h"
@@ -197,6 +196,10 @@ void Capability::notifyEventResult(const std::string& event_desc)
         else
             event_result_cbs[ename](ename, msg_id, dialog_id, success, code);
     }
+}
+
+void Capability::notifyEventResponse(const char* msg_id, const char* json, bool success)
+{
 }
 
 void Capability::addReferrerEvents(const std::string& ename, const std::string& dname)

--- a/src/core/capability_manager.hh
+++ b/src/core/capability_manager.hh
@@ -80,6 +80,7 @@ private:
     std::map<std::string, ICapabilityInterface*> caps;
     std::map<std::string, NuguFocus*> focusmap;
     std::map<std::string, std::string> events;
+    std::map<std::string, std::string> events_cname_map;
     std::string wword;
     std::unique_ptr<PlaySyncManager> playsync_manager = nullptr;
     bool check_asr_focus_release = false;


### PR DESCRIPTION
It add notifyEventResponse() method in Capability
for receiving response info about sent event.
(It composed by message_id, raw json and whether success.)

If the CapabilityAgent need to do something with above method,
it has to override it in that agent.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>