### PR TITLE
base: remove dirseq dependency from networkmanager

### DIFF
--- a/include/base/nugu_directive.h
+++ b/include/base/nugu_directive.h
@@ -175,7 +175,7 @@ int nugu_directive_set_active(NuguDirective *ndir, int flag);
  * @see nugu_directive_get_data_size()
  */
 int nugu_directive_add_data(NuguDirective *ndir, size_t length,
-			    unsigned char *data);
+			    const unsigned char *data);
 
 /**
  * @brief Set the attachment data status to "Received all data"

--- a/include/base/nugu_directive_sequencer.h
+++ b/include/base/nugu_directive_sequencer.h
@@ -94,6 +94,14 @@ NuguDirective *nugu_dirseq_find_by_msgid(const char *msgid);
 int nugu_dirseq_complete(NuguDirective *ndir);
 
 /**
+ * @brief Initialize the directive sequencer
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ */
+int nugu_dirseq_initialize(void);
+
+/**
  * @brief Remove all the directives in the sequencer
  */
 void nugu_dirseq_deinitialize(void);

--- a/include/base/nugu_network_manager.h
+++ b/include/base/nugu_network_manager.h
@@ -18,6 +18,7 @@
 #define __NUGU_NETWORK_MANAGER_H__
 
 #include <base/nugu_event.h>
+#include <base/nugu_directive.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -115,6 +116,21 @@ typedef void (*NuguNetworkManagerEventResponseCallback)(
 	const char *json, void *userdata);
 
 /**
+ * @brief Callback prototype for receiving directive.
+ * @see nugu_network_manager_set_directive_callback()
+ */
+typedef void (*NuguNetworkManagerDirectiveCallback)(NuguDirective *ndir,
+						    void *userdata);
+
+/**
+ * @brief Callback prototype for receiving directive attachment.
+ * @see nugu_network_manager_set_attachment_callback()
+ */
+typedef void (*NuguNetworkManagerAttachmentCallback)(
+	const char *parent_msg_id, int seq, int is_end, const char *media_type,
+	size_t length, const void *data, void *userdata);
+
+/**
  * @brief network protocols
  */
 enum nugu_network_protocol {
@@ -195,6 +211,28 @@ int nugu_network_manager_set_event_result_callback(
  */
 int nugu_network_manager_set_event_response_callback(
 	NuguNetworkManagerEventResponseCallback callback, void *userdata);
+
+/**
+ * @brief Set directive receive callback
+ * @param[in] callback callback function
+ * @param[in] userdata data to pass to the user callback
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ */
+int nugu_network_manager_set_directive_callback(
+	NuguNetworkManagerDirectiveCallback callback, void *userdata);
+
+/**
+ * @brief Set attachment of directive receive callback
+ * @param[in] callback callback function
+ * @param[in] userdata data to pass to the user callback
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ */
+int nugu_network_manager_set_attachment_callback(
+	NuguNetworkManagerAttachmentCallback callback, void *userdata);
 
 /**
  * @brief Set the current network status

--- a/src/base/nugu_directive.c
+++ b/src/base/nugu_directive.c
@@ -237,7 +237,7 @@ EXPORT_API const char *nugu_directive_peek_media_type(NuguDirective *ndir)
 }
 
 EXPORT_API int nugu_directive_add_data(NuguDirective *ndir, size_t length,
-				       unsigned char *data)
+				       const unsigned char *data)
 {
 	g_return_val_if_fail(ndir != NULL, -1);
 

--- a/src/clientkit/nugu_client_impl.cc
+++ b/src/clientkit/nugu_client_impl.cc
@@ -22,6 +22,7 @@
 #include "base/nugu_log.h"
 #include "base/nugu_plugin.h"
 #include "base/nugu_prof.h"
+#include "base/nugu_directive_sequencer.h"
 
 #include "nugu_client_impl.hh"
 
@@ -41,11 +42,15 @@ NuguClientImpl::NuguClientImpl()
 
     network_manager = std::unique_ptr<INetworkManager>(nugu_core_container->createNetworkManager());
     network_manager->addListener(nugu_core_container->getNetworkManagerListener());
+
+    nugu_dirseq_initialize();
 }
 
 NuguClientImpl::~NuguClientImpl()
 {
     nugu_core_container->destroyInstance();
+
+    nugu_dirseq_deinitialize();
 
     if (plugin_loaded)
         unloadPlugins();


### PR DESCRIPTION
For future refactoring, remove the directive sequencer dependency from
the network manager module.

Signed-off-by: Inho Oh <inho.oh@sk.com>