### PR TITLE
pcm: add create/destroy ops to pcm driver

### DIFF
--- a/include/base/nugu_pcm.h
+++ b/include/base/nugu_pcm.h
@@ -54,12 +54,14 @@ typedef struct _nugu_pcm_driver NuguPcmDriver;
  * @brief Create new pcm object
  * @param[in] name pcm name
  * @param[in] driver driver object
+ * @param[in] property audio property
  * @return pcm object
  * @see nugu_pcm_driver_find()
  * @see nugu_pcm_driver_get_default()
  * @see nugu_pcm_free()
  */
-NuguPcm *nugu_pcm_new(const char *name, NuguPcmDriver *driver);
+NuguPcm *nugu_pcm_new(const char *name, NuguPcmDriver *driver,
+		      NuguAudioProperty property);
 
 /**
  * @brief Destroy the pcm object
@@ -98,16 +100,6 @@ int nugu_pcm_remove(NuguPcm *pcm);
  * @see nugu_pcm_remove()
  */
 NuguPcm *nugu_pcm_find(const char *name);
-
-/**
- * @brief Set property to pcm object
- * @param[in] pcm pcm object
- * @param[in] property property
- * @return result
- * @retval 0 success
- * @retval -1 failure
- */
-int nugu_pcm_set_property(NuguPcm *pcm, NuguAudioProperty property);
 
 /**
  * @brief Start pcm playback
@@ -320,11 +312,23 @@ int nugu_pcm_receive_is_last_data(NuguPcm *pcm);
  */
 struct nugu_pcm_driver_ops {
 	/**
+	 * @brief Called when pcm is created
+	 * @see nugu_pcm_new()
+	 */
+	int (*create)(NuguPcmDriver *driver, NuguPcm *pcm,
+		NuguAudioProperty property);
+
+	/**
+	 * @brief Called when pcm is destroyed
+	 * @see nugu_pcm_free()
+	 */
+	void (*destroy)(NuguPcmDriver *driver, NuguPcm *pcm);
+
+	/**
 	 * @brief Called when pcm is started
 	 * @see nugu_pcm_start()
 	 */
-	int (*start)(NuguPcmDriver *driver, NuguPcm *pcm,
-		     NuguAudioProperty property);
+	int (*start)(NuguPcmDriver *driver, NuguPcm *pcm);
 
 	/**
 	 * @brief Called when a pcm data is pushed to pcm object

--- a/plugins/filedump.c
+++ b/plugins/filedump.c
@@ -73,8 +73,17 @@ static struct nugu_decoder_driver_ops decoder_ops = {
 	.destroy = _decoder_destroy
 };
 
-static int _pcm_start(NuguPcmDriver *driver, NuguPcm *pcm,
-		      NuguAudioProperty prop)
+static int _pcm_create(NuguPcmDriver *driver, NuguPcm *pcm,
+		     NuguAudioProperty prop)
+{
+	return 0;
+}
+
+static void _pcm_destroy(NuguPcmDriver *driver, NuguPcm *pcm)
+{
+}
+
+static int _pcm_start(NuguPcmDriver *driver, NuguPcm *pcm)
 {
 	int fd;
 	char buf[255] = PCM_FILENAME_TPL;
@@ -119,6 +128,8 @@ static int _pcm_stop(NuguPcmDriver *driver, NuguPcm *pcm)
 }
 
 static struct nugu_pcm_driver_ops pcm_ops = {
+	.create = _pcm_create,
+	.destroy = _pcm_destroy,
 	.start = _pcm_start,
 	.push_data = _pcm_push_data,
 	.stop = _pcm_stop

--- a/src/core/tts_player.cc
+++ b/src/core/tts_player.cc
@@ -77,13 +77,13 @@ TTSPlayer::TTSPlayer(int volume)
     d->player_name = MEDIA_PLAYER_NAME + std::to_string(uniq_id++);
     nugu_dbg("player's name: %s", d->player_name.c_str());
 
-    d->player = nugu_pcm_new(d->player_name.c_str(), nugu_pcm_driver_get_default());
+    d->player = nugu_pcm_new(d->player_name.c_str(), nugu_pcm_driver_get_default(),
+        (NuguAudioProperty) { NUGU_AUDIO_SAMPLE_RATE_22K, NUGU_AUDIO_FORMAT_S16_LE, 1 });
     if (!d->player) {
         nugu_error("couldn't create tts player");
         return;
     }
     nugu_pcm_add(d->player);
-    nugu_pcm_set_property(d->player, (NuguAudioProperty) { NUGU_AUDIO_SAMPLE_RATE_22K, NUGU_AUDIO_FORMAT_S16_LE, 1 });
 
     d->decoder = nugu_decoder_new(nugu_decoder_driver_find("opus"), d->player);
 


### PR DESCRIPTION
add .create and .destroy ops callbacks to pcm driver to split OpenStream
and StartStream in the PortAudio plugin.

Signed-off-by: Inho Oh <inho.oh@sk.com>