### PR TITLE
AudioPlayer: Fix the bug.

### DIFF
--- a/src/capability/audio_player_agent.hh
+++ b/src/capability/audio_player_agent.hh
@@ -132,7 +132,7 @@ private:
     AudioPlayerState cur_aplayer_state;
     AudioPlayerState prev_aplayer_state;
     bool is_paused;
-    bool is_steal_focus;
+    bool is_paused_by_unfocus;
     std::string ps_id;
     long report_delay_time;
     long report_interval_time;


### PR DESCRIPTION
During media playback, the `PlaybackStarted` event is not sent
on the next media playback request from the App Control Center.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>