### PR TITLE
dialog:fix to handle previous dialog

### DIFF
--- a/include/clientkit/capability.hh
+++ b/include/clientkit/capability.hh
@@ -244,7 +244,7 @@ public:
      * @brief Process directive received from Directive Sequencer.
      * @param[in] ndir directive
      */
-    void processDirective(NuguDirective* ndir) override;
+    void processDirective(NuguDirective* ndir) override final;
 
     /**
      * @brief Destroy directive received from Directive Sequencer.

--- a/include/clientkit/playstack_manager_interface.hh
+++ b/include/clientkit/playstack_manager_interface.hh
@@ -115,6 +115,13 @@ public:
     virtual void remove(const std::string& ps_id, PlayStackRemoveMode mode = PlayStackRemoveMode::Normal) = 0;
 
     /**
+     * @brief Check whether to be stacked condition if the current layer is added.
+     * @param[in] ndir directive
+     * @return true if stacked condition, otherwise false
+     */
+    virtual bool isStackedCondition(NuguDirective* ndir) = 0;
+
+    /**
      * @brief Stop timer for removing playstack.
      */
     virtual void stopHolding() = 0;

--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -267,7 +267,11 @@ void AudioPlayerAgent::executeOnBackgroundAction()
     nugu_dbg("executeOnBackgroundAction()");
 
     nugu_dbg("is_finished: %d, cur_player->state(): %d", is_finished, cur_player->state());
-    if (cur_player->state() == MediaPlayerState::PLAYING) {
+
+    MediaPlayerState state = cur_player->state();
+
+    if (state == MediaPlayerState::PLAYING || state == MediaPlayerState::PREPARE
+        || state == MediaPlayerState::READY) {
         is_paused_by_unfocus = true;
         if (!cur_player->pause()) {
             nugu_error("pause media failed");
@@ -863,12 +867,7 @@ void AudioPlayerAgent::parsingPlay(const char* message)
 
     is_finished = false;
     is_paused_by_unfocus = false;
-
-    if (speak_dir) {
-        nugu_directive_remove_data_callback(speak_dir);
-        destroyDirective(speak_dir);
-        speak_dir = nullptr;
-    }
+    speak_dir = nullptr;
 
     nugu_dbg("= token: %s", token.c_str());
     nugu_dbg("= url: %s", url.c_str());

--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -406,6 +406,7 @@ void TTSAgent::parsingSpeak(const char* message)
     }
 
     has_attachment = true;
+    speak_dir = nullptr;
 
     stopTTS();
 

--- a/src/clientkit/capability.cc
+++ b/src/clientkit/capability.cc
@@ -283,6 +283,19 @@ void Capability::processDirective(NuguDirective* ndir)
         message = nugu_directive_peek_json(ndir);
         dname = nugu_directive_peek_name(ndir);
 
+        // handle previous dialog if exist
+        if (pimpl->cur_ndir) {
+            nugu_directive_remove_data_callback(pimpl->cur_ndir);
+
+            if (playstack_manager->isStackedCondition(ndir)) {
+                nugu_dbg("complete previous dialog");
+                directive_sequencer->complete(pimpl->cur_ndir);
+            } else {
+                nugu_dbg("cancel previous dialog");
+                directive_sequencer->cancel(nugu_directive_peek_dialog_id(pimpl->cur_ndir));
+            }
+        }
+
         pimpl->cur_ndir = ndir;
 
         if (!message || !dname) {

--- a/src/core/playstack_manager.cc
+++ b/src/core/playstack_manager.cc
@@ -172,6 +172,11 @@ void PlayStackManager::remove(const std::string& ps_id, PlayStackRemoveMode mode
     }
 }
 
+bool PlayStackManager::isStackedCondition(NuguDirective* ndir)
+{
+    return ndir && isStackedCondition(extractPlayStackLayer(ndir));
+}
+
 void PlayStackManager::stopHolding()
 {
     if (timer->isStarted()) {

--- a/src/core/playstack_manager.hh
+++ b/src/core/playstack_manager.hh
@@ -38,6 +38,7 @@ public:
 
     void add(const std::string& ps_id, NuguDirective* ndir) override;
     void remove(const std::string& ps_id, PlayStackRemoveMode mode = PlayStackRemoveMode::Normal) override;
+    bool isStackedCondition(NuguDirective* ndir) override;
     void stopHolding() override;
     void resetHolding() override;
     bool isActiveHolding();

--- a/tests/core/test-core-playstack-manager.cc
+++ b/tests/core/test-core-playstack-manager.cc
@@ -224,6 +224,17 @@ static void test_playstack_manager_controlHolding(TestFixture* fixture, gconstpo
     g_assert(fixture->playstack_manager->isActiveHolding());
 }
 
+static void test_playstack_manager_checkStack(TestFixture* fixture, gconstpointer ignored)
+{
+    fixture->playstack_manager->add("ps_id_1", fixture->ndir_info);
+    g_assert(!fixture->playstack_manager->isStackedCondition(fixture->ndir_info));
+
+    fixture->playstack_manager->remove("ps_id_1", PlayStackRemoveMode::Immediately);
+    fixture->playstack_manager->add("ps_id_2", fixture->ndir_media);
+    g_assert(fixture->playstack_manager->isStackedCondition(fixture->ndir_info));
+    g_assert(!fixture->playstack_manager->isStackedCondition(fixture->ndir_media));
+}
+
 int main(int argc, char* argv[])
 {
 #if !GLIB_CHECK_VERSION(2, 36, 0)
@@ -239,6 +250,7 @@ int main(int argc, char* argv[])
     G_TEST_ADD_FUNC("/core/PlayStackManager/holdStack", test_playstack_manager_holdStack);
     G_TEST_ADD_FUNC("/core/PlayStackManager/layerPolicy", test_playstack_manager_layerPolicy);
     G_TEST_ADD_FUNC("/core/PlayStackManager/controlHolding", test_playstack_manager_controlHolding);
+    G_TEST_ADD_FUNC("/core/PlayStackManager/checkStack", test_playstack_manager_checkStack);
 
     return g_test_run();
 }


### PR DESCRIPTION
If the previous dialog which is not handled exist,
it fix to handle that proper way.

1) If playstack is stacked condition, it handle to complete.
2) If playstack is not stacked condition, it handle to cancel.

Because, the processDirective of Capability execute important flow
about directive, it change to prevent overriding in derived class.

When the AudioPlayerAgent go to background focus,
if the player state is PREPARE, it cause skip to pause player,
so, media is playing continously.
For preventing that situation, it add conditions about PREPARE, READY case.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>