### PR TITLE
capability: add ResetConnection to SystemAgent

### DIFF
--- a/include/base/nugu_network_manager.h
+++ b/include/base/nugu_network_manager.h
@@ -338,6 +338,14 @@ int nugu_network_manager_disconnect(void);
 int nugu_network_manager_handoff(const NuguNetworkServerPolicy *policy);
 
 /**
+ * @brief Immediately disconnect the current connection and reconnect.
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ */
+int nugu_network_manager_reset_connection(void);
+
+/**
  * @brief Set the access token value.
  * @param[in] token access token
  * @return result

--- a/src/base/nugu_network_manager.c
+++ b/src/base/nugu_network_manager.c
@@ -776,6 +776,28 @@ EXPORT_API int nugu_network_manager_connect(void)
 	return _start_registry(_network);
 }
 
+static void _disconnect(NetworkManager *nm)
+{
+	nugu_info("disconnecting: current step is %d", nm->step);
+
+	nm->serverinfo = NULL;
+
+	if (nm->server) {
+		dg_server_free(nm->server);
+		nm->server = NULL;
+	}
+
+	if (nm->handoff) {
+		dg_server_free(nm->handoff);
+		nm->handoff = NULL;
+	}
+
+	if (nm->registry) {
+		dg_registry_free(nm->registry);
+		nm->registry = NULL;
+	}
+}
+
 EXPORT_API int nugu_network_manager_disconnect(void)
 {
 	g_return_val_if_fail(_network != NULL, -1);
@@ -785,26 +807,23 @@ EXPORT_API int nugu_network_manager_disconnect(void)
 		return 0;
 	}
 
-	nugu_info("disconnecting: current step is %d", _network->step);
-
-	_network->serverinfo = NULL;
-
-	if (_network->server) {
-		dg_server_free(_network->server);
-		_network->server = NULL;
-	}
-
-	if (_network->handoff) {
-		dg_server_free(_network->handoff);
-		_network->handoff = NULL;
-	}
-
-	if (_network->registry) {
-		dg_registry_free(_network->registry);
-		_network->registry = NULL;
-	}
+	_disconnect(_network);
 
 	_update_status(_network, NUGU_NETWORK_DISCONNECTED);
+
+	return 0;
+}
+
+EXPORT_API int nugu_network_manager_reset_connection(void)
+{
+	if (!_network) {
+		nugu_error("network manager not initialized");
+		return -1;
+	}
+
+	_disconnect(_network);
+
+	_start_registry(_network);
 
 	return 0;
 }

--- a/src/capability/system_agent.cc
+++ b/src/capability/system_agent.cc
@@ -27,7 +27,7 @@
 namespace NuguCapability {
 
 static const char* CAPABILITY_NAME = "System";
-static const char* CAPABILITY_VERSION = "1.2";
+static const char* CAPABILITY_VERSION = "1.3";
 
 SystemAgent::SystemAgent()
     : Capability(CAPABILITY_NAME, CAPABILITY_VERSION)
@@ -98,6 +98,8 @@ void SystemAgent::parsingDirective(const char* dname, const char* message)
         parsingResetUserInactivity(message);
     else if (!strcmp(dname, "HandoffConnection"))
         parsingHandoffConnection(message);
+    else if (!strcmp(dname, "ResetConnection"))
+        parsingResetConnection(message);
     else if (!strcmp(dname, "TurnOff"))
         parsingTurnOff(message);
     else if (!strcmp(dname, "UpdateState"))
@@ -385,4 +387,23 @@ void SystemAgent::parsingNoop(const char* message)
 {
     // ignore directive
 }
+
+void SystemAgent::parsingResetConnection(const char* message)
+{
+    Json::Value root;
+    Json::Reader reader;
+    std::string desc;
+
+    if (!reader.parse(message, root)) {
+        nugu_error("parsing error");
+        return;
+    }
+
+    desc = root["description"].asString();
+    if (desc.size() != 0)
+        nugu_dbg("description: %s", desc.c_str());
+
+    nugu_network_manager_reset_connection();
+}
+
 } // NuguCapability

--- a/src/capability/system_agent.hh
+++ b/src/capability/system_agent.hh
@@ -55,6 +55,7 @@ private:
     void parsingNoDirectives(const char* message);
     void parsingRevoke(const char* message);
     void parsingNoop(const char* message);
+    void parsingResetConnection(const char* message);
 
     ISystemListener* system_listener;
     INuguTimer* timer;


### PR DESCRIPTION
Add 'ResetConnection' directive to SystemAgent. When receiving this
message from the server, the SDK should immediately disconnect the
current connection and seamlessly start a new connection from the
device-gateway-registry step.

The following is an example of network state change event according
to network control.

Connect:

    DISCONNECTED -> CONNECTING -> CONNECTED or DISCONNECTED

Disconnect:

    CONNECTED -> DISCONNECTED

Handoff:

    CONNECTED -> CONNECTING -> CONNECTED or DISCONNECTED

ResetConnection:

    CONNECTED -> CONNECTING -> CONNECTED or DISCONNECTED

Signed-off-by: Inho Oh <inho.oh@sk.com>