### PR TITLE
Focus: Add FocusManager

### DIFF
--- a/examples/standalone/nugu_sample.cc
+++ b/examples/standalone/nugu_sample.cc
@@ -44,6 +44,27 @@ void msg_info(std::string&& message)
     NuguSampleManager::info(std::move(message));
 }
 
+class FocusManagerObserver : public IFocusManagerObserver {
+public:
+    void onFocusChanged(const FocusConfiguration& configuration, FocusState state, const std::string& name)
+    {
+        auto focus_manager(nugu_client->getFocusManager());
+        std::string msg;
+
+        msg.append("==================================================\n[")
+            .append(configuration.type)
+            .append(" - ")
+            .append(name)
+            .append("] ")
+            .append(focus_manager->getStateString(state))
+            .append(" (priority: ")
+            .append(std::to_string(configuration.priority))
+            .append(")\n==================================================");
+
+        msg_info(std::move(msg));
+    }
+};
+
 class NetworkManagerListener : public INetworkManagerListener {
 public:
     void onStatusChanged(NetworkStatus status)
@@ -160,6 +181,10 @@ int main(int argc, char** argv)
         msg_error("< It failed to initialize NUGU SDK. Please Check authorization.");
         return EXIT_FAILURE;
     }
+
+    auto focus_manager(nugu_client->getFocusManager());
+    auto focus_manager_observer(make_unique<FocusManagerObserver>());
+    focus_manager->addObserver(focus_manager_observer.get());
 
     auto network_manager_listener(make_unique<NetworkManagerListener>());
     auto network_manager(nugu_client->getNetworkManager());

--- a/include/clientkit/capability.hh
+++ b/include/clientkit/capability.hh
@@ -347,6 +347,9 @@ protected:
     /** @brief IPlaySyncManager instance for using play context sync */
     IPlaySyncManager* playsync_manager = nullptr;
 
+    /** @brief IFocusManager instance for using audio focus */
+    IFocusManager* focus_manager = nullptr;
+
     /** @brief SuspendPolicy variable for deciding suspend action (default:STOP) */
     SuspendPolicy suspend_policy = SuspendPolicy::STOP;
 

--- a/include/clientkit/capability_helper_interface.hh
+++ b/include/clientkit/capability_helper_interface.hh
@@ -22,6 +22,7 @@
 
 #include <base/nugu_event.h>
 #include <base/nugu_focus.h>
+#include <clientkit/focus_manager_interface.hh>
 #include <clientkit/playsync_manager_interface.hh>
 
 namespace NuguClientKit {
@@ -79,8 +80,15 @@ public:
 
     /**
      * @brief Get IPlaySyncManager instance
+     * @return IPlaySyncManager instance
      */
     virtual IPlaySyncManager* getPlaySyncManager() = 0;
+
+    /**
+     * @brief Get IFocusManager instance
+     * @return IFocusManager instance
+     */
+    virtual IFocusManager* getFocusManager() = 0;
 
     /**
      * @brief Set Audio Recorder mute/unmute

--- a/include/clientkit/focus_manager_interface.hh
+++ b/include/clientkit/focus_manager_interface.hh
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NUGU_FOCUS_MANAGER_INTERFACE_H__
+#define __NUGU_FOCUS_MANAGER_INTERFACE_H__
+
+#include <iostream>
+#include <vector>
+
+namespace NuguClientKit {
+
+/**
+ * @file focus_manager_interface.hh
+ * @defgroup FocusManagerInterface FocusManagerInterface
+ * @ingroup SDKNuguClientKit
+ * @brief Focus Manager Interface
+ *
+ * FocusManager manage focus configuration and focus can be requested or released.
+ *
+ * @{
+ */
+
+#define DIALOG_FOCUS_TYPE "Dialog" /** @def Default Dialog Focus Type */
+#define DIALOG_FOCUS_PRIORITY 100 /** @def Default Dialog Focus Priority */
+
+#define COMMUNICATIONS_FOCUS_TYPE "Communications" /** @def Default Communication Focus Type */
+#define COMMUNICATIONS_FOCUS_PRIORITY 200 /** @def Default Communication Focus Priority */
+
+#define ALERTS_FOCUS_TYPE "Alerts" /** @def Default Alerts Focus Type */
+#define ALERTS_FOCUS_PRIORITY 300 /** @def Default Alerts Focus Priority */
+
+#define CONTENT_FOCUS_TYPE "Content" /** @def Default Content Focus Type */
+#define CONTENT_FOCUS_PRIORITY 400 /** @def Default Content Focus Priority */
+
+/**
+ * @brief FocusState
+ */
+enum class FocusState {
+    FOREGROUND, /**< The focus is activated */
+    BACKGROUND, /**< The focus is pending and waiting for release the foreground resource. */
+    NONE /**< The focus is released */
+};
+
+/**
+ * @brief FocusConfiguration
+ */
+typedef struct {
+    std::string type; /**< focus type */
+    int priority; /**< focus priority */
+} FocusConfiguration;
+
+/**
+ * @brief IFocusResourceListener
+ * @see IFocusManager
+ */
+class IFocusResourceListener {
+public:
+    virtual ~IFocusResourceListener() = default;
+
+    /**
+     * @brief Notify the resource of focus state change
+     * @param[in] state resource's new state
+     */
+    virtual void onFocusChanged(FocusState state) = 0;
+};
+
+/**
+ * @brief IFocusManagerObserver
+ * @see IFocusManager
+ */
+class IFocusManagerObserver {
+public:
+    virtual ~IFocusManagerObserver() = default;
+
+    /**
+     * @brief Support to monitor the change of focus state for all resources
+     * @param[in] configuration focus configuration
+     * @param[in] state resource's new state
+     * @param[in] name focus name
+     */
+    virtual void onFocusChanged(const FocusConfiguration& configuration, FocusState state, const std::string& name) = 0;
+};
+
+/**
+ * @brief IFocusManager
+ * @see IFocusResourceListener
+ * @see IFocusManagerObserver
+ */
+class IFocusManager {
+public:
+    /**
+     * @brief Request Focus
+     * @param[in] type focus type
+     * @param[in] name focus name
+     * @param[in] listener listener object
+     * @return if the request is success, then true otherwise false
+     */
+    virtual bool requestFocus(const std::string& type, const std::string& name, IFocusResourceListener* listener) = 0;
+
+    /**
+     * @brief Release Focus
+     * @param[in] type focus type
+     * @return if the release is success, then true otherwise false
+     */
+    virtual bool releaseFocus(const std::string& type) = 0;
+
+    /**
+     * @brief Set focus configurations.
+     * @param[in] configurations focus configurations
+     */
+    virtual void setConfigurations(std::vector<FocusConfiguration>& configurations) = 0;
+
+    /**
+     * @brief Stop all focus.
+     */
+    virtual void stopAllFocus() = 0;
+
+    /**
+     * @brief Stop highest priority of focus that is foreground state.
+     */
+    virtual void stopForegroundFocus() = 0;
+
+    /**
+     * @brief Get state string
+     * @param[in] state focus state
+     * @return state string
+     */
+    virtual std::string getStateString(FocusState state) = 0;
+
+    /**
+     * @brief Add the Observer object
+     * @param[in] observer observer object
+     */
+    virtual void addObserver(IFocusManagerObserver* observer) = 0;
+
+    /**
+     * @brief Remove the Observer object
+     * @param[in] observer observer object
+     */
+    virtual void removeObserver(IFocusManagerObserver* observer) = 0;
+};
+
+} // NuguClientKit
+
+#endif /* __NUGU_FOCUS_MANAGER_INTERFACE_H__ */

--- a/include/clientkit/nugu_client.hh
+++ b/include/clientkit/nugu_client.hh
@@ -121,6 +121,12 @@ public:
      */
     INetworkManager* getNetworkManager();
 
+    /**
+     * @brief Get FocusManager object
+     * @return IFocusManager abstraction object of FocuskManager
+     */
+    IFocusManager* getFocusManager();
+
 private:
     std::unique_ptr<NuguClientImpl> impl;
     CapabilityBuilder* cap_builder;

--- a/include/clientkit/nugu_core_container_interface.hh
+++ b/include/clientkit/nugu_core_container_interface.hh
@@ -18,6 +18,7 @@
 #define __NUGU_CORE_CONTAINER_INTERFACE_H__
 
 #include <clientkit/capability_helper_interface.hh>
+#include <clientkit/focus_manager_interface.hh>
 #include <clientkit/media_player_interface.hh>
 #include <clientkit/network_manager_interface.hh>
 #include <clientkit/nugu_timer_interface.hh>
@@ -76,6 +77,11 @@ public:
      * @brief Get CapabilityHelper instance
      */
     virtual ICapabilityHelper* getCapabilityHelper() = 0;
+
+    /**
+     * @brief Get FocusManager instance
+     */
+    virtual IFocusManager* getFocusManager() = 0;
 };
 
 /**

--- a/src/clientkit/capability.cc
+++ b/src/clientkit/capability.cc
@@ -148,6 +148,7 @@ void Capability::setNuguCoreContainer(INuguCoreContainer* core_container)
     this->core_container = core_container;
     capa_helper = core_container->getCapabilityHelper();
     playsync_manager = capa_helper->getPlaySyncManager();
+    focus_manager = capa_helper->getFocusManager();
 }
 
 void Capability::initialize()

--- a/src/clientkit/nugu_client.cc
+++ b/src/clientkit/nugu_client.cc
@@ -91,4 +91,9 @@ INetworkManager* NuguClient::getNetworkManager()
     return impl->getNetworkManager();
 }
 
+IFocusManager* NuguClient::getFocusManager()
+{
+    return impl->getFocusManager();
+}
+
 } // NuguClientKit

--- a/src/clientkit/nugu_client_impl.cc
+++ b/src/clientkit/nugu_client_impl.cc
@@ -94,6 +94,11 @@ INuguCoreContainer* NuguClientImpl::getNuguCoreContainer()
     return nugu_core_container.get();
 }
 
+IFocusManager* NuguClientImpl::getFocusManager()
+{
+    return nugu_core_container->getFocusManager();
+}
+
 int NuguClientImpl::create(void)
 {
     if (createCapabilities() <= 0) {

--- a/src/clientkit/nugu_client_impl.hh
+++ b/src/clientkit/nugu_client_impl.hh
@@ -43,6 +43,7 @@ public:
     ICapabilityInterface* getCapabilityHandler(const std::string& cname);
     INuguCoreContainer* getNuguCoreContainer();
     INetworkManager* getNetworkManager();
+    IFocusManager* getFocusManager();
 
 private:
     int createCapabilities(void);

--- a/src/core/capability_helper.cc
+++ b/src/core/capability_helper.cc
@@ -52,6 +52,11 @@ IPlaySyncManager* CapabilityHelper::getPlaySyncManager()
     return CapabilityManager::getInstance()->getPlaySyncManager();
 }
 
+IFocusManager* CapabilityHelper::getFocusManager()
+{
+    return CapabilityManager::getInstance()->getFocusManager();
+}
+
 bool CapabilityHelper::setMute(bool mute)
 {
     return AudioRecorderManager::getInstance()->setMute(mute);

--- a/src/core/capability_helper.hh
+++ b/src/core/capability_helper.hh
@@ -30,6 +30,7 @@ public:
 
     // implements ICapabilityHelper
     IPlaySyncManager* getPlaySyncManager() override;
+    IFocusManager* getFocusManager() override;
 
     bool setMute(bool mute) override;
     void sendCommand(const std::string& from, const std::string& to, const std::string& command, const std::string& param) override;

--- a/src/core/capability_manager.cc
+++ b/src/core/capability_manager.cc
@@ -54,6 +54,7 @@ CapabilityManager::CapabilityManager()
 
     wword = WAKEUP_WORD;
     playsync_manager = std::unique_ptr<PlaySyncManager>(new PlaySyncManager());
+    focus_manager = std::unique_ptr<FocusManager>(new FocusManager());
 }
 
 CapabilityManager::~CapabilityManager()
@@ -439,6 +440,11 @@ int CapabilityManager::releaseFocus(const std::string& fname)
 PlaySyncManager* CapabilityManager::getPlaySyncManager()
 {
     return playsync_manager.get();
+}
+
+FocusManager* CapabilityManager::getFocusManager()
+{
+    return focus_manager.get();
 }
 
 } // NuguCore

--- a/src/core/capability_manager.hh
+++ b/src/core/capability_manager.hh
@@ -24,6 +24,7 @@
 #include "base/nugu_event.h"
 #include "base/nugu_focus.h"
 #include "clientkit/capability_interface.hh"
+#include "focus_manager.hh"
 #include "playsync_manager.hh"
 
 namespace NuguCore {
@@ -36,7 +37,9 @@ private:
 public:
     static CapabilityManager* getInstance();
     static void destroyInstance();
+
     PlaySyncManager* getPlaySyncManager();
+    FocusManager* getFocusManager();
 
     static NuguDirseqReturn dirseqCallback(NuguDirective* ndir, void* userdata);
 
@@ -83,6 +86,7 @@ private:
     std::map<std::string, std::string> events_cname_map;
     std::string wword;
     std::unique_ptr<PlaySyncManager> playsync_manager = nullptr;
+    std::unique_ptr<FocusManager> focus_manager = nullptr;
     bool check_asr_focus_release = false;
     std::string asr_dialog_id;
 };

--- a/src/core/focus_manager.cc
+++ b/src/core/focus_manager.cc
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "focus_manager.hh"
+#include "base/nugu_log.h"
+
+namespace NuguCore {
+
+FocusResource::FocusResource(const std::string& type, const std::string& name, int priority, IFocusResourceListener* listener, IFocusResourceObserver* observer)
+    : type(type)
+    , name(name)
+    , priority(priority)
+    , state(FocusState::NONE)
+    , listener(listener)
+    , observer(observer)
+{
+}
+
+void FocusResource::setState(FocusState state)
+{
+    if (this->state == state)
+        return;
+
+    this->state = state;
+    listener->onFocusChanged(state);
+    observer->onFocusChanged(type, name, state);
+}
+
+bool FocusResource::operator<(const FocusResource& resource)
+{
+    return (this->priority < resource.priority);
+}
+
+bool FocusResource::operator>(const FocusResource& resource)
+{
+    return (this->priority > resource.priority);
+}
+
+FocusManager::FocusManager()
+{
+    observers.clear();
+
+    configuration_map.clear();
+    configuration_map[DIALOG_FOCUS_TYPE] = DIALOG_FOCUS_PRIORITY;
+    configuration_map[COMMUNICATIONS_FOCUS_TYPE] = COMMUNICATIONS_FOCUS_PRIORITY;
+    configuration_map[ALERTS_FOCUS_TYPE] = ALERTS_FOCUS_PRIORITY;
+    configuration_map[CONTENT_FOCUS_TYPE] = CONTENT_FOCUS_PRIORITY;
+    printConfigurations();
+}
+
+FocusManager::~FocusManager()
+{
+}
+
+bool FocusManager::requestFocus(const std::string& type, const std::string& name, IFocusResourceListener* listener)
+{
+    if (listener == nullptr) {
+        nugu_error("The parameter(listener) is nullptr");
+        return false;
+    }
+
+    if (configuration_map.find(type) == configuration_map.end()) {
+        nugu_error("The focus[%s] is not exist in focus configuration", type.c_str());
+        return false;
+    }
+
+    FocusResource* activate_focus = nullptr;
+    // get current activated focus
+    if (focus_resource_ordered_map.begin() != focus_resource_ordered_map.end())
+        activate_focus = focus_resource_ordered_map.begin()->second.get();
+
+    int priority = configuration_map[type];
+    if (focus_resource_ordered_map.find(priority) == focus_resource_ordered_map.end()) {
+        // add new focus
+        focus_resource_ordered_map[priority] = std::make_shared<FocusResource>(type, name, priority, listener, this);
+    } else {
+        // update exist focus
+        FocusResource* exist_focus = focus_resource_ordered_map[priority].get();
+
+        if (exist_focus->name != name) {
+            // set previous focus's state to FocusState::NONE
+            exist_focus->setState(FocusState::NONE);
+
+            // update new focus information
+            exist_focus->name = name;
+            exist_focus->listener = listener;
+        }
+    }
+
+    // get request focus
+    FocusResource* request_focus = focus_resource_ordered_map[priority].get();
+
+    if (activate_focus == nullptr || activate_focus == request_focus) {
+        nugu_info("[%s - %s] - FOREGROUND (priority: %d)", request_focus->type.c_str(), request_focus->name.c_str(), request_focus->priority);
+        request_focus->setState(FocusState::FOREGROUND);
+    } else if (*request_focus < *activate_focus) {
+        nugu_info("[%s - %s] - BACKGROUND (priority: %d)", activate_focus->type.c_str(), activate_focus->name.c_str(), activate_focus->priority);
+        activate_focus->setState(FocusState::BACKGROUND);
+        nugu_info("[%s - %s] - FOREGROUND (priority: %d)", request_focus->type.c_str(), request_focus->name.c_str(), request_focus->priority);
+        request_focus->setState(FocusState::FOREGROUND);
+    } else {
+        nugu_info("[%s - %s] - BACKGROUND (priority: %d)", request_focus->type.c_str(), request_focus->name.c_str(), request_focus->priority);
+        request_focus->setState(FocusState::BACKGROUND);
+    }
+    return true;
+}
+
+bool FocusManager::releaseFocus(const std::string& type)
+{
+    if (configuration_map.find(type) == configuration_map.end()) {
+        nugu_error("The focus[%s] is not exist in focus configuration", type.c_str());
+        return false;
+    }
+
+    int priority = configuration_map[type];
+    if (focus_resource_ordered_map.find(priority) == focus_resource_ordered_map.end())
+        return true;
+
+    FocusResource* release_focus = focus_resource_ordered_map[priority].get();
+    nugu_info("[%s - %s] - NONE (priority: %d)", release_focus->type.c_str(), release_focus->name.c_str(), release_focus->priority);
+    release_focus->setState(FocusState::NONE);
+    focus_resource_ordered_map.erase(priority);
+
+    // focus resource is not exist anymore
+    if (focus_resource_ordered_map.size() == 0)
+        return true;
+
+    // activate highest focus
+    FocusResource* activate_focus = focus_resource_ordered_map.begin()->second.get();
+    nugu_info("[%s - %s] - FOREGROUND (priority: %d)", activate_focus->type.c_str(), activate_focus->name.c_str(), activate_focus->priority);
+    activate_focus->setState(FocusState::FOREGROUND);
+    return true;
+}
+
+void FocusManager::setConfigurations(std::vector<FocusConfiguration>& configurations)
+{
+    configuration_map.clear();
+
+    for (auto configuration : configurations)
+        configuration_map[configuration.type] = configuration.priority;
+
+    printConfigurations();
+}
+
+void FocusManager::stopAllFocus()
+{
+    for (auto& container : focus_resource_ordered_map) {
+        FocusResource* focus = container.second.get();
+        nugu_info("[%s - %s] - NONE (priority: %d)", focus->type.c_str(), focus->name.c_str(), focus->priority);
+        focus->setState(FocusState::NONE);
+    }
+    focus_resource_ordered_map.clear();
+}
+
+void FocusManager::stopForegroundFocus()
+{
+    if (focus_resource_ordered_map.size() == 0)
+        return;
+
+    FocusResource* activate_focus = focus_resource_ordered_map.begin()->second.get();
+    nugu_info("[%s - %s] - NONE (priority: %d)", activate_focus->type.c_str(), activate_focus->name.c_str(), activate_focus->priority);
+    activate_focus->setState(FocusState::NONE);
+    focus_resource_ordered_map.erase(activate_focus->priority);
+
+    if (focus_resource_ordered_map.size() == 0)
+        return;
+
+    activate_focus = focus_resource_ordered_map.begin()->second.get();
+    nugu_info("[%s - %s] - FOREGROUND (priority: %d)", activate_focus->type.c_str(), activate_focus->name.c_str(), activate_focus->priority);
+    activate_focus->setState(FocusState::FOREGROUND);
+}
+
+void FocusManager::addObserver(IFocusManagerObserver* observer)
+{
+    if (observer && std::find(observers.begin(), observers.end(), observer) == observers.end())
+        observers.emplace_back(observer);
+}
+
+void FocusManager::removeObserver(IFocusManagerObserver* observer)
+{
+    auto iterator = std::find(observers.begin(), observers.end(), observer);
+
+    if (iterator != observers.end())
+        observers.erase(iterator);
+}
+
+int FocusManager::getFocusResourcePriority(const std::string& type)
+{
+    int priority = -1;
+
+    if (configuration_map.find(type) != configuration_map.end())
+        priority = configuration_map[type];
+
+    return priority;
+}
+
+std::string FocusManager::getStateString(FocusState state)
+{
+    std::string name;
+
+    switch (state) {
+    case FocusState::NONE:
+        name = "NONE";
+        break;
+    case FocusState::FOREGROUND:
+        name = "FOREGROUND";
+        break;
+    case FocusState::BACKGROUND:
+        name = "BACKGROUND";
+        break;
+    }
+
+    return name;
+}
+
+void FocusManager::onFocusChanged(const std::string& type, const std::string& name, FocusState state)
+{
+    if (configuration_map.find(type) == configuration_map.end())
+        return;
+
+    if (observers.size() == 0)
+        return;
+
+    FocusConfiguration configuration;
+    configuration.type = type;
+    configuration.priority = configuration_map[type];
+
+    for (auto& observer : observers)
+        observer->onFocusChanged(configuration, state, name);
+}
+
+void FocusManager::printConfigurations()
+{
+    nugu_info("Focus Resource Configurtaion ==================");
+    for(auto configuration : configuration_map)
+        nugu_info("Resource - priority:%4d, type: %s", configuration.second, configuration.first.c_str());
+    nugu_info("===============================================");
+}
+
+} // NuguCore

--- a/src/core/focus_manager.hh
+++ b/src/core/focus_manager.hh
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NUGU_FOCUS_MANAGER_H__
+#define __NUGU_FOCUS_MANAGER_H__
+
+#include <algorithm>
+#include <map>
+#include <memory>
+
+#include "clientkit/focus_manager_interface.hh"
+
+namespace NuguCore {
+
+using namespace NuguClientKit;
+
+class IFocusResourceObserver {
+public:
+    virtual ~IFocusResourceObserver() = default;
+
+    virtual void onFocusChanged(const std::string& type, const std::string& name, FocusState state) = 0;
+};
+
+class FocusResource {
+public:
+    FocusResource(const std::string& type, const std::string& name, int priority, IFocusResourceListener* listener, IFocusResourceObserver* observer);
+    virtual ~FocusResource() = default;
+
+    void setState(FocusState state);
+
+    bool operator<(const FocusResource& resource);
+    bool operator>(const FocusResource& resource);
+
+public:
+    std::string type;
+    std::string name;
+    int priority;
+    FocusState state;
+    IFocusResourceListener* listener;
+    IFocusResourceObserver* observer;
+};
+
+class FocusManager : public IFocusManager,
+                     public IFocusResourceObserver {
+public:
+    FocusManager();
+    virtual ~FocusManager();
+
+    bool requestFocus(const std::string& type, const std::string& name, IFocusResourceListener* listener) override;
+    bool releaseFocus(const std::string& type) override;
+
+    void setConfigurations(std::vector<FocusConfiguration>& configurations) override;
+    void stopAllFocus() override;
+    void stopForegroundFocus() override;
+
+    std::string getStateString(FocusState state) override;
+
+    void addObserver(IFocusManagerObserver* observer) override;
+    void removeObserver(IFocusManagerObserver* observer) override;
+
+    void onFocusChanged(const std::string& type, const std::string& name, FocusState state) override;
+
+    int getFocusResourcePriority(const std::string& type);
+    void printConfigurations();
+
+private:
+    std::map<std::string, int> configuration_map;
+    std::map<int, std::shared_ptr<FocusResource>> focus_resource_ordered_map;
+    std::vector<IFocusManagerObserver*> observers;
+};
+
+} // NuguCore
+
+#endif /* __NUGU_FOCUS_MANAGER_H__ */

--- a/src/core/nugu_core_container.cc
+++ b/src/core/nugu_core_container.cc
@@ -86,6 +86,11 @@ ICapabilityHelper* NuguCoreContainer::getCapabilityHelper()
     return CapabilityHelper::getInstance();
 }
 
+IFocusManager* NuguCoreContainer::getFocusManager()
+{
+    return CapabilityManager::getInstance()->getFocusManager();
+}
+
 void NuguCoreContainer::setWakeupWord(const std::string& wakeup_word)
 {
     if (!wakeup_word.empty())

--- a/src/core/nugu_core_container.hh
+++ b/src/core/nugu_core_container.hh
@@ -34,8 +34,9 @@ public:
     ISpeechRecognizer* createSpeechRecognizer(const std::string& model_path = "", const EpdAttribute& epd_attr = {}) override;
     IMediaPlayer* createMediaPlayer() override;
     ITTSPlayer* createTTSPlayer() override;
-    ICapabilityHelper* getCapabilityHelper() override;
     INuguTimer* createNuguTimer() override;
+    ICapabilityHelper* getCapabilityHelper() override;
+    IFocusManager* getFocusManager() override;
 
     // wrapping CapabilityManager functions
     void setWakeupWord(const std::string& wakeup_word);

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -1,8 +1,11 @@
-SET(UNIT_TESTS test-core-nugu-timer)
+SET(UNIT_TESTS test-core-nugu-timer
+				test-core-focus-manager)
 
 # Add Compile Sources with Mock for test
 SET(test-core-nugu-timer-srcs test-core-nugu-timer-mock.cc
 								../../src/core/nugu_timer.cc)
+
+SET(test-core-focus-manager-srcs ../../src/core/focus_manager.cc)
 
 FOREACH(test ${UNIT_TESTS})
 	SET(SRC ${test}.cc)
@@ -15,7 +18,9 @@ FOREACH(test ${UNIT_TESTS})
 	TARGET_INCLUDE_DIRECTORIES(${test} PRIVATE
 		../../src/core
 		../../include)
-	TARGET_LINK_LIBRARIES(${test} ${pkgs_LDFLAGS})
+	TARGET_LINK_LIBRARIES(${test} ${pkgs_LDFLAGS}
+		-L${CMAKE_BINARY_DIR}/src -lnugu -lstdc++)
+	ADD_DEPENDENCIES(${test} libnugu)
 	ADD_TEST(${test} ${test})
 	SET_PROPERTY(TEST ${test} PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/src")
 ENDFOREACH(test)

--- a/tests/core/test-core-focus-manager.cc
+++ b/tests/core/test-core-focus-manager.cc
@@ -1,0 +1,414 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <glib.h>
+
+#include "focus_manager.hh"
+
+using namespace NuguCore;
+
+#define INVALID_FOCUS_NAME "Invalid"
+
+#define DIALOG_NAME "dialog"
+
+#define ANOTHER_DIALOG_NAME "another_dialog"
+
+#define COMMUNICATIONS_NAME "communications"
+
+#define ALERTS_NAME "alerts"
+
+#define CONTENT_NAME "content"
+
+#define REQUEST_FOCUS(resource, type, name) \
+    resource->requestFocus(type, name)
+
+#define RELEASE_FOCUS(resource, type) \
+    resource->releaseFocus(type)
+
+#define ASSERT_EXPECTED_STATE(resource, state) \
+    g_assert(resource->getState() == state);
+
+class FocusManagerObserver : public IFocusManagerObserver {
+public:
+    explicit FocusManagerObserver(IFocusManager* focus_manager)
+        : focus_manager_interface(focus_manager)
+    {
+    }
+    virtual ~FocusManagerObserver() = default;
+
+    void onFocusChanged(const FocusConfiguration& configuration, FocusState state, const std::string& name) override
+    {
+        std::string msg;
+
+        msg.append("==================================================\n[")
+            .append(configuration.type)
+            .append(" - ")
+            .append(name)
+            .append("] ")
+            .append(focus_manager_interface->getStateString(state))
+            .append(" (priority: ")
+            .append(std::to_string(configuration.priority))
+            .append(")\n==================================================");
+
+        std::cout << msg << std::endl;
+    }
+
+private:
+    IFocusManager* focus_manager_interface;
+};
+
+class TestFocusResorce : public IFocusResourceListener {
+public:
+    explicit TestFocusResorce(IFocusManager* focus_manager)
+        : focus_manager_interface(focus_manager)
+        , cur_state(FocusState::NONE)
+    {
+    }
+    virtual ~TestFocusResorce() = default;
+
+    bool requestFocus(const std::string& type, const std::string& name)
+    {
+        return focus_manager_interface->requestFocus(type, name, this);
+    }
+
+    bool releaseFocus(const std::string& type)
+    {
+        return focus_manager_interface->releaseFocus(type);
+    }
+
+    void stopAllFocus()
+    {
+        focus_manager_interface->stopAllFocus();
+    }
+
+    void stopForegroundFocus()
+    {
+        focus_manager_interface->stopForegroundFocus();
+    }
+
+    void onFocusChanged(FocusState state) override
+    {
+        cur_state = state;
+    }
+
+    FocusState getState()
+    {
+        return cur_state;
+    }
+
+private:
+    IFocusManager* focus_manager_interface;
+    FocusState cur_state;
+};
+
+typedef struct {
+    FocusManager* focus_manager;
+    FocusManagerObserver* focus_observer;
+    TestFocusResorce* dialog_resource;
+    TestFocusResorce* comm_resource;
+    TestFocusResorce* alert_resource;
+    TestFocusResorce* content_resource;
+    TestFocusResorce* another_dialog_resource;
+} ntimerFixture;
+
+static void setup(ntimerFixture* fixture, gconstpointer user_data)
+{
+    fixture->focus_manager = new FocusManager();
+    fixture->focus_observer = new FocusManagerObserver(fixture->focus_manager);
+    fixture->focus_manager->addObserver(fixture->focus_observer);
+
+    fixture->dialog_resource = new TestFocusResorce(fixture->focus_manager);
+    fixture->comm_resource = new TestFocusResorce(fixture->focus_manager);
+    fixture->alert_resource = new TestFocusResorce(fixture->focus_manager);
+    fixture->content_resource = new TestFocusResorce(fixture->focus_manager);
+    fixture->another_dialog_resource = new TestFocusResorce(fixture->focus_manager);
+
+    std::vector<FocusConfiguration> focus_configuration;
+
+    focus_configuration.push_back({ DIALOG_FOCUS_TYPE, DIALOG_FOCUS_PRIORITY });
+    focus_configuration.push_back({ COMMUNICATIONS_FOCUS_TYPE, COMMUNICATIONS_FOCUS_PRIORITY });
+    focus_configuration.push_back({ ALERTS_FOCUS_TYPE, ALERTS_FOCUS_PRIORITY });
+    focus_configuration.push_back({ CONTENT_FOCUS_TYPE, CONTENT_FOCUS_PRIORITY });
+    fixture->focus_manager->setConfigurations(focus_configuration);
+}
+
+static void teardown(ntimerFixture* fixture, gconstpointer user_data)
+{
+    delete fixture->focus_manager;
+    delete fixture->focus_observer;
+    delete fixture->dialog_resource;
+    delete fixture->comm_resource;
+    delete fixture->alert_resource;
+    delete fixture->content_resource;
+    delete fixture->another_dialog_resource;
+}
+
+#define G_TEST_ADD_FUNC(name, func) \
+    g_test_add(name, ntimerFixture, NULL, setup, func, teardown);
+
+static void test_focusmanager_configurations(ntimerFixture* fixture, gconstpointer ignored)
+{
+    FocusManager* focus_manager = fixture->focus_manager;
+    std::vector<FocusConfiguration> focus_configuration;
+
+    // Add Dialog Resource to FocusManager
+    focus_configuration.push_back({ DIALOG_FOCUS_TYPE, DIALOG_FOCUS_PRIORITY });
+    focus_manager->setConfigurations(focus_configuration);
+
+    g_assert(focus_manager->getFocusResourcePriority(DIALOG_FOCUS_TYPE) == DIALOG_FOCUS_PRIORITY);
+    g_assert(focus_manager->getFocusResourcePriority(COMMUNICATIONS_FOCUS_TYPE) == -1);
+
+    // Add Dialog Resource with higher priority and Communication Resource to FocusManager
+    focus_configuration.clear();
+    focus_configuration.push_back({ DIALOG_FOCUS_TYPE, DIALOG_FOCUS_PRIORITY + 100 });
+    focus_configuration.push_back({ COMMUNICATIONS_FOCUS_TYPE, COMMUNICATIONS_FOCUS_PRIORITY });
+    focus_manager->setConfigurations(focus_configuration);
+
+    g_assert(focus_manager->getFocusResourcePriority(DIALOG_FOCUS_TYPE) == (DIALOG_FOCUS_PRIORITY + 100));
+    g_assert(focus_manager->getFocusResourcePriority(COMMUNICATIONS_FOCUS_TYPE) == COMMUNICATIONS_FOCUS_PRIORITY);
+}
+
+static void test_focusmanager_request_resource_with_invalid_name(ntimerFixture* fixture, gconstpointer ignored)
+{
+    g_assert(!REQUEST_FOCUS(fixture->dialog_resource, INVALID_FOCUS_NAME, DIALOG_NAME));
+    ASSERT_EXPECTED_STATE(fixture->dialog_resource, FocusState::NONE);
+}
+
+static void test_focusmanager_request_resource_with_no_activate_resource(ntimerFixture* fixture, gconstpointer igresource)
+{
+    g_assert(REQUEST_FOCUS(fixture->dialog_resource, DIALOG_FOCUS_TYPE, DIALOG_NAME));
+    ASSERT_EXPECTED_STATE(fixture->dialog_resource, FocusState::FOREGROUND);
+}
+
+static void test_focusmanager_request_resource_with_higher_priority_resource(ntimerFixture* fixture, gconstpointer ignored)
+{
+    g_assert(REQUEST_FOCUS(fixture->dialog_resource, DIALOG_FOCUS_TYPE, DIALOG_NAME));
+    ASSERT_EXPECTED_STATE(fixture->dialog_resource, FocusState::FOREGROUND);
+
+    g_assert(REQUEST_FOCUS(fixture->content_resource, CONTENT_FOCUS_TYPE, CONTENT_NAME));
+    ASSERT_EXPECTED_STATE(fixture->content_resource, FocusState::BACKGROUND);
+}
+
+static void test_focusmanager_request_resource_with_lower_priority_resource(ntimerFixture* fixture, gconstpointer ignored)
+{
+    g_assert(REQUEST_FOCUS(fixture->content_resource, CONTENT_FOCUS_TYPE, CONTENT_NAME));
+    ASSERT_EXPECTED_STATE(fixture->content_resource, FocusState::FOREGROUND);
+
+    g_assert(REQUEST_FOCUS(fixture->dialog_resource, DIALOG_FOCUS_TYPE, DIALOG_NAME));
+    ASSERT_EXPECTED_STATE(fixture->content_resource, FocusState::BACKGROUND);
+    ASSERT_EXPECTED_STATE(fixture->dialog_resource, FocusState::FOREGROUND);
+}
+
+static void test_focusmanager_request_two_resources_with_highest_priority_resource(ntimerFixture* fixture, gconstpointer ignored)
+{
+    g_assert(REQUEST_FOCUS(fixture->dialog_resource, DIALOG_FOCUS_TYPE, DIALOG_NAME));
+    ASSERT_EXPECTED_STATE(fixture->dialog_resource, FocusState::FOREGROUND);
+
+    g_assert(REQUEST_FOCUS(fixture->alert_resource, ALERTS_FOCUS_TYPE, ALERTS_NAME));
+    ASSERT_EXPECTED_STATE(fixture->alert_resource, FocusState::BACKGROUND);
+
+    g_assert(REQUEST_FOCUS(fixture->content_resource, CONTENT_FOCUS_TYPE, CONTENT_NAME));
+    ASSERT_EXPECTED_STATE(fixture->content_resource, FocusState::BACKGROUND);
+}
+
+static void test_focusmanager_request_two_resources_with_medium_priority_resource(ntimerFixture* fixture, gconstpointer ignored)
+{
+    g_assert(REQUEST_FOCUS(fixture->alert_resource, ALERTS_FOCUS_TYPE, ALERTS_NAME));
+    ASSERT_EXPECTED_STATE(fixture->alert_resource, FocusState::FOREGROUND);
+
+    g_assert(REQUEST_FOCUS(fixture->dialog_resource, DIALOG_FOCUS_TYPE, DIALOG_NAME));
+    ASSERT_EXPECTED_STATE(fixture->alert_resource, FocusState::BACKGROUND);
+    ASSERT_EXPECTED_STATE(fixture->dialog_resource, FocusState::FOREGROUND);
+
+    g_assert(REQUEST_FOCUS(fixture->content_resource, CONTENT_FOCUS_TYPE, CONTENT_NAME));
+    ASSERT_EXPECTED_STATE(fixture->content_resource, FocusState::BACKGROUND);
+    ASSERT_EXPECTED_STATE(fixture->alert_resource, FocusState::BACKGROUND);
+    ASSERT_EXPECTED_STATE(fixture->dialog_resource, FocusState::FOREGROUND);
+}
+
+static void test_focusmanager_request_two_resources_with_lowest_priority_resource(ntimerFixture* fixture, gconstpointer ignored)
+{
+    g_assert(REQUEST_FOCUS(fixture->content_resource, CONTENT_FOCUS_TYPE, CONTENT_NAME));
+    ASSERT_EXPECTED_STATE(fixture->content_resource, FocusState::FOREGROUND);
+
+    g_assert(REQUEST_FOCUS(fixture->alert_resource, ALERTS_FOCUS_TYPE, ALERTS_NAME));
+    ASSERT_EXPECTED_STATE(fixture->content_resource, FocusState::BACKGROUND);
+    ASSERT_EXPECTED_STATE(fixture->alert_resource, FocusState::FOREGROUND);
+
+    g_assert(REQUEST_FOCUS(fixture->dialog_resource, DIALOG_FOCUS_TYPE, DIALOG_NAME));
+    ASSERT_EXPECTED_STATE(fixture->dialog_resource, FocusState::FOREGROUND);
+    ASSERT_EXPECTED_STATE(fixture->alert_resource, FocusState::BACKGROUND);
+    ASSERT_EXPECTED_STATE(fixture->content_resource, FocusState::BACKGROUND);
+}
+
+static void test_focusmanager_request_same_resource_on_foreground(ntimerFixture* fixture, gconstpointer ignored)
+{
+    g_assert(REQUEST_FOCUS(fixture->content_resource, CONTENT_FOCUS_TYPE, CONTENT_NAME));
+    ASSERT_EXPECTED_STATE(fixture->content_resource, FocusState::FOREGROUND);
+
+    g_assert(REQUEST_FOCUS(fixture->content_resource, CONTENT_FOCUS_TYPE, CONTENT_NAME));
+    ASSERT_EXPECTED_STATE(fixture->content_resource, FocusState::FOREGROUND);
+}
+
+static void test_focusmanager_request_same_resource_on_background(ntimerFixture* fixture, gconstpointer ignored)
+{
+    g_assert(REQUEST_FOCUS(fixture->dialog_resource, DIALOG_FOCUS_TYPE, DIALOG_NAME));
+    ASSERT_EXPECTED_STATE(fixture->dialog_resource, FocusState::FOREGROUND);
+
+    g_assert(REQUEST_FOCUS(fixture->content_resource, CONTENT_FOCUS_TYPE, CONTENT_NAME));
+    ASSERT_EXPECTED_STATE(fixture->content_resource, FocusState::BACKGROUND);
+
+    g_assert(REQUEST_FOCUS(fixture->content_resource, CONTENT_FOCUS_TYPE, CONTENT_NAME));
+    ASSERT_EXPECTED_STATE(fixture->content_resource, FocusState::BACKGROUND);
+}
+
+static void test_focusmanager_request_same_resource_with_other_name(ntimerFixture* fixture, gconstpointer ignored)
+{
+    g_assert(REQUEST_FOCUS(fixture->dialog_resource, DIALOG_FOCUS_TYPE, DIALOG_NAME));
+    ASSERT_EXPECTED_STATE(fixture->dialog_resource, FocusState::FOREGROUND);
+
+    g_assert(REQUEST_FOCUS(fixture->another_dialog_resource, DIALOG_FOCUS_TYPE, ANOTHER_DIALOG_NAME));
+    ASSERT_EXPECTED_STATE(fixture->dialog_resource, FocusState::NONE);
+    ASSERT_EXPECTED_STATE(fixture->another_dialog_resource, FocusState::FOREGROUND);
+}
+
+static void test_focusmanager_release_no_activity_resource(ntimerFixture* fixture, gconstpointer ignored)
+{
+    ASSERT_EXPECTED_STATE(fixture->dialog_resource, FocusState::NONE);
+    g_assert(RELEASE_FOCUS(fixture->dialog_resource, DIALOG_FOCUS_TYPE));
+}
+
+static void test_focusmanager_release_foreground_resource(ntimerFixture* fixture, gconstpointer ignored)
+{
+    g_assert(REQUEST_FOCUS(fixture->dialog_resource, DIALOG_FOCUS_TYPE, DIALOG_NAME));
+    ASSERT_EXPECTED_STATE(fixture->dialog_resource, FocusState::FOREGROUND);
+
+    g_assert(RELEASE_FOCUS(fixture->dialog_resource, DIALOG_FOCUS_TYPE));
+    ASSERT_EXPECTED_STATE(fixture->dialog_resource, FocusState::NONE);
+}
+
+static void test_focusmanager_release_foreground_resource_with_background_resource(ntimerFixture* fixture, gconstpointer ignored)
+{
+    g_assert(REQUEST_FOCUS(fixture->dialog_resource, DIALOG_FOCUS_TYPE, DIALOG_NAME));
+    ASSERT_EXPECTED_STATE(fixture->dialog_resource, FocusState::FOREGROUND);
+
+    g_assert(REQUEST_FOCUS(fixture->content_resource, CONTENT_FOCUS_TYPE, CONTENT_NAME));
+    ASSERT_EXPECTED_STATE(fixture->content_resource, FocusState::BACKGROUND);
+
+    g_assert(RELEASE_FOCUS(fixture->dialog_resource, DIALOG_FOCUS_TYPE));
+    ASSERT_EXPECTED_STATE(fixture->dialog_resource, FocusState::NONE);
+    ASSERT_EXPECTED_STATE(fixture->content_resource, FocusState::FOREGROUND);
+}
+
+static void test_focusmanager_release_background_resource(ntimerFixture* fixture, gconstpointer ignored)
+{
+    g_assert(REQUEST_FOCUS(fixture->dialog_resource, DIALOG_FOCUS_TYPE, DIALOG_NAME));
+    ASSERT_EXPECTED_STATE(fixture->dialog_resource, FocusState::FOREGROUND);
+
+    g_assert(REQUEST_FOCUS(fixture->content_resource, CONTENT_FOCUS_TYPE, CONTENT_NAME));
+    ASSERT_EXPECTED_STATE(fixture->content_resource, FocusState::BACKGROUND);
+
+    g_assert(RELEASE_FOCUS(fixture->content_resource, CONTENT_FOCUS_TYPE));
+    ASSERT_EXPECTED_STATE(fixture->dialog_resource, FocusState::FOREGROUND);
+    ASSERT_EXPECTED_STATE(fixture->content_resource, FocusState::NONE);
+}
+
+static void test_focusmanager_stop_foreground_focus_with_one_activity(ntimerFixture* fixture, gconstpointer ignored)
+{
+    g_assert(REQUEST_FOCUS(fixture->dialog_resource, DIALOG_FOCUS_TYPE, DIALOG_NAME));
+    ASSERT_EXPECTED_STATE(fixture->dialog_resource, FocusState::FOREGROUND);
+
+    fixture->dialog_resource->stopForegroundFocus();
+    ASSERT_EXPECTED_STATE(fixture->dialog_resource, FocusState::NONE);
+}
+
+static void test_focusmanager_stop_foreground_focus_with_one_activity_one_pending(ntimerFixture* fixture, gconstpointer ignored)
+{
+    g_assert(REQUEST_FOCUS(fixture->dialog_resource, DIALOG_FOCUS_TYPE, DIALOG_NAME));
+    ASSERT_EXPECTED_STATE(fixture->dialog_resource, FocusState::FOREGROUND);
+
+    g_assert(REQUEST_FOCUS(fixture->content_resource, CONTENT_FOCUS_TYPE, CONTENT_NAME));
+    ASSERT_EXPECTED_STATE(fixture->content_resource, FocusState::BACKGROUND);
+
+    fixture->dialog_resource->stopForegroundFocus();
+    ASSERT_EXPECTED_STATE(fixture->dialog_resource, FocusState::NONE);
+    ASSERT_EXPECTED_STATE(fixture->content_resource, FocusState::FOREGROUND);
+}
+
+static void test_focusmanager_stop_all_focus_with_no_resource(ntimerFixture* fixture, gconstpointer ignored)
+{
+    ASSERT_EXPECTED_STATE(fixture->dialog_resource, FocusState::NONE);
+    fixture->dialog_resource->stopAllFocus();
+}
+
+static void test_focusmanager_stop_all_focus_with_one_resource(ntimerFixture* fixture, gconstpointer ignored)
+{
+    g_assert(REQUEST_FOCUS(fixture->dialog_resource, DIALOG_FOCUS_TYPE, DIALOG_NAME));
+    ASSERT_EXPECTED_STATE(fixture->dialog_resource, FocusState::FOREGROUND);
+
+    fixture->dialog_resource->stopAllFocus();
+    ASSERT_EXPECTED_STATE(fixture->dialog_resource, FocusState::NONE);
+}
+
+static void test_focusmanager_stop_all_focus_with_two_resources(ntimerFixture* fixture, gconstpointer ignored)
+{
+    g_assert(REQUEST_FOCUS(fixture->dialog_resource, DIALOG_FOCUS_TYPE, DIALOG_NAME));
+    ASSERT_EXPECTED_STATE(fixture->dialog_resource, FocusState::FOREGROUND);
+
+    g_assert(REQUEST_FOCUS(fixture->content_resource, CONTENT_FOCUS_TYPE, CONTENT_NAME));
+    ASSERT_EXPECTED_STATE(fixture->content_resource, FocusState::BACKGROUND);
+
+    fixture->dialog_resource->stopAllFocus();
+    ASSERT_EXPECTED_STATE(fixture->dialog_resource, FocusState::NONE);
+    ASSERT_EXPECTED_STATE(fixture->content_resource, FocusState::NONE);
+}
+
+int main(int argc, char* argv[])
+{
+#if !GLIB_CHECK_VERSION(2, 36, 0)
+    g_type_init();
+#endif
+
+    g_test_init(&argc, &argv, (void*)NULL);
+    g_log_set_always_fatal((GLogLevelFlags)G_LOG_FATAL_MASK);
+
+    G_TEST_ADD_FUNC("/core/FocusManager/FocusConfigurations", test_focusmanager_configurations);
+    G_TEST_ADD_FUNC("/core/FocusManager/RequestResourceInvalidName", test_focusmanager_request_resource_with_invalid_name);
+    G_TEST_ADD_FUNC("/core/FocusManager/RequestResourceWithNoActivateResource", test_focusmanager_request_resource_with_no_activate_resource);
+    G_TEST_ADD_FUNC("/core/FocusManager/RequestResourceWithHigherPriorityResource", test_focusmanager_request_resource_with_higher_priority_resource);
+    G_TEST_ADD_FUNC("/core/FocusManager/RequestResourceWithLowerPriorityResource", test_focusmanager_request_resource_with_lower_priority_resource);
+    G_TEST_ADD_FUNC("/core/FocusManager/RequestTowResourcesWithHighestPriorityResource", test_focusmanager_request_two_resources_with_highest_priority_resource);
+    G_TEST_ADD_FUNC("/core/FocusManager/RequestTowResourcesWithMediumPriorityResource", test_focusmanager_request_two_resources_with_medium_priority_resource);
+    G_TEST_ADD_FUNC("/core/FocusManager/RequestTowResourcesWithLowestPriorityResource", test_focusmanager_request_two_resources_with_lowest_priority_resource);
+    G_TEST_ADD_FUNC("/core/FocusManager/RequestSameResourceOnForeground", test_focusmanager_request_same_resource_on_foreground);
+    G_TEST_ADD_FUNC("/core/FocusManager/RequestSameResourceOnBackground", test_focusmanager_request_same_resource_on_background);
+    G_TEST_ADD_FUNC("/core/FocusManager/RequestSameResourceWithOtherInterfaceName", test_focusmanager_request_same_resource_with_other_name);
+    G_TEST_ADD_FUNC("/core/FocusManager/ReleaseNoActivityResource", test_focusmanager_release_no_activity_resource);
+    G_TEST_ADD_FUNC("/core/FocusManager/ReleaseForegroundResource", test_focusmanager_release_foreground_resource);
+    G_TEST_ADD_FUNC("/core/FocusManager/ReleaseForegroundResourceWithBackgroundResource", test_focusmanager_release_foreground_resource_with_background_resource);
+    G_TEST_ADD_FUNC("/core/FocusManager/ReleaseBackgroundResource", test_focusmanager_release_background_resource);
+    G_TEST_ADD_FUNC("/core/FocusManager/StopForegroundFocusWithOneActivity", test_focusmanager_stop_foreground_focus_with_one_activity);
+    G_TEST_ADD_FUNC("/core/FocusManager/StopForegroundFocusWithOneActivityOnePending", test_focusmanager_stop_foreground_focus_with_one_activity_one_pending);
+    G_TEST_ADD_FUNC("/core/FocusManager/StopAllFocusWithNoResource", test_focusmanager_stop_all_focus_with_no_resource);
+    G_TEST_ADD_FUNC("/core/FocusManager/StopAllFocusWithOneResource", test_focusmanager_stop_all_focus_with_one_resource);
+    G_TEST_ADD_FUNC("/core/FocusManager/StopAllFocusWithTwoResources", test_focusmanager_stop_all_focus_with_two_resources);
+
+    return g_test_run();
+}


### PR DESCRIPTION
FocusManager replaces NuguFocus by extending the following features:

* Supports freely generate and inject focus channel
* Supports easily control for changing state of focus channel
* Supports monitoring of changing state of focus channel
* Remove internally hard-coded focus name and priority

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>