### PR TITLE
AudioPlayerAgent: Change media content identification

### DIFF
--- a/src/capability/audio_player_agent.hh
+++ b/src/capability/audio_player_agent.hh
@@ -139,6 +139,7 @@ private:
     long report_delay_time;
     long report_interval_time;
     std::string cur_token;
+    std::string cur_url;
     std::string pre_ref_dialog_id;
     std::string cur_dialog_id;
     bool is_finished;


### PR DESCRIPTION
Change the policy to identify media content from token-based
to URL-based.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>