### PR TITLE
Session:Change function name in SessionManager

### DIFF
--- a/include/clientkit/session_manager_interface.hh
+++ b/include/clientkit/session_manager_interface.hh
@@ -40,7 +40,7 @@ namespace NuguClientKit {
 typedef struct {
     std::string session_id; /**< session id */
     std::string ps_id; /**< play service id */
-    bool is_synced; /**< whether session is synced */
+    bool is_active; /**< whether session is active */
 } Session;
 
 /**
@@ -58,22 +58,22 @@ public:
     virtual void set(const std::string& dialog_id, Session&& session) = 0;
 
     /**
-     * @brief Sync Session object which is mapped with dialog request id.
-     * @param[in] dialog_id dialog request id for Session object
+     * @brief Activate Session which is mapped with dialog request id.
+     * @param[in] dialog_id dialog request id for Session
      */
-    virtual void sync(const std::string& dialog_id) = 0;
+    virtual void activate(const std::string& dialog_id) = 0;
 
     /**
-     * @brief Release sync Session object which is mapped with dialog request id.
-     * @param[in] dialog_id dialog request id for Session object
+     * @brief Deactivate Session which is mapped with dialog request id.
+     * @param[in] dialog_id dialog request id for Session
      */
-    virtual void release(const std::string& dialog_id) = 0;
+    virtual void deactivate(const std::string& dialog_id) = 0;
 
     /**
-     * @brief Get current synced session info which is composed by session list.
+     * @brief Get current active session info which is composed by session list.
      * @return session info which is formatted to json type
      */
-    virtual Json::Value getSyncedSessionInfo() = 0;
+    virtual Json::Value getActiveSessionInfo() = 0;
 };
 
 /**

--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -707,7 +707,7 @@ ListeningState ASRAgent::getListeningState()
 void ASRAgent::resetExpectSpeechState()
 {
     if (!es_attr.dialog_id.empty())
-        session_manager->release(es_attr.dialog_id);
+        session_manager->deactivate(es_attr.dialog_id);
 
     if (es_attr.is_handle)
         es_attr = {};
@@ -752,6 +752,6 @@ void ASRAgent::syncSession()
         return;
     }
 
-    session_manager->sync(es_attr.dialog_id);
+    session_manager->activate(es_attr.dialog_id);
 }
 } // NuguCapability

--- a/src/capability/session_agent.cc
+++ b/src/capability/session_agent.cc
@@ -32,7 +32,7 @@ SessionAgent::SessionAgent()
 void SessionAgent::updateInfoForContext(Json::Value& ctx)
 {
     Json::Value session;
-    Json::Value session_list = session_manager->getSyncedSessionInfo();
+    Json::Value session_list = session_manager->getActiveSessionInfo();
 
     session["version"] = getVersion();
 

--- a/src/core/session_manager.cc
+++ b/src/core/session_manager.cc
@@ -41,7 +41,7 @@ void SessionManager::set(const std::string& dialog_id, Session&& session)
     session_map.emplace(dialog_id, session);
 }
 
-void SessionManager::sync(const std::string& dialog_id)
+void SessionManager::activate(const std::string& dialog_id)
 {
     if (dialog_id.empty()) {
         nugu_error("The dialog request ID is empty.");
@@ -49,13 +49,13 @@ void SessionManager::sync(const std::string& dialog_id)
     }
 
     try {
-        session_map.at(dialog_id).is_synced = true;
+        session_map.at(dialog_id).is_active = true;
     } catch (std::out_of_range& exception) {
         nugu_warn("The such session is not exist.");
     }
 }
 
-void SessionManager::release(const std::string& dialog_id)
+void SessionManager::deactivate(const std::string& dialog_id)
 {
     if (dialog_id.empty()) {
         nugu_error("The dialog request ID is empty.");
@@ -65,12 +65,12 @@ void SessionManager::release(const std::string& dialog_id)
     session_map.erase(dialog_id);
 }
 
-Json::Value SessionManager::getSyncedSessionInfo()
+Json::Value SessionManager::getActiveSessionInfo()
 {
     Json::Value session_info_list;
 
     for (const auto& item : session_map) {
-        if (item.second.is_synced) {
+        if (item.second.is_active) {
             Json::Value session_info;
             session_info["sessionId"] = item.second.session_id;
             session_info["playServiceId"] = item.second.ps_id;

--- a/src/core/session_manager.hh
+++ b/src/core/session_manager.hh
@@ -31,9 +31,9 @@ public:
     virtual ~SessionManager();
 
     void set(const std::string& dialog_id, Session&& session) override;
-    void sync(const std::string& dialog_id) override;
-    void release(const std::string& dialog_id) override;
-    Json::Value getSyncedSessionInfo() override;
+    void activate(const std::string& dialog_id) override;
+    void deactivate(const std::string& dialog_id) override;
+    Json::Value getActiveSessionInfo() override;
 
 private:
     std::map<std::string, Session> session_map;


### PR DESCRIPTION
As following the agreement of common naming about SessionManager,
it changes the below function name.

sync() -> activate()
release() -> deactivate()
getSyncedSessionInfo() -> getActiveSessionInfo()

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>