### PR TITLE
Capability: Fix the hangup

### DIFF
--- a/include/clientkit/capability.hh
+++ b/include/clientkit/capability.hh
@@ -171,10 +171,10 @@ public:
     /**
      * @brief Notify event response info.
      * @param[in] msg_id message id which is sent with event
-     * @param[in] json raw data which is received from server about event
+     * @param[in] data raw data which is received from server about event (json format)
      * @param[in] success whether receive event response
      */
-    void notifyEventResponse(const char* msg_id, const char* json, bool success);
+    void notifyEventResponse(const std::string& msg_id, const std::string& data, bool success);
 
     /**
      * @brief Add event name and directive name for referred dialog request id.

--- a/include/clientkit/capability_interface.hh
+++ b/include/clientkit/capability_interface.hh
@@ -129,10 +129,10 @@ public:
     /**
      * @brief Notify event response info.
      * @param[in] msg_id message id which is sent with event
-     * @param[in] json raw data which is received from server about event
+     * @param[in] data raw data which is received from server about event (json format)
      * @param[in] success whether receive event response
      */
-    virtual void notifyEventResponse(const char* msg_id, const char* json, bool success) = 0;
+    virtual void notifyEventResponse(const std::string& msg_id, const std::string& data, bool success) = 0;
 
     /**
      * @brief Get the capability name of the current object.

--- a/include/clientkit/network_manager_interface.hh
+++ b/include/clientkit/network_manager_interface.hh
@@ -84,10 +84,10 @@ public:
     /**
      * @brief Report the response data received from the server.
      * @param[in] msg_id event message id
-     * @param[in] json response json data
+     * @param[in] data response raw data (format json)
      * @param[in] success event result
      */
-    virtual void onEventResponse(const char* msg_id, const char* json, bool success);
+    virtual void onEventResponse(const char* msg_id, const char* data, bool success);
 };
 
 /**

--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -669,11 +669,9 @@ void ASRAgent::syncSession()
     session_manager->activate(es_attr.dialog_id);
 }
 
-void ASRAgent::notifyEventResponse(const char* msg_id, const char* json, bool success)
+void ASRAgent::notifyEventResponse(const std::string& msg_id, const std::string& data, bool success)
 {
     // release focus when there are no focus stealer like TTS
-    std::string data { json };
-
     if (data.find("ASR") != std::string::npos && data.find("NotifyResult") != std::string::npos
         && data.find("TTS") == std::string::npos) {
         nugu_info("Focus(type: %s) Release", DIALOG_FOCUS_TYPE);

--- a/src/capability/asr_agent.hh
+++ b/src/capability/asr_agent.hh
@@ -86,7 +86,7 @@ public:
     ASRState getASRState();
     void setListeningId(const std::string& id);
     void syncSession();
-    void notifyEventResponse(const char* msg_id, const char* json, bool success) override;
+    void notifyEventResponse(const std::string& msg_id, const std::string& data, bool success) override;
 
 private:
     void sendEventCommon(const std::string& ename, EventResultCallback cb = nullptr);

--- a/src/clientkit/capability.cc
+++ b/src/clientkit/capability.cc
@@ -202,7 +202,7 @@ void Capability::notifyEventResult(const std::string& event_desc)
     }
 }
 
-void Capability::notifyEventResponse(const char* msg_id, const char* json, bool success)
+void Capability::notifyEventResponse(const std::string& msg_id, const std::string& data, bool success)
 {
 }
 

--- a/src/clientkit/network_manager_interface.cc
+++ b/src/clientkit/network_manager_interface.cc
@@ -21,6 +21,6 @@ void INetworkManagerListener::onStatusChanged(NetworkStatus status) {}
 void INetworkManagerListener::onError(NetworkError error) {}
 void INetworkManagerListener::onEventSent(const char* ename, const char* msg_id, const char* dialog_id, const char* referrer_id) {}
 void INetworkManagerListener::onEventSendResult(const char* msg_id, bool success, int code) {}
-void INetworkManagerListener::onEventResponse(const char* msg_id, const char* json, bool success) {}
+void INetworkManagerListener::onEventResponse(const char* msg_id, const char* data, bool success) {}
 
 } //NuguClientKit

--- a/src/core/capability_manager.cc
+++ b/src/core/capability_manager.cc
@@ -150,7 +150,7 @@ void CapabilityManager::onEventSendResult(const char* msg_id, bool success, int 
     events.erase(msg_id);
 }
 
-void CapabilityManager::onEventResponse(const char* msg_id, const char* json, bool success)
+void CapabilityManager::onEventResponse(const char* msg_id, const char* data, bool success)
 {
     if (!success)
         nugu_error("can't receive event response: msg_id=%s", msg_id);
@@ -158,8 +158,12 @@ void CapabilityManager::onEventResponse(const char* msg_id, const char* json, bo
     try {
         ICapabilityInterface* cap = findCapability(events_cname_map.at(msg_id));
 
-        if (cap)
-            cap->notifyEventResponse(msg_id, json, success);
+        if (cap) {
+            std::string message_id = msg_id ? msg_id : "";
+            std::string message_data = data ? data : "";
+
+            cap->notifyEventResponse(message_id, message_data, success);
+        }
 
         events_cname_map.erase(msg_id);
     } catch (std::out_of_range& exception) {

--- a/src/core/capability_manager.hh
+++ b/src/core/capability_manager.hh
@@ -51,7 +51,7 @@ public:
 
     // overriding INetworkManagerListener
     void onEventSendResult(const char* msg_id, bool success, int code) override;
-    void onEventResponse(const char* msg_id, const char* json, bool success) override;
+    void onEventResponse(const char* msg_id, const char* data, bool success) override;
 
     void setWakeupWord(const std::string& word);
     std::string getWakeupWord();


### PR DESCRIPTION
When an sending event response failure such as a timeout, the payload
is filled with nullptr, and assigning it to std::string causes hangup.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>