### PR TITLE
capability: add missing override annotation

### DIFF
--- a/include/clientkit/capability.hh
+++ b/include/clientkit/capability.hh
@@ -174,7 +174,7 @@ public:
      * @param[in] data raw data which is received from server about event (json format)
      * @param[in] success whether receive event response
      */
-    void notifyEventResponse(const std::string& msg_id, const std::string& data, bool success);
+    void notifyEventResponse(const std::string& msg_id, const std::string& data, bool success) override;
 
     /**
      * @brief Add event name and directive name for referred dialog request id.


### PR DESCRIPTION
add missing `override` annotation to `notifyEventResponse` API
in the `capability.hh` header file.

Signed-off-by: Inho Oh <inho.oh@sk.com>