### PR TITLE
ASR:Adjust handling ExpectSpeech

### DIFF
--- a/include/clientkit/capability.hh
+++ b/include/clientkit/capability.hh
@@ -235,6 +235,12 @@ public:
     std::string getPlayServiceIdInStackControl(const Json::Value& playstack_control);
 
     /**
+     * @brief Preprocess directive received from Directive Sequencer.
+     * @param[in] ndir directive
+     */
+    void preprocessDirective(NuguDirective* ndir) override;
+
+    /**
      * @brief Process directive received from Directive Sequencer.
      * @param[in] ndir directive
      */

--- a/include/clientkit/capability_interface.hh
+++ b/include/clientkit/capability_interface.hh
@@ -147,6 +147,12 @@ public:
     virtual std::string getVersion() = 0;
 
     /**
+     * @brief Preprocess directive received from Directive Sequencer.
+     * @param[in] ndir directive
+     */
+    virtual void preprocessDirective(NuguDirective* ndir) = 0;
+
+    /**
      * @brief Process directive received from Directive Sequencer.
      * @param[in] ndir directive
      */

--- a/src/capability/asr_agent.hh
+++ b/src/capability/asr_agent.hh
@@ -52,6 +52,7 @@ public:
     void startRecognition(bool expected);
     void stopRecognition() override;
 
+    void preprocessDirective(NuguDirective* ndir) override;
     void parsingDirective(const char* dname, const char* message) override;
     void updateInfoForContext(Json::Value& ctx) override;
     void saveAllContextInfo();
@@ -96,9 +97,10 @@ private:
     void onRecordData(unsigned char* buf, int length) override;
 
     // parsing directive
-    void parsingExpectSpeech(const char* message);
+    void parsingExpectSpeech(std::string&& dialog_id, const char* message);
     void parsingNotifyResult(const char* message);
     void parsingCancelRecognize(const char* message);
+    void handleExpectSpeech();
 
     void releaseASRFocus(bool is_cancel, ASRError error, bool release_focus = true);
     void cancelRecognition();

--- a/src/clientkit/capability.cc
+++ b/src/clientkit/capability.cc
@@ -270,6 +270,10 @@ std::string Capability::getPlayServiceIdInStackControl(const Json::Value& playst
     return playstack_ps_id;
 }
 
+void Capability::preprocessDirective(NuguDirective* ndir)
+{
+}
+
 void Capability::processDirective(NuguDirective* ndir)
 {
     if (ndir) {

--- a/src/core/capability_manager.cc
+++ b/src/core/capability_manager.cc
@@ -79,6 +79,9 @@ bool CapabilityManager::onPreHandleDirective(NuguDirective* ndir)
         return true;
     }
 
+    nugu_info("preprocessDirective");
+    cap->preprocessDirective(ndir);
+
     return false;
 }
 
@@ -90,8 +93,11 @@ bool CapabilityManager::onHandleDirective(NuguDirective* ndir)
         return false;
     }
 
-    nugu_info("preprocessDirective");
-    preprocessDirective(ndir);
+    std::string groups = nugu_directive_peek_groups(ndir);
+
+    sendCommandAll("receive_directive_group", groups);
+    sendCommandAll("directive_dialog_id", nugu_directive_peek_dialog_id(ndir));
+    playsync_manager->setDirectiveGroups(groups);
 
     nugu_info("processDirective");
     cap->processDirective(ndir);
@@ -267,15 +273,6 @@ std::string CapabilityManager::makeAllContextCommonInfo(bool include_playstack)
     root["client"] = client;
 
     return writer.write(root);
-}
-
-void CapabilityManager::preprocessDirective(NuguDirective* ndir)
-{
-    std::string groups = nugu_directive_peek_groups(ndir);
-
-    sendCommandAll("receive_directive_group", groups);
-    sendCommandAll("directive_dialog_id", nugu_directive_peek_dialog_id(ndir));
-    playsync_manager->setDirectiveGroups(groups);
 }
 
 bool CapabilityManager::isSupportDirectiveVersion(const std::string& version, ICapabilityInterface* cap)

--- a/src/core/capability_manager.hh
+++ b/src/core/capability_manager.hh
@@ -63,7 +63,6 @@ public:
     std::string makeAllContextInfo();
     std::string makeAllContextInfoStack();
 
-    void preprocessDirective(NuguDirective* ndir);
     bool isSupportDirectiveVersion(const std::string& version, ICapabilityInterface* cap);
 
     bool sendCommand(const std::string& from, const std::string& to, const std::string& command, const std::string& param);

--- a/src/core/directive_sequencer.cc
+++ b/src/core/directive_sequencer.cc
@@ -104,14 +104,14 @@ DirectiveSequencer::~DirectiveSequencer()
     if (idler_src != 0)
         g_source_remove(idler_src);
 
+    dump_policies(policy_map);
+    dump_dialog_queue(audio_map, visual_map);
+    dump_msgid(msgid_directive_map);
+
     /* Remove scheduled(but not yet handled) directives */
     for (auto& ndir : scheduled_list) {
         nugu_directive_unref(ndir);
     }
-
-    dump_policies(policy_map);
-    dump_dialog_queue(audio_map, visual_map);
-    dump_msgid(msgid_directive_map);
 
     nugu_network_manager_set_directive_callback(NULL, NULL);
     nugu_network_manager_set_attachment_callback(NULL, NULL);


### PR DESCRIPTION
It change the time of parsing ASR ExpectSpeech directive
from onHandleDirective() to onPreHandleDirective().

It fix to call nugu_directive_unref() in appropriate
location at DirectiveSequencer destructor.

It remove the unnecessary header in ASRAgent.

Signed-off-by: kimhyungrok <hr97gdi@gmail.com>