### PR TITLE
core: introduce a new DirectiveSequencer

### DIFF
--- a/include/base/nugu_directive_sequencer.h
+++ b/include/base/nugu_directive_sequencer.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __NUGU_DIRECTIVE_SEQUENCER_H__
-#define __NUGU_DIRECTIVE_SEQUENCER_H__
+#ifndef __NUGU_DIRECTIVE_SEQUENCER_LEGACY_H__
+#define __NUGU_DIRECTIVE_SEQUENCER_LEGACY_H__
 
 #include <base/nugu_directive.h>
 

--- a/include/clientkit/capability.hh
+++ b/include/clientkit/capability.hh
@@ -180,9 +180,15 @@ public:
      * @brief Add event name and directive name for referred dialog request id.
      * @param[in] ename event name
      * @param[in] dname directive name
-     * @return referred dialog request id
      */
     void addReferrerEvents(const std::string& ename, const std::string& dname);
+
+    /**
+     * @brief Add blocking policy for directive name
+     * @param[in] dname directive name
+     * @param[in] policy BlockingPolicy information
+     */
+    void addBlockingPolicy(const std::string& dname, BlockingPolicy policy);
 
     /**
      * @brief Get referred dialog request id.
@@ -352,6 +358,9 @@ protected:
 
     /** @brief ISessionManager instance for using session management */
     ISessionManager* session_manager = nullptr;
+
+    /** @brief IDirectiveSequencer instance for directive sequence management */
+    IDirectiveSequencer* directive_sequencer = nullptr;
 
     /** @brief SuspendPolicy variable for deciding suspend action (default:STOP) */
     SuspendPolicy suspend_policy = SuspendPolicy::STOP;

--- a/include/clientkit/capability_helper_interface.hh
+++ b/include/clientkit/capability_helper_interface.hh
@@ -24,6 +24,7 @@
 #include <clientkit/focus_manager_interface.hh>
 #include <clientkit/playsync_manager_interface.hh>
 #include <clientkit/session_manager_interface.hh>
+#include <clientkit/directive_sequencer_interface.hh>
 
 namespace NuguClientKit {
 /**
@@ -61,6 +62,12 @@ public:
      * @return ISessionManager instance
      */
     virtual ISessionManager* getSessionManager() = 0;
+
+     /**
+     * @brief Get IDirectiveSequencer instance
+     * @return IDirectiveSequencer instance
+     */
+    virtual IDirectiveSequencer* getDirectiveSequencer() = 0;
 
     /**
      * @brief Set Audio Recorder mute/unmute

--- a/include/clientkit/directive_sequencer_interface.hh
+++ b/include/clientkit/directive_sequencer_interface.hh
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NUGU_DIRECTIVE_SEQUENCER_INTERFACE_H__
+#define __NUGU_DIRECTIVE_SEQUENCER_INTERFACE_H__
+
+#include <base/nugu_directive.h>
+
+namespace NuguClientKit {
+
+/**
+ * @file directive_sequencer_interface.hh
+ * @defgroup DirectiveSequencerInterface DirectiveSequencerInterface
+ * @ingroup SDKNuguClientKit
+ * @brief Directive Sequencer Interface
+ *
+ * DirectiveSequencer delivers the directives received from the network to
+ * the CapabilityAgent according to the dialog-id and blocking policy.
+ *
+ * @{
+ */
+
+/**
+ * @brief BlockingMedium
+ */
+enum class BlockingMedium {
+    AUDIO = 0, /**< Audio related medium */
+    VISUAL = 1, /**< Visual related medium */
+    NONE = 2 /**< None medium */
+};
+
+/**
+ * @brief BlockingPolicy
+ */
+typedef struct {
+    BlockingMedium medium; /**< BlockingMedium */
+    bool isBlocking; /**< true: Blocking, false: Non-blocking */
+} BlockingPolicy;
+
+/**
+ * @brief IDirectiveSequencerListener
+ * @see IDirectiveSequencer
+ */
+class IDirectiveSequencerListener {
+public:
+    virtual ~IDirectiveSequencerListener() = default;
+
+    /**
+     * @brief Notify the directive to handle in advance
+     * @param[in] ndir NuguDirective object
+     * @return Stop propagation or not.
+     * @retval true The directive is handled. Stop propagating to other listeners.
+     * @retval false The directive is not handled.
+     */
+    virtual bool onPreHandleDirective(NuguDirective* ndir) = 0;
+
+    /**
+     * @brief Notify the directive to handle
+     * @param[in] ndir NuguDirective object
+     * @return Directive processing result
+     * @retval true The directives were handled normally.
+     * @retval false There was a problem with the directive processing.
+     */
+    virtual bool onHandleDirective(NuguDirective* ndir) = 0;
+};
+
+/**
+ * @brief IDirectiveSequencer
+ * @see IDirectiveSequencerListener
+ */
+class IDirectiveSequencer {
+public:
+    virtual ~IDirectiveSequencer() = default;
+
+    /**
+     * @brief Add the Listener object
+     * @param[in] name_space directive namespace
+     * @param[in] listener listener object
+     */
+    virtual void addListener(const std::string& name_space, IDirectiveSequencerListener* listener) = 0;
+
+    /**
+     * @brief Remove the Listener object
+     * @param[in] name_space directive namespace
+     * @param[in] listener listener object
+     */
+    virtual void removeListener(const std::string& name_space, IDirectiveSequencerListener* listener) = 0;
+
+    /**
+     * @brief Add the BlockingPolicy
+     * @param[in] name_space directive namespace
+     * @param[in] name directive name
+     * @param[in] policy BlockingPolicy
+     * @return Result of adding policy
+     * @retval true success
+     * @retval false failure
+     */
+    virtual bool addPolicy(const std::string& name_space, const std::string& name, BlockingPolicy policy) = 0;
+
+    /**
+     * @brief Get the BlockingPolicy for namespace.name
+     * @param[in] name_space directive namespace
+     * @param[in] name directive name
+     * @return BlockingPolicy
+     */
+    virtual BlockingPolicy getPolicy(const std::string& name_space, const std::string& name) = 0;
+
+    /**
+     * @brief Cancel all pending directives related to the dialog_id.
+     * The canceled directives are freed.
+     * @param[in] dialog_id dialog-request-id
+     * @return result
+     * @retval true success
+     * @retval false failure
+     */
+    virtual bool cancel(const std::string& dialog_id) = 0;
+
+    /**
+     * @brief Complete the blocking directive. The NuguDirective object will be destroyed.
+     * If there are pending directives, those directives will be processed at the next idle time.
+     * @param[in] ndir NuguDirective object
+     * @return result
+     * @retval true success
+     * @retval false failure
+     */
+    virtual bool complete(NuguDirective* ndir) = 0;
+
+    /**
+     * @brief Add new directive to sequencer
+     * @param[in] ndir NuguDirective object
+     * @return result
+     * @retval true success
+     * @retval false failure
+     */
+    virtual bool add(NuguDirective* ndir) = 0;
+};
+
+/**
+ * @}
+ */
+
+} // NuguClientKit
+
+#endif /* __NUGU_DIRECTIVE_SEQUENCER_INTERFACE_H__ */

--- a/include/clientkit/nugu_core_container_interface.hh
+++ b/include/clientkit/nugu_core_container_interface.hh
@@ -19,6 +19,7 @@
 
 #include <clientkit/capability_helper_interface.hh>
 #include <clientkit/focus_manager_interface.hh>
+#include <clientkit/directive_sequencer_interface.hh>
 #include <clientkit/media_player_interface.hh>
 #include <clientkit/network_manager_interface.hh>
 #include <clientkit/nugu_timer_interface.hh>
@@ -82,6 +83,11 @@ public:
      * @brief Get FocusManager instance
      */
     virtual IFocusManager* getFocusManager() = 0;
+
+    /**
+     * @brief Get DirectiveSequencer instance
+     */
+    virtual IDirectiveSequencer* getDirectiveSequencer() = 0;
 };
 
 /**

--- a/src/clientkit/capability.cc
+++ b/src/clientkit/capability.cc
@@ -147,9 +147,11 @@ void Capability::setNuguCoreContainer(INuguCoreContainer* core_container)
 {
     this->core_container = core_container;
     capa_helper = core_container->getCapabilityHelper();
+
     playsync_manager = capa_helper->getPlaySyncManager();
     focus_manager = capa_helper->getFocusManager();
     session_manager = capa_helper->getSessionManager();
+    directive_sequencer = capa_helper->getDirectiveSequencer();
 }
 
 void Capability::initialize()
@@ -209,6 +211,16 @@ void Capability::notifyEventResponse(const char* msg_id, const char* json, bool 
 void Capability::addReferrerEvents(const std::string& ename, const std::string& dname)
 {
     pimpl->referrer_events[ename] = dname;
+}
+
+void Capability::addBlockingPolicy(const std::string& dname, BlockingPolicy policy)
+{
+    if (directive_sequencer == nullptr) {
+        nugu_error("directive sequencer is nullptr");
+        return;
+    }
+
+    directive_sequencer->addPolicy(pimpl->cname, dname, policy);
 }
 
 std::string Capability::getReferrerDialogRequestId(const std::string& ename)

--- a/src/core/capability_helper.cc
+++ b/src/core/capability_helper.cc
@@ -62,6 +62,11 @@ ISessionManager* CapabilityHelper::getSessionManager()
     return CapabilityManager::getInstance()->getSessionManager();
 }
 
+IDirectiveSequencer* CapabilityHelper::getDirectiveSequencer()
+{
+    return CapabilityManager::getInstance()->getDirectiveSequencer();
+}
+
 bool CapabilityHelper::setMute(bool mute)
 {
     return AudioRecorderManager::getInstance()->setMute(mute);

--- a/src/core/capability_helper.hh
+++ b/src/core/capability_helper.hh
@@ -32,6 +32,7 @@ public:
     IPlaySyncManager* getPlaySyncManager() override;
     IFocusManager* getFocusManager() override;
     ISessionManager* getSessionManager() override;
+    IDirectiveSequencer* getDirectiveSequencer() override;
 
     bool setMute(bool mute) override;
     void sendCommand(const std::string& from, const std::string& to, const std::string& command, const std::string& param) override;

--- a/src/core/capability_manager.hh
+++ b/src/core/capability_manager.hh
@@ -26,10 +26,12 @@
 #include "focus_manager.hh"
 #include "playsync_manager.hh"
 #include "session_manager.hh"
+#include "directive_sequencer.hh"
 
 namespace NuguCore {
 
-class CapabilityManager : public INetworkManagerListener {
+class CapabilityManager : public INetworkManagerListener,
+                          public IDirectiveSequencerListener {
 private:
     CapabilityManager();
     virtual ~CapabilityManager();
@@ -41,6 +43,7 @@ public:
     PlaySyncManager* getPlaySyncManager();
     FocusManager* getFocusManager();
     SessionManager* getSessionManager();
+    DirectiveSequencer* getDirectiveSequencer();
 
     static NuguDirseqReturn dirseqCallback(NuguDirective* ndir, void* userdata);
 
@@ -70,6 +73,9 @@ public:
     void suspendAll();
     void restoreAll();
 
+    bool onPreHandleDirective(NuguDirective* ndir) override;
+    bool onHandleDirective(NuguDirective* ndir) override;
+
 private:
     ICapabilityInterface* findCapability(const std::string& cname);
 
@@ -81,6 +87,7 @@ private:
     std::unique_ptr<PlaySyncManager> playsync_manager = nullptr;
     std::unique_ptr<FocusManager> focus_manager = nullptr;
     std::unique_ptr<SessionManager> session_manager = nullptr;
+    std::unique_ptr<DirectiveSequencer> directive_sequencer = nullptr;
 };
 
 } // NuguCore

--- a/src/core/directive_sequencer.cc
+++ b/src/core/directive_sequencer.cc
@@ -1,0 +1,488 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+
+#include "base/nugu_log.h"
+#include "base/nugu_network_manager.h"
+#include "base/nugu_prof.h"
+
+#include "directive_sequencer.hh"
+
+namespace NuguCore {
+
+static void dump_policies(const DirectiveSequencer::BlockingPolicyMap& m)
+{
+    if (m.size() == 0) {
+        nugu_dbg("Empty blocking policy");
+        return;
+    }
+
+    nugu_info("--[BlockingPolicy]--");
+
+    for (auto& item : m) {
+        nugu_dbg("\tNamespace: %s", item.first.c_str());
+
+        for (auto& policy : item.second) {
+            nugu_dbg("\t\tName: %s, Medium: %d, Blocking: %d", policy.first.c_str(),
+                policy.second.medium, policy.second.isBlocking);
+        }
+    }
+}
+
+static void dump_dialog_queue(const DirectiveSequencer::DialogQueueMap& audio, const DirectiveSequencer::DialogQueueMap& visual)
+{
+    if (audio.size() == 0) {
+        nugu_dbg("Empty DialogQueue for Medium::AUDIO");
+    } else {
+        nugu_info("--[DialogQueue for Medium::AUDIO]--");
+
+        for (auto& queue : audio) {
+            nugu_dbg("\tDialog-id: '%s'", queue.first.c_str());
+            for (auto& ndir : queue.second) {
+                nugu_dbg("\t\t%s.%s", nugu_directive_peek_namespace(ndir),
+                    nugu_directive_peek_name(ndir));
+            }
+        }
+    }
+
+    if (visual.size() == 0) {
+        nugu_dbg("Empty DialogQueue for Medium::VISUAL");
+    } else {
+        nugu_info("--[DialogQueue for Medium::VISUAL]--");
+
+        for (auto& queue : visual) {
+            nugu_dbg("\tDialog-id: '%s'", queue.first.c_str());
+            for (auto& ndir : queue.second) {
+                nugu_dbg("\t\t%s.%s", nugu_directive_peek_namespace(ndir),
+                    nugu_directive_peek_name(ndir));
+            }
+        }
+    }
+}
+
+static void dump_msgid(const std::map<std::string, NuguDirective*>& m)
+{
+    if (m.size() == 0) {
+        nugu_dbg("Empty msgid lookup table");
+        return;
+    }
+
+    nugu_info("--[msgid lookup table]--");
+
+    for (auto& ndir : m) {
+        nugu_dbg("\tMessage-id(%s): %s.%s dialog_id(%s)", ndir.first.c_str(),
+            nugu_directive_peek_namespace(ndir.second),
+            nugu_directive_peek_name(ndir.second),
+            nugu_directive_peek_dialog_id(ndir.second));
+    }
+}
+
+DirectiveSequencer::DirectiveSequencer()
+    : idler_src(0)
+{
+    nugu_network_manager_set_directive_callback(onDirective, this);
+    nugu_network_manager_set_attachment_callback(onAttachment, this);
+}
+
+DirectiveSequencer::~DirectiveSequencer()
+{
+    /* Cancel the pending idler */
+    if (idler_src != 0)
+        g_source_remove(idler_src);
+
+    /* Remove scheduled(but not yet handled) directives */
+    for (auto& ndir : scheduled_list) {
+        nugu_directive_unref(ndir);
+    }
+
+    dump_policies(policy_map);
+    dump_dialog_queue(audio_map, visual_map);
+    dump_msgid(msgid_directive_map);
+
+    nugu_network_manager_set_directive_callback(NULL, NULL);
+    nugu_network_manager_set_attachment_callback(NULL, NULL);
+}
+
+/* Callback by network-manager */
+void DirectiveSequencer::onDirective(NuguDirective* ndir, void* userdata)
+{
+    DirectiveSequencer* sequencer = static_cast<DirectiveSequencer*>(userdata);
+
+    if (sequencer->add(ndir) == false)
+        nugu_directive_unref(ndir);
+}
+
+/* Callback by network-manager */
+void DirectiveSequencer::onAttachment(const char* parent_msg_id, int seq,
+    int is_end, const char* media_type, size_t length,
+    const void* data, void* userdata)
+{
+    DirectiveSequencer* sequencer = static_cast<DirectiveSequencer*>(userdata);
+    NuguDirective* ndir;
+    DirectiveSequencer::MsgidDirectiveMap::const_iterator iter;
+
+    iter = sequencer->msgid_directive_map.find(parent_msg_id);
+    if (iter == sequencer->msgid_directive_map.end()) {
+        nugu_error("can't find directive for attachment parent_message_id('%s')", parent_msg_id);
+        return;
+    }
+
+    ndir = iter->second;
+    if (!ndir) {
+        nugu_error("internal error: invalid directive");
+        return;
+    }
+
+    if (seq == 0)
+        nugu_prof_mark_data(NUGU_PROF_TYPE_TTS_FIRST_ATTACHMENT,
+            nugu_directive_peek_dialog_id(ndir),
+            nugu_directive_peek_msg_id(ndir), NULL);
+
+    if (is_end) {
+        nugu_prof_mark_data(NUGU_PROF_TYPE_TTS_LAST_ATTACHMENT,
+            nugu_directive_peek_dialog_id(ndir),
+            nugu_directive_peek_msg_id(ndir), NULL);
+
+        nugu_directive_close_data(ndir);
+    }
+
+    nugu_directive_set_media_type(ndir, media_type);
+    nugu_directive_add_data(ndir, length, (unsigned char*)data);
+}
+
+gboolean DirectiveSequencer::onNext(gpointer userdata)
+{
+    DirectiveSequencer* sequencer = static_cast<DirectiveSequencer*>(userdata);
+
+    nugu_dbg("idle callback: process next directives");
+
+    for (auto& ndir : sequencer->scheduled_list)
+        sequencer->handleDirective(ndir);
+
+    sequencer->idler_src = 0;
+    sequencer->scheduled_list.clear();
+
+    return FALSE;
+}
+
+bool DirectiveSequencer::complete(NuguDirective* ndir)
+{
+    const char* name_space = nugu_directive_peek_namespace(ndir);
+    const char* name = nugu_directive_peek_name(ndir);
+    const char* msg_id = nugu_directive_peek_msg_id(ndir);
+
+    /* Remove from lookup table */
+    DirectiveSequencer::MsgidDirectiveMap::const_iterator msgid_iter = msgid_directive_map.find(msg_id);
+    if (msgid_iter != msgid_directive_map.end())
+        msgid_directive_map.erase(msgid_iter);
+
+    BlockingPolicy policy = getPolicy(name_space, name);
+
+    nugu_dbg("directive completed: '%s.%s' (medium: %d, isBlocking: %d)",
+        name_space, name, policy.medium, policy.isBlocking);
+
+    DirectiveSequencer::DialogQueueMap* qmap = nullptr;
+
+    if (policy.medium == BlockingMedium::NONE) {
+        /* NONE type does not need to check the queue */
+        nugu_directive_unref(ndir);
+        return true;
+    } else if (policy.medium == BlockingMedium::AUDIO) {
+        qmap = &audio_map;
+    } else if (policy.medium == BlockingMedium::VISUAL) {
+        qmap = &visual_map;
+    }
+
+    const char* dialog_id = nugu_directive_peek_dialog_id(ndir);
+    DirectiveSequencer::DialogQueueMap::iterator iter = qmap->find(dialog_id);
+
+    /* There is no queue for the dialog */
+    if (iter == qmap->end()) {
+        nugu_directive_unref(ndir);
+        return true;
+    }
+
+    /* The directive does not match the first entry in the queue. */
+    if (iter->second.front() != ndir) {
+        nugu_error("not yet handled blocking directive(%s)", dialog_id);
+        return false;
+    }
+
+    /* Remove the blocking directive from the queue */
+    iter->second.pop_front();
+
+    dump_dialog_queue(audio_map, visual_map);
+
+    /* The queue corresponding to the dialog is empty */
+    if (iter->second.size() == 0) {
+        nugu_dbg("no pending directives. remove the dialog(%s) from map", dialog_id);
+        qmap->erase(dialog_id);
+        nugu_directive_unref(ndir);
+        return true;
+    }
+
+    nugu_directive_unref(ndir);
+
+    /* Add next directive to scheduled list to handle at next idle time */
+    scheduled_list.push_back(iter->second.front());
+
+    if (idler_src == 0)
+        idler_src = g_idle_add(onNext, this);
+
+    return true;
+}
+
+bool DirectiveSequencer::preHandleDirective(NuguDirective* ndir)
+{
+    const char* name_space = nugu_directive_peek_namespace(ndir);
+
+    for (auto& listener : listeners_map[name_space]) {
+        if (listener->onPreHandleDirective(ndir) == true) {
+            nugu_info("The '%s.%s' directive pre-handled", name_space,
+                nugu_directive_peek_name(ndir));
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void DirectiveSequencer::handleDirective(NuguDirective* ndir)
+{
+    const char* name_space = nugu_directive_peek_namespace(ndir);
+    const char* name = nugu_directive_peek_name(ndir);
+
+    nugu_dbg("process the directive '%s.%s'", name_space, name);
+    nugu_directive_set_active(ndir, 1);
+
+    for (auto& listener : listeners_map[name_space]) {
+        if (listener->onHandleDirective(ndir) == false) {
+            nugu_error("fail to handle '%s.%s' directive", name_space, name);
+            complete(ndir);
+            return;
+        }
+    }
+}
+
+bool DirectiveSequencer::add(NuguDirective* ndir)
+{
+    if (ndir == nullptr) {
+        nugu_error("ndir is NULL");
+        return false;
+    }
+
+    const char* name_space = nugu_directive_peek_namespace(ndir);
+    const char* name = nugu_directive_peek_name(ndir);
+
+    if (listeners_map.find(name_space) == listeners_map.end()) {
+        nugu_error("can't find '%s' capability agent", name_space);
+        return false;
+    }
+
+    BlockingPolicy policy = getPolicy(name_space, name);
+
+    nugu_dbg("receive '%s.%s' directive (medium: %d, isBlocking: %s)",
+        name_space, name, policy.medium,
+        (policy.isBlocking == true) ? "True" : "False");
+
+    /* Stop propagation if the directive was pre-processed */
+    if (preHandleDirective(ndir))
+        return true;
+
+    /**
+     * Add the directive to the lookup table to quickly find the corresponding
+     * directive when receiving an attachment.
+     */
+    msgid_directive_map[nugu_directive_peek_msg_id(ndir)] = ndir;
+
+    DialogQueueMap* qmap = nullptr;
+
+    if (policy.medium == BlockingMedium::NONE) {
+        nugu_dbg("BlockingMedium::NONE type - handle immediately");
+        handleDirective(ndir);
+        return true;
+    } else if (policy.medium == BlockingMedium::AUDIO) {
+        qmap = &audio_map;
+    } else if (policy.medium == BlockingMedium::VISUAL) {
+        qmap = &visual_map;
+    }
+
+    const char* dialog_id = nugu_directive_peek_dialog_id(ndir);
+
+    DialogQueueMap::iterator iter = qmap->find(dialog_id);
+
+    /* There are already blocking directive in the queue */
+    if (iter != qmap->end()) {
+        nugu_dbg("push '%s.%s' to queue due to the previous blocking directive.", name_space, name);
+        iter->second.push_back(ndir);
+        dump_dialog_queue(audio_map, visual_map);
+        return true;
+    }
+
+    nugu_dbg("Handle the directive immediately due to empty queue");
+
+    if (policy.isBlocking) {
+        nugu_dbg("push '%s.%s' to queue due to blocking policy", name_space, name);
+        (*qmap)[dialog_id].push_back(ndir);
+    }
+
+    dump_dialog_queue(audio_map, visual_map);
+
+    handleDirective(ndir);
+
+    return true;
+}
+
+void DirectiveSequencer::addListener(const std::string& name_space,
+    IDirectiveSequencerListener* listener)
+{
+    if (listener == nullptr)
+        return;
+
+    auto iterator = listeners_map.find(name_space);
+    if (iterator == listeners_map.end()) {
+        listeners_map[name_space].push_back(listener);
+    } else {
+        if (std::find(iterator->second.begin(), iterator->second.end(), listener) == iterator->second.end()) {
+            iterator->second.push_back(listener);
+        }
+    }
+}
+
+void DirectiveSequencer::removeListener(const std::string& name_space,
+    IDirectiveSequencerListener* listener)
+{
+    if (listener == nullptr)
+        return;
+
+    auto iterator = listeners_map.find(name_space);
+    if (iterator == listeners_map.end()) {
+        nugu_error("can't find the namespace '%s'", name_space.c_str());
+        return;
+    }
+
+    auto listener_iter = std::find(iterator->second.begin(), iterator->second.end(), listener);
+    if (listener_iter == iterator->second.end()) {
+        nugu_error("can't find the listener %p", listener);
+        return;
+    }
+
+    iterator->second.erase(listener_iter);
+
+    if (listeners_map[name_space].begin() == listeners_map[name_space].end())
+        listeners_map.erase(name_space);
+}
+
+bool DirectiveSequencer::addPolicy(const std::string& name_space,
+    const std::string& name, BlockingPolicy policy)
+{
+    BlockingPolicyMap::const_iterator iter = policy_map.find(name_space);
+    if (iter != policy_map.end()) {
+        std::map<std::string, BlockingPolicy>::const_iterator j = iter->second.find(name);
+        if (j != iter->second.end()) {
+            nugu_error("'%s.%s' policy already exist", name_space.c_str(), name.c_str());
+            return false;
+        }
+    }
+
+    policy_map[name_space].insert(std::make_pair(name, policy));
+
+    nugu_dbg("add policy: '%s.%s' medium=%d, blocking=%d",
+        name_space.c_str(), name.c_str(), policy.medium, policy.isBlocking);
+
+    return true;
+}
+
+BlockingPolicy DirectiveSequencer::getPolicy(const std::string& name_space,
+    const std::string& name)
+{
+    BlockingPolicy default_policy = { BlockingMedium::NONE, false };
+
+    BlockingPolicyMap::const_iterator iter = policy_map.find(name_space);
+    if (iter == policy_map.end())
+        return default_policy;
+
+    std::map<std::string, BlockingPolicy>::const_iterator j = iter->second.find(name);
+    if (j == iter->second.end())
+        return default_policy;
+
+    return j->second;
+}
+
+bool DirectiveSequencer::cancel(const std::string& dialog_id)
+{
+    DialogQueueMap::iterator audio_iter;
+    DialogQueueMap::iterator visual_iter;
+    DirectiveSequencer::MsgidDirectiveMap::const_iterator msgid_iter;
+
+    nugu_dbg("cancel all directives for dialog_id(%s)", dialog_id.c_str());
+
+    /* remove directive from scheduled list */
+    auto new_end = std::remove_if(scheduled_list.begin(), scheduled_list.end(),
+        [dialog_id](NuguDirective* ndir) {
+            return (dialog_id.compare(nugu_directive_peek_dialog_id(ndir)) == 0);
+        });
+    scheduled_list.erase(new_end, scheduled_list.end());
+
+    audio_iter = audio_map.find(dialog_id);
+    visual_iter = visual_map.find(dialog_id);
+
+    if (audio_iter == audio_map.end() && visual_iter == visual_map.end()) {
+        nugu_error("can't find pending directives for dialog_id(%s)", dialog_id.c_str());
+        return true;
+    }
+
+    dump_msgid(msgid_directive_map);
+
+    /* remove audio queue */
+    if (audio_iter != audio_map.end()) {
+        for (auto& ndir : audio_iter->second) {
+            /* Remove from lookup table */
+            msgid_iter = msgid_directive_map.find(nugu_directive_peek_msg_id(ndir));
+            if (msgid_iter != msgid_directive_map.end())
+                msgid_directive_map.erase(msgid_iter);
+
+            /* Destroy the directive */
+            nugu_directive_unref(ndir);
+        }
+
+        /* Clear the queue */
+        audio_iter->second.clear();
+    }
+
+    /* remove visual queue */
+    if (visual_iter != visual_map.end()) {
+        for (auto& ndir : visual_iter->second) {
+            /* Remove from lookup table */
+            msgid_iter = msgid_directive_map.find(nugu_directive_peek_msg_id(ndir));
+            if (msgid_iter != msgid_directive_map.end())
+                msgid_directive_map.erase(msgid_iter);
+
+            /* Destroy the directive */
+            nugu_directive_unref(ndir);
+        }
+
+        /* Clear the queue */
+        visual_iter->second.clear();
+    }
+
+    dump_msgid(msgid_directive_map);
+
+    return true;
+}
+
+}

--- a/src/core/directive_sequencer.hh
+++ b/src/core/directive_sequencer.hh
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NUGU_DIRECTIVE_SEQUENCER_H__
+#define __NUGU_DIRECTIVE_SEQUENCER_H__
+
+#include <deque>
+#include <map>
+#include <vector>
+
+#include <glib.h>
+
+#include "clientkit/directive_sequencer_interface.hh"
+
+namespace NuguCore {
+
+using namespace NuguClientKit;
+
+class DirectiveSequencer : public IDirectiveSequencer {
+
+public:
+    DirectiveSequencer();
+    virtual ~DirectiveSequencer();
+
+    void addListener(const std::string& name_space, IDirectiveSequencerListener* listener) override;
+    void removeListener(const std::string& name_space, IDirectiveSequencerListener* listener) override;
+
+    bool addPolicy(const std::string& name_space, const std::string& name, BlockingPolicy policy) override;
+    BlockingPolicy getPolicy(const std::string& name_space, const std::string& name) override;
+
+    bool cancel(const std::string& dialog_id) override;
+    bool complete(NuguDirective* ndir) override;
+    bool add(NuguDirective* ndir) override;
+
+    using BlockingPolicyMap = std::map<std::string, std::map<std::string, BlockingPolicy>>;
+    using DialogQueueMap = std::map<std::string, std::deque<NuguDirective*>>;
+    using MsgidDirectiveMap = std::map<std::string, NuguDirective*>;
+
+private:
+    /**
+     * ["namespace"] = [
+     *   "name1" = BlockingPolicy,
+     *   "name2" = BlockingPolicy
+     * ]
+     */
+    BlockingPolicyMap policy_map;
+
+    /**
+     * ["namespace"] = IDirectiveSequencerListener*
+     */
+    std::map<std::string, std::vector<IDirectiveSequencerListener*>> listeners_map;
+
+    /**
+     * Lookup table for directive searching when receive an attachment
+     * ["message-id"] = NuguDirective*
+     */
+    MsgidDirectiveMap msgid_directive_map;
+
+    /**
+     * Pending directive queue for dialog-id
+     *   audio_map["dialog-id-a"] = [
+     *     directive-1(block), directive-2(non-block)
+     *   ]
+     *   audio_map["dialog-id-b"] = [ directive-4(block) ]
+     *   visual_map["dialog-id-a"] = [ directive-3(block) ]
+     *   visual_map["dialog-id-b"] = []
+     */
+    DialogQueueMap audio_map;
+    DialogQueueMap visual_map;
+
+    /**
+     * Scheduled directive lists to handle in next idle time
+     */
+    std::vector<NuguDirective*> scheduled_list;
+    guint idler_src;
+
+    bool preHandleDirective(NuguDirective* ndir);
+    void handleDirective(NuguDirective* ndir);
+
+    /* Network manager callback */
+    static void onDirective(NuguDirective* ndir, void* userdata);
+    static void onAttachment(const char* parent_msg_id, int seq, int is_end,
+        const char* media_type, size_t length,
+        const void* data, void* userdata);
+
+    /* GMainLoop idle callback */
+    static gboolean onNext(gpointer userdata);
+};
+
+} // NuguCore
+
+#endif /* __NUGU_DIRECTIVE_SEQUENCER_H__ */

--- a/src/core/nugu_core_container.cc
+++ b/src/core/nugu_core_container.cc
@@ -91,6 +91,11 @@ IFocusManager* NuguCoreContainer::getFocusManager()
     return CapabilityManager::getInstance()->getFocusManager();
 }
 
+IDirectiveSequencer* NuguCoreContainer::getDirectiveSequencer()
+{
+    return CapabilityManager::getInstance()->getDirectiveSequencer();
+}
+
 void NuguCoreContainer::setWakeupWord(const std::string& wakeup_word)
 {
     if (!wakeup_word.empty())

--- a/src/core/nugu_core_container.hh
+++ b/src/core/nugu_core_container.hh
@@ -37,6 +37,7 @@ public:
     INuguTimer* createNuguTimer() override;
     ICapabilityHelper* getCapabilityHelper() override;
     IFocusManager* getFocusManager() override;
+    IDirectiveSequencer* getDirectiveSequencer() override;
 
     // wrapping CapabilityManager functions
     void setWakeupWord(const std::string& wakeup_word);

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -1,10 +1,12 @@
-SET(UNIT_TESTS test-core-nugu-timer
-				test-core-focus-manager)
+SET(UNIT_TESTS
+	test-core-nugu-timer
+	test-core-focus-manager
+	test-core-directive-sequencer)
 
 # Add Compile Sources with Mock for test
-SET(test-core-nugu-timer-srcs test-core-nugu-timer-mock.cc
-								../../src/core/nugu_timer.cc)
-
+SET(test-core-nugu-timer-srcs
+	test-core-nugu-timer-mock.cc ../../src/core/nugu_timer.cc)
+SET(test-core-directive-sequencer-srcs ../../src/core/directive_sequencer.cc)
 SET(test-core-focus-manager-srcs ../../src/core/focus_manager.cc)
 
 FOREACH(test ${UNIT_TESTS})

--- a/tests/core/test-core-directive-sequencer.cc
+++ b/tests/core/test-core-directive-sequencer.cc
@@ -1,0 +1,582 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <glib.h>
+
+#include "base/nugu_log.h"
+#include "directive_sequencer.hh"
+
+using namespace NuguCore;
+
+/* Generate dummy directive */
+static NuguDirective* directive_new(const char* name_space, const char* name,
+    const char* dialog_id, const char* msg_id)
+{
+    return nugu_directive_new(name_space, name, "1.0", msg_id, dialog_id,
+        "ref1", "{}", "[]");
+}
+
+static void test_sequencer_policy(void)
+{
+    DirectiveSequencer seq;
+    BlockingPolicy policy;
+
+    /* Policy check */
+    g_assert(seq.addPolicy("TTS", "Speak", { BlockingMedium::AUDIO, true }) == true);
+    g_assert(seq.addPolicy("AudioPlayer", "Play", { BlockingMedium::AUDIO, false }) == true);
+
+    policy = seq.getPolicy("TTS", "Speak");
+    g_assert(policy.medium == BlockingMedium::AUDIO);
+    g_assert(policy.isBlocking == true);
+
+    policy = seq.getPolicy("AudioPlayer", "Play");
+    g_assert(policy.medium == BlockingMedium::AUDIO);
+    g_assert(policy.isBlocking == false);
+
+    /* not registered policy: NONE with non-blocking */
+    policy = seq.getPolicy("test", "test");
+    g_assert(policy.medium == BlockingMedium::NONE);
+    g_assert(policy.isBlocking == false);
+
+    /* duplicated policy */
+    g_assert(seq.addPolicy("TTS", "Speak", { BlockingMedium::NONE, false }) == false);
+    g_assert(seq.addPolicy("TTS", "Speak", { BlockingMedium::AUDIO, true }) == false);
+    g_assert(seq.addPolicy("TTS", "Speak", { BlockingMedium::AUDIO, false }) == false);
+}
+
+class CountAgent : public IDirectiveSequencerListener {
+public:
+    bool onPreHandleDirective(NuguDirective* ndir) override
+    {
+        value++;
+
+        /**
+         * The directive is not handled in the pre-handle callback.
+         */
+        return false;
+    }
+
+    bool onHandleDirective(NuguDirective* ndir) override
+    {
+        value++;
+        return true;
+    }
+
+    int value;
+};
+
+class CountPrehandleAgent : public IDirectiveSequencerListener {
+public:
+    bool onPreHandleDirective(NuguDirective* ndir) override
+    {
+        value++;
+
+        /**
+         * The directive is handled in the pre-handle callback.
+         */
+        return true;
+    }
+
+    bool onHandleDirective(NuguDirective* ndir) override
+    {
+        g_assert(TRUE);
+
+        return true;
+    }
+
+    int value;
+};
+
+static void test_sequencer_listener(void)
+{
+    DirectiveSequencer seq;
+    CountAgent* counter1 = new CountAgent;
+    CountPrehandleAgent* counter2 = new CountPrehandleAgent;
+    NuguDirective* ndir;
+
+    /* Simple listener invocation test */
+    counter1->value = 0;
+    ndir = directive_new("TTS", "test", "dlg1", "msg1");
+    seq.addListener("TTS", counter1);
+    g_assert(seq.add(ndir) == true);
+    g_assert(counter1->value == 2);
+    seq.complete(ndir);
+    seq.removeListener("TTS", counter1);
+
+    /* Remove listener test */
+    counter1->value = 0;
+    ndir = directive_new("TTS", "test", "dlg1", "msg1");
+    g_assert(seq.add(ndir) == false);
+    g_assert(counter1->value == 0);
+    nugu_directive_unref(ndir);
+
+    /* prehandle test */
+    counter2->value = 0;
+    ndir = directive_new("TTS", "test", "dlg1", "msg1");
+    seq.addListener("TTS", counter2);
+    g_assert(seq.add(ndir) == true);
+    g_assert(counter2->value == 1); /* onHandleDirective ignored */
+    seq.complete(ndir);
+    seq.removeListener("TTS", counter2);
+
+    /* multiple listener (counter1, counter2) test */
+    counter1->value = 0;
+    counter2->value = 0;
+    seq.addListener("TTS", counter1);
+    seq.addListener("TTS", counter2);
+    ndir = directive_new("TTS", "test", "dlg1", "msg1");
+    g_assert(seq.add(ndir) == true);
+    g_assert(counter1->value == 1); /* onHandleDirective ignored */
+    g_assert(counter2->value == 1); /* onHandleDirective ignored */
+    seq.complete(ndir);
+    seq.removeListener("TTS", counter1);
+    seq.removeListener("TTS", counter2);
+
+    /* multiple listener (counter2, counter1) test */
+    counter1->value = 0;
+    counter2->value = 0;
+    ndir = directive_new("TTS", "test", "dlg1", "msg1");
+    seq.addListener("TTS", counter2);
+    seq.addListener("TTS", counter1);
+    g_assert(seq.add(ndir) == true);
+    g_assert(counter1->value == 0); /* onPreHandleDirective and onHandleDirective ignored */
+    g_assert(counter2->value == 1); /* onHandleDirective ignored */
+    seq.complete(ndir);
+    seq.removeListener("TTS", counter1);
+    seq.removeListener("TTS", counter2);
+
+    delete counter1;
+    delete counter2;
+}
+
+class DummyAgent : public IDirectiveSequencerListener {
+public:
+    bool onPreHandleDirective(NuguDirective* ndir) override
+    {
+        return false;
+    }
+
+    bool onHandleDirective(NuguDirective* ndir) override
+    {
+        /* ignore TTS namespace */
+        if (g_strcmp0(nugu_directive_peek_namespace(ndir), "TTS") == 0) {
+            value += 100;
+            return true;
+        }
+
+        /* only 'Dummy' namespace allow */
+        g_assert_cmpstr(nugu_directive_peek_namespace(ndir), ==, "Dummy");
+
+        if (g_strcmp0(nugu_directive_peek_name(ndir), "A") == 0) {
+            value += 1;
+        } else {
+            value += 10;
+        }
+
+        return true;
+    }
+
+    int value;
+};
+
+static void test_sequencer_simple_add(void)
+{
+    DirectiveSequencer seq;
+    DummyAgent* dummy = new DummyAgent;
+    NuguDirective* ndir;
+
+    seq.addListener("TTS", dummy);
+    seq.addListener("Dummy", dummy);
+
+    /* No corresponding listener */
+    dummy->value = 0;
+    ndir = directive_new("Invalid", "test", "dlg1", "msg1");
+    g_assert(seq.add(ndir) == false);
+    g_assert(dummy->value == 0);
+    nugu_directive_unref(ndir);
+
+    /* Same handler for different namespaces. */
+    dummy->value = 0;
+    ndir = directive_new("TTS", "invalid", "dlg1", "msg1");
+    g_assert(seq.add(ndir) == true);
+    g_assert(dummy->value == 100);
+    seq.complete(ndir);
+
+    /* handled: case-2 */
+    dummy->value = 0;
+    ndir = directive_new("Dummy", "invalid", "dlg1", "msg1");
+    g_assert(seq.add(ndir) == true);
+    g_assert(dummy->value == 10);
+    seq.complete(ndir);
+
+    /* handled: case-3 */
+    dummy->value = 0;
+    ndir = directive_new("Dummy", "A", "dlg1", "msg1");
+    g_assert(seq.add(ndir) == true);
+    g_assert(dummy->value == 1);
+    seq.complete(ndir);
+
+    /* Remove 'TTS' listener: No corresponding listener */
+    seq.removeListener("TTS", dummy);
+
+    dummy->value = 0;
+    ndir = directive_new("TTS", "invalid", "dlg1", "msg1");
+    g_assert(seq.add(ndir) == false);
+    g_assert(dummy->value == 0);
+    nugu_directive_unref(ndir);
+
+    delete dummy;
+}
+
+class TTSAgent : public IDirectiveSequencerListener {
+public:
+    TTSAgent(DirectiveSequencer* seq, GMainLoop* loop)
+        : seq(seq)
+        , loop(loop)
+        , speak_dir(nullptr)
+        , idler(0)
+    {
+    }
+    virtual ~TTSAgent() = default;
+
+    bool onPreHandleDirective(NuguDirective* ndir) override
+    {
+        return false;
+    }
+
+    bool onHandleDirective(NuguDirective* ndir) override
+    {
+        /* Allow only 'TTS' namespace */
+        g_assert_cmpstr(nugu_directive_peek_namespace(ndir), ==, "TTS");
+        value += 1;
+
+        if (g_strcmp0(nugu_directive_peek_name(ndir), "Speak") == 0) {
+            /**
+             * Multiple dialog-id test case:
+             *  - Remove previous dialog-id related directive
+             */
+            if (speak_dir != nullptr) {
+                /* The dialog-id must be different */
+                g_assert_cmpstr(nugu_directive_peek_dialog_id(speak_dir), !=, nugu_directive_peek_dialog_id(ndir));
+
+                /* Cancel(destroy) the previous dialog */
+                seq->cancel(nugu_directive_peek_dialog_id(speak_dir));
+
+                if (idler)
+                    g_source_remove(idler);
+            }
+
+            speak_dir = ndir;
+
+            /* Unblock the blocking directive after 500ms */
+            idler = g_timeout_add(500, onTimeout, this);
+        } else if (g_strcmp0(nugu_directive_peek_name(ndir), "Quit") == 0) {
+            seq->complete(ndir);
+            g_main_loop_quit(loop);
+        } else {
+            seq->complete(ndir);
+        }
+
+        return true;
+    }
+
+    static gboolean onTimeout(gpointer userdata)
+    {
+        TTSAgent* agent = static_cast<TTSAgent*>(userdata);
+
+        agent->idler = 0;
+        agent->speakFinished();
+
+        return FALSE;
+    }
+
+    void speakFinished(void)
+    {
+        g_assert(speak_dir != nullptr);
+        g_assert(value == 1);
+
+        seq->complete(speak_dir);
+
+        speak_dir = nullptr;
+    }
+
+    int value;
+    DirectiveSequencer* seq;
+    GMainLoop* loop;
+    NuguDirective* speak_dir;
+    guint idler;
+};
+
+class AudioPlayerAgent : public IDirectiveSequencerListener {
+public:
+    AudioPlayerAgent(DirectiveSequencer* seq, GMainLoop* loop)
+        : seq(seq)
+        , loop(loop)
+    {
+    }
+    virtual ~AudioPlayerAgent() = default;
+
+    bool onPreHandleDirective(NuguDirective* ndir) override
+    {
+        return false;
+    }
+
+    bool onHandleDirective(NuguDirective* ndir) override
+    {
+        g_assert_cmpstr(nugu_directive_peek_namespace(ndir), ==, "AudioPlayer");
+        value += 1;
+
+        if (g_strcmp0(nugu_directive_peek_name(ndir), "Play") == 0) {
+            seq->complete(ndir);
+            g_main_loop_quit(loop);
+        } else {
+            seq->complete(ndir);
+        }
+
+        return true;
+    }
+
+    int value;
+    DirectiveSequencer* seq;
+    GMainLoop* loop;
+};
+
+static void test_sequencer_simple_blocking(void)
+{
+    DirectiveSequencer seq;
+    GMainLoop* loop = g_main_loop_new(NULL, FALSE);
+
+    TTSAgent* tts = new TTSAgent(&seq, loop);
+    AudioPlayerAgent* audio = new AudioPlayerAgent(&seq, loop);
+
+    seq.addPolicy("TTS", "Speak", { BlockingMedium::AUDIO, true });
+    seq.addPolicy("AudioPlayer", "Play", { BlockingMedium::AUDIO, false });
+
+    seq.addListener("TTS", tts);
+    seq.addListener("AudioPlayer", audio);
+
+    tts->value = 0;
+    audio->value = 0;
+
+    /* Handle audio medium (block) */
+    seq.add(directive_new("TTS", "Speak", "dlg1", "msg1"));
+    g_assert(tts->value == 1);
+    g_assert(audio->value == 0);
+
+    /* Pending audio medium (non-block) */
+    seq.add(directive_new("AudioPlayer", "Play", "dlg1", "msg2"));
+    g_assert(audio->value == 0);
+
+    /* TTS.Speak(block) is completed after timer */
+    g_main_loop_run(loop);
+    g_main_loop_unref(loop);
+
+    /* All directives are handled */
+    g_assert(tts->value == 1);
+    g_assert(audio->value == 1);
+
+    delete tts;
+    delete audio;
+}
+
+class VisualAgent : public IDirectiveSequencerListener {
+public:
+    VisualAgent(DirectiveSequencer* seq, GMainLoop* loop)
+        : seq(seq)
+        , loop(loop)
+    {
+    }
+    virtual ~VisualAgent() = default;
+
+    bool onPreHandleDirective(NuguDirective* ndir) override
+    {
+        return false;
+    }
+
+    bool onHandleDirective(NuguDirective* ndir) override
+    {
+        g_assert_cmpstr(nugu_directive_peek_namespace(ndir), ==, "Visual");
+        value += 1;
+
+        if (g_strcmp0(nugu_directive_peek_name(ndir), "Block") == 0) {
+            block_dir = ndir;
+
+            /* Unblock the blocking directive after 500ms */
+            g_timeout_add(500, onTimeout, this);
+        } else if (g_strcmp0(nugu_directive_peek_name(ndir), "Signal") == 0) {
+            seq->complete(ndir);
+            g_main_loop_quit(loop);
+        } else if (g_strcmp0(nugu_directive_peek_name(ndir), "Nonblock") == 0) {
+            seq->complete(ndir);
+        }
+
+        return true;
+    }
+
+    static gboolean onTimeout(gpointer userdata)
+    {
+        VisualAgent* agent = static_cast<VisualAgent*>(userdata);
+
+        /* Done: "Nonblock", "Block", Pending: "Signal" */
+        g_assert(agent->value == 2);
+
+        agent->blockFinished();
+
+        return FALSE;
+    }
+
+    void blockFinished(void)
+    {
+        seq->complete(block_dir);
+    }
+
+    int value;
+    DirectiveSequencer* seq;
+    NuguDirective* block_dir;
+    GMainLoop* loop;
+};
+
+static void test_sequencer_multi_blocking(void)
+{
+    DirectiveSequencer seq;
+    GMainLoop* loop = g_main_loop_new(NULL, FALSE);
+
+    TTSAgent* tts = new TTSAgent(&seq, loop);
+    AudioPlayerAgent* audio = new AudioPlayerAgent(&seq, loop);
+    VisualAgent* visual = new VisualAgent(&seq, loop);
+
+    seq.addPolicy("TTS", "Speak", { BlockingMedium::AUDIO, true });
+    seq.addPolicy("AudioPlayer", "Dummy", { BlockingMedium::AUDIO, false });
+    seq.addPolicy("Visual", "Nonblock", { BlockingMedium::VISUAL, false });
+    seq.addPolicy("Visual", "Block", { BlockingMedium::VISUAL, true });
+    seq.addPolicy("Visual", "Signal", { BlockingMedium::VISUAL, false });
+
+    seq.addListener("TTS", tts);
+    seq.addListener("AudioPlayer", audio);
+    seq.addListener("Visual", visual);
+
+    tts->value = 0;
+    audio->value = 0;
+    visual->value = 0;
+
+    /* Handle audio medium (block) */
+    seq.add(directive_new("TTS", "Speak", "dlg1", "msg1"));
+    g_assert(tts->value == 1);
+    g_assert(audio->value == 0);
+    g_assert(visual->value == 0);
+
+    /* Pending audio medium (non-block) */
+    seq.add(directive_new("AudioPlayer", "Dummy", "dlg1", "msg2"));
+    g_assert(tts->value == 1);
+    g_assert(audio->value == 0);
+    g_assert(visual->value == 0);
+
+    /* Handle visual medium (non-block) */
+    seq.add(directive_new("Visual", "Nonblock", "dlg1", "msg3"));
+    g_assert(tts->value == 1);
+    g_assert(audio->value == 0);
+    g_assert(visual->value == 1);
+
+    /* Handle visual medium (block) */
+    seq.add(directive_new("Visual", "Block", "dlg1", "msg4"));
+    g_assert(tts->value == 1);
+    g_assert(audio->value == 0);
+    g_assert(visual->value == 2);
+
+    /* Pending visual medium (non-block) */
+    seq.add(directive_new("Visual", "Signal", "dlg1", "msg5"));
+    g_assert(tts->value == 1);
+    g_assert(audio->value == 0);
+    g_assert(visual->value == 2);
+
+    /* TTS.Speak(block) and Visual.Block(block) are completed after timer */
+    g_main_loop_run(loop);
+    g_main_loop_unref(loop);
+
+    /* All directives are handled */
+    g_assert(tts->value == 1);
+    g_assert(audio->value == 1);
+    g_assert(visual->value == 3);
+
+    delete tts;
+    delete audio;
+    delete visual;
+}
+
+static void test_sequencer_multi_dialog(void)
+{
+    DirectiveSequencer seq;
+    GMainLoop* loop = g_main_loop_new(NULL, FALSE);
+
+    TTSAgent* tts = new TTSAgent(&seq, loop);
+
+    seq.addPolicy("TTS", "Speak", { BlockingMedium::AUDIO, true });
+    seq.addPolicy("TTS", "Quit", { BlockingMedium::AUDIO, false });
+    seq.addListener("TTS", tts);
+
+    tts->value = 0;
+
+    /* Multiple dialog-id with non-block directive */
+    seq.add(directive_new("TTS", "Dummy", "dlg1", "msg1"));
+    g_assert(tts->value == 1);
+    seq.add(directive_new("TTS", "Dummy", "dlg2", "msg2"));
+    g_assert(tts->value == 2);
+
+    tts->value = 0;
+
+    /* dialog 1 (block + non-block) */
+    seq.add(directive_new("TTS", "Speak", "dlg1", "msg3"));
+    g_assert(tts->value == 1);
+    seq.add(directive_new("TTS", "Quit", "dlg1", "msg4"));
+    g_assert(tts->value == 1);
+
+    /* dialog 2 (block + non-block) */
+    seq.add(directive_new("TTS", "Speak", "dlg2", "msg5"));
+    g_assert(tts->value == 2);
+    seq.add(directive_new("TTS", "Quit", "dlg2", "msg6"));
+    g_assert(tts->value == 2);
+    tts->value--;
+
+    g_main_loop_run(loop);
+    g_main_loop_unref(loop);
+
+    g_assert(tts->value == 2);
+
+    delete tts;
+}
+
+int main(int argc, char* argv[])
+{
+#if !GLIB_CHECK_VERSION(2, 36, 0)
+    g_type_init();
+#endif
+
+    g_test_init(&argc, &argv, (void*)NULL);
+    g_log_set_always_fatal((GLogLevelFlags)G_LOG_FATAL_MASK);
+
+    g_test_add_func("/core/DirectiveSequencer/policy", test_sequencer_policy);
+    g_test_add_func("/core/DirectiveSequencer/listener", test_sequencer_listener);
+    g_test_add_func("/core/DirectiveSequencer/simple_add", test_sequencer_simple_add);
+    g_test_add_func("/core/DirectiveSequencer/simple_blocking", test_sequencer_simple_blocking);
+    g_test_add_func("/core/DirectiveSequencer/multi_blocking", test_sequencer_multi_blocking);
+    g_test_add_func("/core/DirectiveSequencer/multi_dialog", test_sequencer_multi_dialog);
+
+    return g_test_run();
+}


### PR DESCRIPTION
The DirectiveSequencer delivers the directives received from the
network to the CapabilityAgent according to the dialog-id and
blocking policy.

Each Capability agent must register blocking policies through
DirectPolicySequencer::addPolicy() to handle the Directive in
accordance with the policy.

In addition, listeners must be registered to receive directive
events from the DirectiveSequencer.

Signed-off-by: Inho Oh <inho.oh@sk.com>