### PR TITLE
capability: fix return type for property, command

### DIFF
--- a/include/clientkit/capability.hh
+++ b/include/clientkit/capability.hh
@@ -284,15 +284,21 @@ public:
      * @brief It is possible to share own property value among objects.
      * @param[in] property capability property
      * @param[in] values capability property value
+     * @return property get result
+     * @retval true The property is valid
+     * @retval false The property is invalid
      */
-    void getProperty(const std::string& property, std::string& value) override;
+    bool getProperty(const std::string& property, std::string& value) override;
 
     /**
      * @brief It is possible to share own property values among objects.
      * @param[in] property capability property
      * @param[in] values capability property values
+     * @return property get result
+     * @retval true The property is valid
+     * @retval false The property is invalid
      */
-    void getProperties(const std::string& property, std::list<std::string>& values) override;
+    bool getProperties(const std::string& property, std::list<std::string>& values) override;
 
     /**
      * @brief Set the listener object.
@@ -305,8 +311,11 @@ public:
      * @param[in] from capability who send the command
      * @param[in] command command
      * @param[in] param command parameter
+     * @return command result
+     * @retval true The command is valid
+     * @retval false The command is invalid
      */
-    void receiveCommand(const std::string& from, const std::string& command, const std::string& param) override;
+    bool receiveCommand(const std::string& from, const std::string& command, const std::string& param) override;
 
     /**
      * @brief Process command received from capability manager.

--- a/include/clientkit/capability_helper_interface.hh
+++ b/include/clientkit/capability_helper_interface.hh
@@ -88,8 +88,11 @@ public:
      * @param[in] to target CapabilityAgent
      * @param[in] command command
      * @param[in] param parameter
+     * @return send command result
+     * @retval true CapabilityAgent and command are valid
+     * @retval false CapabilityAgent or command is invalid
      */
-    virtual void sendCommand(const std::string& from, const std::string& to, const std::string& command, const std::string& param) = 0;
+    virtual bool sendCommand(const std::string& from, const std::string& to, const std::string& command, const std::string& param) = 0;
 
     /**
      * @brief Request to send event result via CapabilityManager.
@@ -117,16 +120,22 @@ public:
      * @param[in] cap CapabilityAgent
      * @param[in] property property key
      * @param[in] value property value
+     * @return property get result
+     * @retval true CapabilityAgent and property are valid
+     * @retval false CapabilityAgent or property is invalid
      */
-    virtual void getCapabilityProperty(const std::string& cap, const std::string& property, std::string& value) = 0;
+    virtual bool getCapabilityProperty(const std::string& cap, const std::string& property, std::string& value) = 0;
 
     /**
      * @brief Get properties from CapabilityAgent.
      * @param[in] cap CapabilityAgent
      * @param[in] property property key
      * @param[in] values property values
+     * @return property get result
+     * @retval true CapabilityAgent and property are valid
+     * @retval false CapabilityAgent or property is invalid
      */
-    virtual void getCapabilityProperties(const std::string& cap, const std::string& property, std::list<std::string>& values) = 0;
+    virtual bool getCapabilityProperties(const std::string& cap, const std::string& property, std::list<std::string>& values) = 0;
 
     /**
      * @brief Get context info.

--- a/include/clientkit/capability_interface.hh
+++ b/include/clientkit/capability_interface.hh
@@ -163,8 +163,11 @@ public:
      * @param[in] from capability who send the command
      * @param[in] command command
      * @param[in] param command parameter
+     * @return command result
+     * @retval true The command is valid
+     * @retval false The command is invalid
      */
-    virtual void receiveCommand(const std::string& from, const std::string& command, const std::string& param) = 0;
+    virtual bool receiveCommand(const std::string& from, const std::string& command, const std::string& param) = 0;
 
     /**
      * @brief Process command received from capability manager.
@@ -177,15 +180,21 @@ public:
      * @brief It is possible to share own property value among objects.
      * @param[in] property capability property
      * @param[in] values capability property value
+     * @return property get result
+     * @retval true The property is valid
+     * @retval false The property is invalid
      */
-    virtual void getProperty(const std::string& property, std::string& value) = 0;
+    virtual bool getProperty(const std::string& property, std::string& value) = 0;
 
     /**
      * @brief It is possible to share own property values among objects.
      * @param[in] property capability property
      * @param[in] values capability property values
+     * @return property get result
+     * @retval true The property is valid
+     * @retval false The property is invalid
      */
-    virtual void getProperties(const std::string& property, std::list<std::string>& values) = 0;
+    virtual bool getProperties(const std::string& property, std::list<std::string>& values) = 0;
 
     /**
      * @brief Set the listener object

--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -229,7 +229,7 @@ void ASRAgent::saveAllContextInfo()
     all_context_info = capa_helper->makeAllContextInfoStack();
 }
 
-void ASRAgent::receiveCommand(const std::string& from, const std::string& command, const std::string& param)
+bool ASRAgent::receiveCommand(const std::string& from, const std::string& command, const std::string& param)
 {
     std::string convert_command;
     convert_command.resize(command.size());
@@ -242,11 +242,17 @@ void ASRAgent::receiveCommand(const std::string& from, const std::string& comman
             nugu_info("Focus(type: %s) Release", DIALOG_FOCUS_TYPE);
             stopRecognition();
         }
-    } else if (convert_command == "cancel")
+    } else if (convert_command == "cancel") {
         cancelRecognition();
+    } else {
+        nugu_error("invalid command: %s", command.c_str());
+        return false;
+    }
+
+    return true;
 }
 
-void ASRAgent::getProperty(const std::string& property, std::string& value)
+bool ASRAgent::getProperty(const std::string& property, std::string& value)
 {
     value = "";
 
@@ -257,10 +263,15 @@ void ASRAgent::getProperty(const std::string& property, std::string& value)
             Json::StyledWriter writer;
             value = writer.write(es_attr.asr_context);
         }
+    } else {
+        nugu_error("invalid property: %s", property.c_str());
+        return false;
     }
+
+    return true;
 }
 
-void ASRAgent::getProperties(const std::string& property, std::list<std::string>& values)
+bool ASRAgent::getProperties(const std::string& property, std::list<std::string>& values)
 {
     values.clear();
 
@@ -268,7 +279,12 @@ void ASRAgent::getProperties(const std::string& property, std::list<std::string>
         for (int i = 0; i < (int)es_attr.domain_types.size(); i++) {
             values.emplace_back(es_attr.domain_types[i].asString());
         }
+    } else {
+        nugu_error("invalid property: %s", property.c_str());
+        return false;
     }
+
+    return true;
 }
 
 void ASRAgent::checkResponseTimeout()

--- a/src/capability/asr_agent.hh
+++ b/src/capability/asr_agent.hh
@@ -56,9 +56,9 @@ public:
     void updateInfoForContext(Json::Value& ctx) override;
     void saveAllContextInfo();
 
-    void receiveCommand(const std::string& from, const std::string& command, const std::string& param) override;
-    void getProperty(const std::string& property, std::string& value) override;
-    void getProperties(const std::string& property, std::list<std::string>& values) override;
+    bool receiveCommand(const std::string& from, const std::string& command, const std::string& param) override;
+    bool getProperty(const std::string& property, std::string& value) override;
+    bool getProperties(const std::string& property, std::list<std::string>& values) override;
     void checkResponseTimeout();
     void clearResponseTimeout();
 

--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -62,8 +62,8 @@ void AudioPlayerAgent::initialize()
     }
 
     std::string volume_str;
-    capa_helper->getCapabilityProperty("Speaker", "music", volume_str);
-    volume = std::stoi(volume_str);
+    if (capa_helper->getCapabilityProperty("Speaker", "music", volume_str))
+        volume = std::stoi(volume_str);
 
     media_player = core_container->createMediaPlayer();
     media_player->addListener(this);
@@ -479,14 +479,20 @@ void AudioPlayerAgent::updateInfoForContext(Json::Value& ctx)
     ctx[getName()] = aplayer;
 }
 
-void AudioPlayerAgent::receiveCommand(const std::string& from, const std::string& command, const std::string& param)
+bool AudioPlayerAgent::receiveCommand(const std::string& from, const std::string& command, const std::string& param)
 {
     std::string convert_command;
     convert_command.resize(command.size());
     std::transform(command.cbegin(), command.cend(), convert_command.begin(), ::tolower);
 
-    if (!convert_command.compare("setvolume"))
+    if (!convert_command.compare("setvolume")) {
         cur_player->setVolume(std::stoi(param));
+    } else {
+        nugu_error("invalid command: %s", command.c_str());
+        return false;
+    }
+
+    return true;
 }
 
 void AudioPlayerAgent::setCapabilityListener(ICapabilityListener* listener)

--- a/src/capability/audio_player_agent.hh
+++ b/src/capability/audio_player_agent.hh
@@ -47,7 +47,7 @@ public:
 
     void parsingDirective(const char* dname, const char* message) override;
     void updateInfoForContext(Json::Value& ctx) override;
-    void receiveCommand(const std::string& from, const std::string& command, const std::string& param) override;
+    bool receiveCommand(const std::string& from, const std::string& command, const std::string& param) override;
     void setCapabilityListener(ICapabilityListener* clistener) override;
 
     static void directiveDataCallback(NuguDirective* ndir, int seq, void* userdata);

--- a/src/capability/speaker_agent.cc
+++ b/src/capability/speaker_agent.cc
@@ -97,7 +97,7 @@ void SpeakerAgent::setCapabilityListener(ICapabilityListener* clistener)
         speaker_listener = dynamic_cast<ISpeakerListener*>(clistener);
 }
 
-void SpeakerAgent::getProperty(const std::string& property, std::string& value)
+bool SpeakerAgent::getProperty(const std::string& property, std::string& value)
 {
     std::string convert_property;
     convert_property.resize(property.size());
@@ -117,6 +117,8 @@ void SpeakerAgent::getProperty(const std::string& property, std::string& value)
         value = std::to_string(speakers[SpeakerType::NUGU]->volume);
 
     nugu_dbg("request to get property(%s) and return value(%s)", property.c_str(), value.c_str());
+
+    return true;
 }
 
 void SpeakerAgent::setSpeakerInfo(const std::map<SpeakerType, SpeakerInfo>& info)

--- a/src/capability/speaker_agent.hh
+++ b/src/capability/speaker_agent.hh
@@ -33,7 +33,7 @@ public:
     void parsingDirective(const char* dname, const char* message) override;
     void updateInfoForContext(Json::Value& ctx) override;
     void setCapabilityListener(ICapabilityListener* clistener) override;
-    void getProperty(const std::string& property, std::string& value) override;
+    bool getProperty(const std::string& property, std::string& value) override;
 
     void setSpeakerInfo(const std::map<SpeakerType, SpeakerInfo>& info) override;
 

--- a/src/capability/system_agent.cc
+++ b/src/capability/system_agent.cc
@@ -128,7 +128,7 @@ void SystemAgent::setCapabilityListener(ICapabilityListener* clistener)
         system_listener = dynamic_cast<ISystemListener*>(clistener);
 }
 
-void SystemAgent::receiveCommand(const std::string& from, const std::string& command, const std::string& param)
+bool SystemAgent::receiveCommand(const std::string& from, const std::string& command, const std::string& param)
 {
     std::string convert_command;
     convert_command.resize(command.size());
@@ -138,7 +138,12 @@ void SystemAgent::receiveCommand(const std::string& from, const std::string& com
         nugu_dbg("update timer");
         if (timer)
             timer->start();
+    } else {
+        nugu_error("invalid command: %s", command.c_str());
+        return false;
     }
+
+    return true;
 }
 
 void SystemAgent::synchronizeState()

--- a/src/capability/system_agent.hh
+++ b/src/capability/system_agent.hh
@@ -35,7 +35,7 @@ public:
     void updateInfoForContext(Json::Value& ctx) override;
     void setCapabilityListener(ICapabilityListener* clistener) override;
 
-    void receiveCommand(const std::string& from, const std::string& command, const std::string& param) override;
+    bool receiveCommand(const std::string& from, const std::string& command, const std::string& param) override;
 
     void synchronizeState() override;
     void updateUserActivity() override;

--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -64,8 +64,8 @@ void TTSAgent::initialize()
     }
 
     std::string volume_str;
-    capa_helper->getCapabilityProperty("Speaker", "voice_command", volume_str);
-    volume = std::stoi(volume_str);
+    if (capa_helper->getCapabilityProperty("Speaker", "voice_command", volume_str))
+        volume = std::stoi(volume_str);
 
     player = core_container->createTTSPlayer();
     player->addListener(this);

--- a/src/clientkit/capability.cc
+++ b/src/clientkit/capability.cc
@@ -317,14 +317,18 @@ void Capability::parsingDirective(const char* dname, const char* message)
     destroyDirective(pimpl->cur_ndir);
 }
 
-void Capability::getProperty(const std::string& property, std::string& value)
+bool Capability::getProperty(const std::string& property, std::string& value)
 {
     value = "";
+
+    return true;
 }
 
-void Capability::getProperties(const std::string& property, std::list<std::string>& values)
+bool Capability::getProperties(const std::string& property, std::list<std::string>& values)
 {
     values.clear();
+
+    return true;
 }
 
 std::string Capability::sendEvent(const std::string& name, const std::string& context, const std::string& payload, EventResultCallback cb, bool is_sync)
@@ -389,8 +393,9 @@ void Capability::setCapabilityListener(ICapabilityListener* clistener)
 {
 }
 
-void Capability::receiveCommand(const std::string& from, const std::string& command, const std::string& param)
+bool Capability::receiveCommand(const std::string& from, const std::string& command, const std::string& param)
 {
+    return true;
 }
 
 void Capability::receiveCommandAll(const std::string& command, const std::string& param)

--- a/src/core/capability_helper.cc
+++ b/src/core/capability_helper.cc
@@ -77,9 +77,9 @@ bool CapabilityHelper::setMute(bool mute)
     return AudioRecorderManager::getInstance()->setMute(mute);
 }
 
-void CapabilityHelper::sendCommand(const std::string& from, const std::string& to, const std::string& command, const std::string& param)
+bool CapabilityHelper::sendCommand(const std::string& from, const std::string& to, const std::string& command, const std::string& param)
 {
-    CapabilityManager::getInstance()->sendCommand(from, to, command, param);
+    return CapabilityManager::getInstance()->sendCommand(from, to, command, param);
 }
 
 void CapabilityHelper::requestEventResult(NuguEvent* event)
@@ -102,14 +102,14 @@ std::string CapabilityHelper::getWakeupWord()
     return CapabilityManager::getInstance()->getWakeupWord();
 }
 
-void CapabilityHelper::getCapabilityProperty(const std::string& cap, const std::string& property, std::string& value)
+bool CapabilityHelper::getCapabilityProperty(const std::string& cap, const std::string& property, std::string& value)
 {
-    CapabilityManager::getInstance()->getCapabilityProperty(cap, property, value);
+    return CapabilityManager::getInstance()->getCapabilityProperty(cap, property, value);
 }
 
-void CapabilityHelper::getCapabilityProperties(const std::string& cap, const std::string& property, std::list<std::string>& values)
+bool CapabilityHelper::getCapabilityProperties(const std::string& cap, const std::string& property, std::list<std::string>& values)
 {
-    CapabilityManager::getInstance()->getCapabilityProperties(cap, property, values);
+    return CapabilityManager::getInstance()->getCapabilityProperties(cap, property, values);
 }
 
 std::string CapabilityHelper::makeContextInfo(const std::string& cname, Json::Value& ctx)

--- a/src/core/capability_helper.hh
+++ b/src/core/capability_helper.hh
@@ -36,13 +36,13 @@ public:
     IDirectiveSequencer* getDirectiveSequencer() override;
 
     bool setMute(bool mute) override;
-    void sendCommand(const std::string& from, const std::string& to, const std::string& command, const std::string& param) override;
+    bool sendCommand(const std::string& from, const std::string& to, const std::string& command, const std::string& param) override;
     void requestEventResult(NuguEvent* event) override;
     void suspendAll() override;
     void restoreAll() override;
     std::string getWakeupWord() override;
-    void getCapabilityProperty(const std::string& cap, const std::string& property, std::string& value) override;
-    void getCapabilityProperties(const std::string& cap, const std::string& property, std::list<std::string>& values) override;
+    bool getCapabilityProperty(const std::string& cap, const std::string& property, std::string& value) override;
+    bool getCapabilityProperties(const std::string& cap, const std::string& property, std::list<std::string>& values) override;
 
     // about context
     std::string makeContextInfo(const std::string& cname, Json::Value& ctx) override;

--- a/src/core/capability_manager.cc
+++ b/src/core/capability_manager.cc
@@ -300,35 +300,38 @@ void CapabilityManager::sendCommandAll(const std::string& command, const std::st
         iter.second->receiveCommandAll(command, param);
 }
 
-void CapabilityManager::sendCommand(const std::string& from, const std::string& to,
+bool CapabilityManager::sendCommand(const std::string& from, const std::string& to,
     const std::string& command, const std::string& param)
 {
     for (const auto& iter : caps) {
         if (iter.second->getName() == to) {
-            iter.second->receiveCommand(from, command, param);
-            break;
+            return iter.second->receiveCommand(from, command, param);
         }
     }
+
+    return false;
 }
 
-void CapabilityManager::getCapabilityProperty(const std::string& cap, const std::string& property, std::string& value)
+bool CapabilityManager::getCapabilityProperty(const std::string& cap, const std::string& property, std::string& value)
 {
     for (const auto& iter : caps) {
         if (iter.second->getName() == cap) {
-            iter.second->getProperty(property, value);
-            break;
+            return iter.second->getProperty(property, value);
         }
     }
+
+    return false;
 }
 
-void CapabilityManager::getCapabilityProperties(const std::string& cap, const std::string& property, std::list<std::string>& values)
+bool CapabilityManager::getCapabilityProperties(const std::string& cap, const std::string& property, std::list<std::string>& values)
 {
     for (const auto& iter : caps) {
         if (iter.second->getName() == cap) {
-            iter.second->getProperties(property, values);
-            break;
+            return iter.second->getProperties(property, values);
         }
     }
+
+    return false;
 }
 
 void CapabilityManager::suspendAll()

--- a/src/core/capability_manager.hh
+++ b/src/core/capability_manager.hh
@@ -66,10 +66,10 @@ public:
     void preprocessDirective(NuguDirective* ndir);
     bool isSupportDirectiveVersion(const std::string& version, ICapabilityInterface* cap);
 
-    void sendCommand(const std::string& from, const std::string& to, const std::string& command, const std::string& param);
+    bool sendCommand(const std::string& from, const std::string& to, const std::string& command, const std::string& param);
     void sendCommandAll(const std::string& command, const std::string& param);
-    void getCapabilityProperty(const std::string& cap, const std::string& property, std::string& value);
-    void getCapabilityProperties(const std::string& cap, const std::string& property, std::list<std::string>& values);
+    bool getCapabilityProperty(const std::string& cap, const std::string& property, std::string& value);
+    bool getCapabilityProperties(const std::string& cap, const std::string& property, std::list<std::string>& values);
     void suspendAll();
     void restoreAll();
 


### PR DESCRIPTION
Change the current return type 'void' to 'bool' to check result for
getProperty(), getProperties(), receiveCommand() and sendCommand() APIs.

Signed-off-by: Inho Oh <inho.oh@sk.com>