### PR TITLE
tts: set size limit for the 1st attachment

### DIFF
--- a/include/base/nugu_directive.h
+++ b/include/base/nugu_directive.h
@@ -47,7 +47,8 @@ typedef struct _nugu_directive NuguDirective;
 /**
  * @brief Callback prototype for receiving an attachment
  */
-typedef void (*NuguDirectiveDataCallback)(NuguDirective *ndir, void *userdata);
+typedef void (*NuguDirectiveDataCallback)(NuguDirective *ndir, int seq,
+					  void *userdata);
 
 /**
  * @brief Create new directive object

--- a/src/base/nugu_directive.c
+++ b/src/base/nugu_directive.c
@@ -34,6 +34,7 @@ struct _nugu_directive {
 	char *referrer_id;
 	char *groups;
 
+	int seq;
 	int is_active;
 	int is_end;
 
@@ -71,6 +72,7 @@ nugu_directive_new(const char *name_space, const char *name,
 	ndir->json = strdup(json);
 	ndir->groups = strdup(groups);
 
+	ndir->seq = -1;
 	ndir->is_active = 0;
 	ndir->buf = nugu_buffer_new(0);
 	ndir->media_type = NULL;
@@ -255,6 +257,8 @@ EXPORT_API int nugu_directive_add_data(NuguDirective *ndir, size_t length,
 				   length);
 			return -1;
 		}
+
+		ndir->seq++;
 	}
 
 	if (nugu_directive_is_active(ndir) == 0) {
@@ -263,7 +267,7 @@ EXPORT_API int nugu_directive_add_data(NuguDirective *ndir, size_t length,
 	}
 
 	if (ndir->callback)
-		ndir->callback(ndir, ndir->callback_userdata);
+		ndir->callback(ndir, ndir->seq, ndir->callback_userdata);
 
 	return 0;
 }

--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -172,7 +172,7 @@ void AudioPlayerAgent::restore()
     suspended = false;
 }
 
-void AudioPlayerAgent::directiveDataCallback(NuguDirective* ndir, void* userdata)
+void AudioPlayerAgent::directiveDataCallback(NuguDirective* ndir, int seq, void* userdata)
 {
     getAttachmentData(ndir, userdata);
 }

--- a/src/capability/audio_player_agent.hh
+++ b/src/capability/audio_player_agent.hh
@@ -50,7 +50,7 @@ public:
     void receiveCommand(const std::string& from, const std::string& command, const std::string& param) override;
     void setCapabilityListener(ICapabilityListener* clistener) override;
 
-    static void directiveDataCallback(NuguDirective* ndir, void* userdata);
+    static void directiveDataCallback(NuguDirective* ndir, int seq, void* userdata);
     static void getAttachmentData(NuguDirective* ndir, void* userdata);
 
     // implements IAudioPlayerHandler

--- a/src/capability/tts_agent.hh
+++ b/src/capability/tts_agent.hh
@@ -51,8 +51,8 @@ public:
     std::string sendEventSpeechPlay(const std::string& token, const std::string& text, const std::string& play_service_id = "", EventResultCallback cb = nullptr);
     void setCapabilityListener(ICapabilityListener* clistener) override;
 
-    static void directiveDataCallback(NuguDirective* ndir, void* userdata);
-    static void getAttachmentData(NuguDirective* ndir, void* userdata);
+    static void directiveDataCallback(NuguDirective* ndir, int seq, void* userdata);
+    static void getAttachmentData(NuguDirective* ndir, int seq, void* userdata);
 
 private:
     void sendEventCommon(CapabilityEvent *event, const std::string& token, EventResultCallback cb = nullptr);

--- a/src/core/tts_player.cc
+++ b/src/core/tts_player.cc
@@ -229,6 +229,8 @@ bool TTSPlayer::write_audio(const char* data, int size)
         }
     }
 
+    nugu_dbg("opus %d bytes -> pcm %d bytes", size, dsize);
+
     if (d->count == 0)
         nugu_prof_mark(NUGU_PROF_TYPE_TTS_FIRST_DECODING);
 

--- a/tests/test-nugu-directive.c
+++ b/tests/test-nugu-directive.c
@@ -28,7 +28,7 @@
 int flag;
 unsigned char dummy[] = { 1, 2, 3, 4, 5 };
 
-static void on_data(NuguDirective *ndir, void *userdata)
+static void on_data(NuguDirective *ndir, int seq, void *userdata)
 {
 	int ud = GPOINTER_TO_INT(userdata);
 	unsigned char *tmp;


### PR DESCRIPTION
There is a variation in performance because the size of the first of
the attachment data coming in the TTS response is not uniform.

This patch attempts to ensure constant performance for the first data
output by setting limits (4200 bytes) to the smallest of the first data
from multiple scenario cases.

Signed-off-by: Inho Oh <inho.oh@sk.com>