### PR TITLE
ASR:update ASR focus release

### DIFF
--- a/include/clientkit/capability_helper_interface.hh
+++ b/include/clientkit/capability_helper_interface.hh
@@ -134,13 +134,6 @@ public:
     virtual std::string getWakeupWord() = 0;
 
     /**
-     * @brief Check the response directive group on the server to see if asr focus should be released
-     * @param[in] groups directive groups
-     * @param[in] dialog_id directive's dialog request id
-     */
-    virtual void checkAndReleaseASRFocus(const std::string& groups, const std::string& dialog_id) = 0;
-
-    /**
      * @brief Get property from CapabilityAgent.
      * @param[in] cap CapabilityAgent
      * @param[in] property property key

--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -324,9 +324,11 @@ void ASRAgent::receiveCommand(const std::string& from, const std::string& comman
 
     nugu_dbg("receive command(%s) from %s", command.c_str(), from.c_str());
 
-    if (!convert_command.compare("releasefocus"))
-        stopRecognition();
-    else if (!convert_command.compare("cancel"))
+    if (!convert_command.compare("releasefocus")) {
+        if (param.find("TTS") == std::string::npos && param.find("AudioPlayer") == std::string::npos)
+            stopRecognition();
+
+    } else if (!convert_command.compare("cancel"))
         cancelRecognition();
 }
 
@@ -754,4 +756,15 @@ void ASRAgent::syncSession()
 
     session_manager->activate(es_attr.dialog_id);
 }
+
+void ASRAgent::notifyEventResponse(const char* msg_id, const char* json, bool success)
+{
+    // release focus when there are no focus stealer like TTS, AudioPlayer
+    std::string data { json };
+
+    if (data.find("ASR") != std::string::npos && data.find("NotifyResult") != std::string::npos
+        && data.find("TTS") == std::string::npos && data.find("AudioPlayer") == std::string::npos)
+        stopRecognition();
+}
+
 } // NuguCapability

--- a/src/capability/asr_agent.hh
+++ b/src/capability/asr_agent.hh
@@ -85,6 +85,7 @@ public:
     ASRState getASRState();
     void setListeningId(const std::string& id);
     void syncSession();
+    void notifyEventResponse(const char* msg_id, const char* json, bool success) override;
 
 private:
     void sendEventCommon(const std::string& ename, EventResultCallback cb = nullptr);

--- a/src/capability/text_agent.cc
+++ b/src/capability/text_agent.cc
@@ -131,7 +131,7 @@ void TextAgent::receiveCommandAll(const std::string& command, const std::string&
         if (text_listener)
             text_listener->onState(cur_state, cur_dialog_id);
 
-        capa_helper->checkAndReleaseASRFocus(dir_groups, cur_dialog_id);
+        capa_helper->sendCommand("Text", "ASR", "releaseFocus", dir_groups);
         cur_dialog_id = "";
     }
 }

--- a/src/core/capability_helper.cc
+++ b/src/core/capability_helper.cc
@@ -92,11 +92,6 @@ std::string CapabilityHelper::getWakeupWord()
     return CapabilityManager::getInstance()->getWakeupWord();
 }
 
-void CapabilityHelper::checkAndReleaseASRFocus(const std::string& groups, const std::string& dialog_id)
-{
-    return CapabilityManager::getInstance()->checkAndReleaseASRFocus(groups, dialog_id);
-}
-
 void CapabilityHelper::getCapabilityProperty(const std::string& cap, const std::string& property, std::string& value)
 {
     CapabilityManager::getInstance()->getCapabilityProperty(cap, property, value);

--- a/src/core/capability_helper.hh
+++ b/src/core/capability_helper.hh
@@ -39,7 +39,6 @@ public:
     void suspendAll() override;
     void restoreAll() override;
     std::string getWakeupWord() override;
-    void checkAndReleaseASRFocus(const std::string& groups, const std::string& dialog_id) override;
     void getCapabilityProperty(const std::string& cap, const std::string& property, std::string& value) override;
     void getCapabilityProperties(const std::string& cap, const std::string& property, std::list<std::string>& values) override;
 

--- a/src/core/capability_manager.cc
+++ b/src/core/capability_manager.cc
@@ -279,17 +279,6 @@ std::string CapabilityManager::makeAllContextInfoStack()
     return writer.write(root);
 }
 
-void CapabilityManager::checkAndReleaseASRFocus(const std::string& groups, const std::string& dialog_id)
-{
-    nugu_info("Check ASR Focus Release: %s", groups.c_str());
-    if (groups.find("TTS") == std::string::npos && groups.find("AudioPlayer") == std::string::npos) {
-        nugu_info("ASR Focus Release by CapabilityManager");
-        sendCommand("CapabilityManager", "ASR", "releaseFocus", dialog_id);
-    } else {
-        nugu_info("ASR Focus Release by TTS or AudioPlayer");
-    }
-}
-
 void CapabilityManager::preprocessDirective(NuguDirective* ndir)
 {
     std::string name_space = nugu_directive_peek_namespace(ndir);
@@ -299,16 +288,6 @@ void CapabilityManager::preprocessDirective(NuguDirective* ndir)
     sendCommandAll("receive_directive_group", groups);
     sendCommandAll("directive_dialog_id", nugu_directive_peek_dialog_id(ndir));
     playsync_manager->setDirectiveGroups(groups);
-
-    if (name_space == "ASR" && dname == "NotifyResult") {
-        check_asr_focus_release = true;
-        asr_dialog_id = nugu_directive_peek_dialog_id(ndir);
-    } else {
-        if (check_asr_focus_release && asr_dialog_id == nugu_directive_peek_dialog_id(ndir)) {
-            checkAndReleaseASRFocus(groups, asr_dialog_id);
-            check_asr_focus_release = false;
-        }
-    }
 }
 
 bool CapabilityManager::isSupportDirectiveVersion(const std::string& version, ICapabilityInterface* cap)

--- a/src/core/capability_manager.hh
+++ b/src/core/capability_manager.hh
@@ -61,7 +61,6 @@ public:
     std::string makeAllContextInfo();
     std::string makeAllContextInfoStack();
 
-    void checkAndReleaseASRFocus(const std::string& groups, const std::string& dialog_id);
     void preprocessDirective(NuguDirective* ndir);
     bool isSupportDirectiveVersion(const std::string& version, ICapabilityInterface* cap);
 
@@ -90,8 +89,6 @@ private:
     std::unique_ptr<PlaySyncManager> playsync_manager = nullptr;
     std::unique_ptr<FocusManager> focus_manager = nullptr;
     std::unique_ptr<SessionManager> session_manager = nullptr;
-    bool check_asr_focus_release = false;
-    std::string asr_dialog_id;
 };
 
 } // NuguCore


### PR DESCRIPTION
It change the location of releasing the ASR focus from CapabilityManager
to ASRAgent when there are no existing stealable directive namespace
like TTS, AudioPlayer.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>