### PR TITLE
NuguClient:Remove getFocusManager in NuguClient

### DIFF
--- a/examples/standalone/nugu_sample.cc
+++ b/examples/standalone/nugu_sample.cc
@@ -27,6 +27,7 @@ using namespace NuguClientKit;
 std::unique_ptr<NuguClient> nugu_client = nullptr;
 std::unique_ptr<NuguSampleManager> nugu_sample_manager = nullptr;
 std::unique_ptr<CapabilityCollection> capa_collection = nullptr;
+INuguCoreContainer* nugu_core_container = nullptr;
 
 template <typename T, typename... Ts>
 std::unique_ptr<T> make_unique(Ts&&... params)
@@ -48,7 +49,7 @@ class FocusManagerObserver : public IFocusManagerObserver {
 public:
     void onFocusChanged(const FocusConfiguration& configuration, FocusState state, const std::string& name)
     {
-        auto focus_manager(nugu_client->getFocusManager());
+        auto focus_manager(nugu_core_container->getCapabilityHelper()->getFocusManager());
         std::string msg;
 
         msg.append("==================================================\n[")
@@ -175,6 +176,7 @@ int main(int argc, char** argv)
 
     nugu_client = make_unique<NuguClient>();
     capa_collection = make_unique<CapabilityCollection>();
+    nugu_core_container = nugu_client->getNuguCoreContainer();
 
     registerCapabilities();
 
@@ -183,7 +185,7 @@ int main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
-    auto focus_manager(nugu_client->getFocusManager());
+    auto focus_manager(nugu_core_container->getCapabilityHelper()->getFocusManager());
     auto focus_manager_observer(make_unique<FocusManagerObserver>());
     focus_manager->addObserver(focus_manager_observer.get());
 
@@ -198,7 +200,6 @@ int main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
-    auto nugu_core_container(nugu_client->getNuguCoreContainer());
     auto wakeup_handler(std::unique_ptr<IWakeupHandler>(
         nugu_core_container->createWakeupHandler(nugu_sample_manager->getModelPath())));
 

--- a/include/clientkit/nugu_client.hh
+++ b/include/clientkit/nugu_client.hh
@@ -121,12 +121,6 @@ public:
      */
     INetworkManager* getNetworkManager();
 
-    /**
-     * @brief Get FocusManager object
-     * @return IFocusManager abstraction object of FocuskManager
-     */
-    IFocusManager* getFocusManager();
-
 private:
     std::unique_ptr<NuguClientImpl> impl;
     CapabilityBuilder* cap_builder;

--- a/include/clientkit/nugu_core_container_interface.hh
+++ b/include/clientkit/nugu_core_container_interface.hh
@@ -18,8 +18,6 @@
 #define __NUGU_CORE_CONTAINER_INTERFACE_H__
 
 #include <clientkit/capability_helper_interface.hh>
-#include <clientkit/focus_manager_interface.hh>
-#include <clientkit/directive_sequencer_interface.hh>
 #include <clientkit/media_player_interface.hh>
 #include <clientkit/network_manager_interface.hh>
 #include <clientkit/nugu_timer_interface.hh>
@@ -78,16 +76,6 @@ public:
      * @brief Get CapabilityHelper instance
      */
     virtual ICapabilityHelper* getCapabilityHelper() = 0;
-
-    /**
-     * @brief Get FocusManager instance
-     */
-    virtual IFocusManager* getFocusManager() = 0;
-
-    /**
-     * @brief Get DirectiveSequencer instance
-     */
-    virtual IDirectiveSequencer* getDirectiveSequencer() = 0;
 };
 
 /**

--- a/src/clientkit/nugu_client.cc
+++ b/src/clientkit/nugu_client.cc
@@ -91,9 +91,4 @@ INetworkManager* NuguClient::getNetworkManager()
     return impl->getNetworkManager();
 }
 
-IFocusManager* NuguClient::getFocusManager()
-{
-    return impl->getFocusManager();
-}
-
 } // NuguClientKit

--- a/src/clientkit/nugu_client_impl.cc
+++ b/src/clientkit/nugu_client_impl.cc
@@ -94,11 +94,6 @@ INuguCoreContainer* NuguClientImpl::getNuguCoreContainer()
     return nugu_core_container.get();
 }
 
-IFocusManager* NuguClientImpl::getFocusManager()
-{
-    return nugu_core_container->getFocusManager();
-}
-
 int NuguClientImpl::create(void)
 {
     if (createCapabilities() <= 0) {

--- a/src/clientkit/nugu_client_impl.hh
+++ b/src/clientkit/nugu_client_impl.hh
@@ -43,7 +43,6 @@ public:
     ICapabilityInterface* getCapabilityHandler(const std::string& cname);
     INuguCoreContainer* getNuguCoreContainer();
     INetworkManager* getNetworkManager();
-    IFocusManager* getFocusManager();
 
 private:
     int createCapabilities(void);

--- a/src/core/nugu_core_container.cc
+++ b/src/core/nugu_core_container.cc
@@ -40,15 +40,11 @@ INetworkManager* NuguCoreContainer::createNetworkManager()
 
 IWakeupHandler* NuguCoreContainer::createWakeupHandler(const std::string& model_path)
 {
-    // TODO : It needs guarantee related plugin is loaded.
-
     return new WakeupHandler(model_path);
 }
 
 ISpeechRecognizer* NuguCoreContainer::createSpeechRecognizer(const std::string& model_path, const EpdAttribute& epd_attr)
 {
-    // TODO : It needs guarantee related plugin is loaded.
-
     SpeechRecognizer::Attribute sr_attribute;
 
     sr_attribute.model_path = model_path;
@@ -64,15 +60,11 @@ ISpeechRecognizer* NuguCoreContainer::createSpeechRecognizer(const std::string& 
 
 IMediaPlayer* NuguCoreContainer::createMediaPlayer()
 {
-    // TODO : It needs guarantee related plugin is loaded.
-
     return new MediaPlayer();
 }
 
 ITTSPlayer* NuguCoreContainer::createTTSPlayer()
 {
-    // TODO : It needs guarantee related plugin is loaded.
-
     return new TTSPlayer();
 }
 
@@ -84,16 +76,6 @@ INuguTimer* NuguCoreContainer::createNuguTimer()
 ICapabilityHelper* NuguCoreContainer::getCapabilityHelper()
 {
     return CapabilityHelper::getInstance();
-}
-
-IFocusManager* NuguCoreContainer::getFocusManager()
-{
-    return CapabilityManager::getInstance()->getFocusManager();
-}
-
-IDirectiveSequencer* NuguCoreContainer::getDirectiveSequencer()
-{
-    return CapabilityManager::getInstance()->getDirectiveSequencer();
 }
 
 void NuguCoreContainer::setWakeupWord(const std::string& wakeup_word)

--- a/src/core/nugu_core_container.hh
+++ b/src/core/nugu_core_container.hh
@@ -36,8 +36,6 @@ public:
     ITTSPlayer* createTTSPlayer() override;
     INuguTimer* createNuguTimer() override;
     ICapabilityHelper* getCapabilityHelper() override;
-    IFocusManager* getFocusManager() override;
-    IDirectiveSequencer* getDirectiveSequencer() override;
 
     // wrapping CapabilityManager functions
     void setWakeupWord(const std::string& wakeup_word);


### PR DESCRIPTION
Because, in ICapabilityHelper, the getFocusManager function
is already defined and it's possible to access by NuguCoreContainer,
there are no need to define another same function in NuguClient.

Also, it should remove the related function which is defined
in NuguCoreContainer. (It's same case about getDirectiveSequencer.)

Signed-off-by: kimhyungrok <hr97gdi@gmail.com>