### PR TITLE
FocusManager: releaseFocus

### DIFF
--- a/include/clientkit/focus_manager_interface.hh
+++ b/include/clientkit/focus_manager_interface.hh
@@ -111,11 +111,12 @@ public:
     virtual bool requestFocus(const std::string& type, const std::string& name, IFocusResourceListener* listener) = 0;
 
     /**
-     * @brief Release Focus
+     * @brief Release focus
      * @param[in] type focus type
+     * @param[in] name focus name
      * @return if the release is success, then true otherwise false
      */
-    virtual bool releaseFocus(const std::string& type) = 0;
+    virtual bool releaseFocus(const std::string& type, const std::string& name) = 0;
 
     /**
      * @brief Set focus configurations.

--- a/src/core/focus_manager.cc
+++ b/src/core/focus_manager.cc
@@ -118,7 +118,7 @@ bool FocusManager::requestFocus(const std::string& type, const std::string& name
     return true;
 }
 
-bool FocusManager::releaseFocus(const std::string& type)
+bool FocusManager::releaseFocus(const std::string& type, const std::string& name)
 {
     if (configuration_map.find(type) == configuration_map.end()) {
         nugu_error("The focus[%s] is not exist in focus configuration", type.c_str());
@@ -130,6 +130,12 @@ bool FocusManager::releaseFocus(const std::string& type)
         return true;
 
     FocusResource* release_focus = focus_resource_ordered_map[priority].get();
+
+    if (name.size() && release_focus->name != name) {
+        nugu_dbg("already released focus [%s - %s]", release_focus->type.c_str(), name.c_str());
+        return true;
+    }
+
     nugu_info("[%s - %s] - NONE (priority: %d)", release_focus->type.c_str(), release_focus->name.c_str(), release_focus->priority);
     release_focus->setState(FocusState::NONE);
     focus_resource_ordered_map.erase(priority);

--- a/src/core/focus_manager.hh
+++ b/src/core/focus_manager.hh
@@ -60,7 +60,7 @@ public:
     virtual ~FocusManager();
 
     bool requestFocus(const std::string& type, const std::string& name, IFocusResourceListener* listener) override;
-    bool releaseFocus(const std::string& type) override;
+    bool releaseFocus(const std::string& type, const std::string& name) override;
 
     void setConfigurations(std::vector<FocusConfiguration>& configurations) override;
     void stopAllFocus() override;

--- a/tests/core/test-core-focus-manager.cc
+++ b/tests/core/test-core-focus-manager.cc
@@ -85,12 +85,13 @@ public:
 
     bool requestFocus(const std::string& type, const std::string& name)
     {
+        this->name = name;
         return focus_manager_interface->requestFocus(type, name, this);
     }
 
     bool releaseFocus(const std::string& type)
     {
-        return focus_manager_interface->releaseFocus(type);
+        return focus_manager_interface->releaseFocus(type, name);
     }
 
     void stopAllFocus()
@@ -116,6 +117,7 @@ public:
 private:
     IFocusManager* focus_manager_interface;
     FocusState cur_state;
+    std::string name;
 };
 
 typedef struct {
@@ -295,6 +297,19 @@ static void test_focusmanager_release_no_activity_resource(ntimerFixture* fixtur
     g_assert(RELEASE_FOCUS(fixture->dialog_resource, DIALOG_FOCUS_TYPE));
 }
 
+static void test_focusmanager_release_resource_with_other_name(ntimerFixture* fixture, gconstpointer ignored)
+{
+    g_assert(REQUEST_FOCUS(fixture->dialog_resource, DIALOG_FOCUS_TYPE, DIALOG_NAME));
+    ASSERT_EXPECTED_STATE(fixture->dialog_resource, FocusState::FOREGROUND);
+
+    g_assert(REQUEST_FOCUS(fixture->another_dialog_resource, DIALOG_FOCUS_TYPE, ANOTHER_DIALOG_NAME));
+    ASSERT_EXPECTED_STATE(fixture->dialog_resource, FocusState::NONE);
+    ASSERT_EXPECTED_STATE(fixture->another_dialog_resource, FocusState::FOREGROUND);
+
+    g_assert(RELEASE_FOCUS(fixture->dialog_resource, DIALOG_FOCUS_TYPE));
+    ASSERT_EXPECTED_STATE(fixture->another_dialog_resource, FocusState::FOREGROUND);
+}
+
 static void test_focusmanager_release_foreground_resource(ntimerFixture* fixture, gconstpointer ignored)
 {
     g_assert(REQUEST_FOCUS(fixture->dialog_resource, DIALOG_FOCUS_TYPE, DIALOG_NAME));
@@ -401,6 +416,7 @@ int main(int argc, char* argv[])
     G_TEST_ADD_FUNC("/core/FocusManager/RequestSameResourceOnBackground", test_focusmanager_request_same_resource_on_background);
     G_TEST_ADD_FUNC("/core/FocusManager/RequestSameResourceWithOtherInterfaceName", test_focusmanager_request_same_resource_with_other_name);
     G_TEST_ADD_FUNC("/core/FocusManager/ReleaseNoActivityResource", test_focusmanager_release_no_activity_resource);
+    G_TEST_ADD_FUNC("/core/FocusManager/ReleaseResourceWithOtherInterfaceName", test_focusmanager_release_resource_with_other_name);
     G_TEST_ADD_FUNC("/core/FocusManager/ReleaseForegroundResource", test_focusmanager_release_foreground_resource);
     G_TEST_ADD_FUNC("/core/FocusManager/ReleaseForegroundResourceWithBackgroundResource", test_focusmanager_release_foreground_resource_with_background_resource);
     G_TEST_ADD_FUNC("/core/FocusManager/ReleaseBackgroundResource", test_focusmanager_release_background_resource);


### PR DESCRIPTION
Add a `name` parameter to `releaseFocus` function for explicit
control focus.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>