### PR TITLE
NuguClient:Remove INetworkManagerListener inheritance

### DIFF
--- a/src/clientkit/nugu_client_impl.cc
+++ b/src/clientkit/nugu_client_impl.cc
@@ -22,14 +22,12 @@
 #include "base/nugu_log.h"
 #include "base/nugu_plugin.h"
 #include "base/nugu_prof.h"
-#include "capability/system_interface.hh"
 
 #include "nugu_client_impl.hh"
 
 namespace NuguClientKit {
 
 using namespace NuguCore;
-using namespace NuguCapability;
 
 NuguClientImpl::NuguClientImpl()
     : nugu_core_container(std::unique_ptr<NuguCoreContainer>(new NuguCoreContainer()))
@@ -43,7 +41,6 @@ NuguClientImpl::NuguClientImpl()
 
     network_manager = std::unique_ptr<INetworkManager>(nugu_core_container->createNetworkManager());
     network_manager->addListener(nugu_core_container->getNetworkManagerListener());
-    network_manager->addListener(this);
 }
 
 NuguClientImpl::~NuguClientImpl()
@@ -232,17 +229,6 @@ void NuguClientImpl::deInitialize(void)
 
     nugu_dbg("NuguClientImpl deInitialize success.");
     initialized = false;
-}
-
-void NuguClientImpl::onStatusChanged(NetworkStatus status)
-{
-    if (status != NetworkStatus::CONNECTED)
-        return;
-
-    ISystemHandler* sys_handler = dynamic_cast<ISystemHandler*>(getCapabilityHandler("System"));
-
-    if (sys_handler)
-        sys_handler->synchronizeState();
 }
 
 INetworkManager* NuguClientImpl::getNetworkManager()

--- a/src/clientkit/nugu_client_impl.hh
+++ b/src/clientkit/nugu_client_impl.hh
@@ -27,7 +27,7 @@ namespace NuguClientKit {
 
 using namespace NuguCore;
 
-class NuguClientImpl : public INetworkManagerListener {
+class NuguClientImpl {
 public:
     NuguClientImpl();
     virtual ~NuguClientImpl();
@@ -43,9 +43,6 @@ public:
     ICapabilityInterface* getCapabilityHandler(const std::string& cname);
     INuguCoreContainer* getNuguCoreContainer();
     INetworkManager* getNetworkManager();
-
-    // overriding INetworkManagerListener
-    void onStatusChanged(NetworkStatus status) override;
 
 private:
     int createCapabilities(void);


### PR DESCRIPTION
As the network policy is changed not to send SynchronizeState event
when the connection is completed, it remove NetworkManagerListener
inheritance and remove overriding onStatusChanged method.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>