### PR TITLE
core: add missing map erase to directive sequencer

### DIFF
--- a/src/core/directive_sequencer.cc
+++ b/src/core/directive_sequencer.cc
@@ -462,6 +462,8 @@ bool DirectiveSequencer::cancel(const std::string& dialog_id)
 
         /* Clear the queue */
         audio_iter->second.clear();
+
+        audio_map.erase(dialog_id);
     }
 
     /* remove visual queue */
@@ -478,9 +480,13 @@ bool DirectiveSequencer::cancel(const std::string& dialog_id)
 
         /* Clear the queue */
         visual_iter->second.clear();
+
+        visual_map.erase(dialog_id);
     }
 
     dump_msgid(msgid_directive_map);
+
+    dump_dialog_queue(audio_map, visual_map);
 
     return true;
 }


### PR DESCRIPTION
There was a bug where the audio/visual map's dialog_id key was not
deleted when calling the `cancel` API.

Signed-off-by: Inho Oh <inho.oh@sk.com>