### PR TITLE
TextAgent: Remove unused field

### DIFF
--- a/src/capability/text_agent.cc
+++ b/src/capability/text_agent.cc
@@ -193,12 +193,10 @@ void TextAgent::sendEventTextInput(const std::string& text, const std::string& t
     Json::StyledWriter writer;
     Json::Value root;
     std::string ps_id = "";
-    std::string property = "";
     std::string asr_context = "";
     std::list<std::string> domainTypes;
 
     capa_helper->getCapabilityProperty("ASR", "es.playServiceId", ps_id);
-    capa_helper->getCapabilityProperty("ASR", "es.property", property);
     capa_helper->getCapabilityProperty("ASR", "es.asrContext", asr_context);
     capa_helper->getCapabilityProperties("ASR", "es.domainTypes", domainTypes);
 
@@ -207,8 +205,6 @@ void TextAgent::sendEventTextInput(const std::string& text, const std::string& t
         root["token"] = token;
     if (ps_id.size())
         root["playServiceId"] = ps_id;
-    if (property.size())
-        root["property"] = property;
     if (asr_context.size())
         root["asrContext"] = asr_context;
     if (domainTypes.size()) {


### PR DESCRIPTION
The `property` is removed in specification.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>