### PR TITLE
plugin: fix plugin de-initialize order

### DIFF
--- a/src/base/nugu_pcm.c
+++ b/src/base/nugu_pcm.c
@@ -104,8 +104,10 @@ EXPORT_API int nugu_pcm_driver_register(NuguPcmDriver *driver)
 	}
 
 	_pcm_drivers = g_list_append(_pcm_drivers, driver);
+
 	if (!_default_driver)
 		nugu_pcm_driver_set_default(driver);
+
 	return 0;
 }
 
@@ -133,6 +135,8 @@ EXPORT_API int nugu_pcm_driver_remove(NuguPcmDriver *driver)
 EXPORT_API int nugu_pcm_driver_set_default(NuguPcmDriver *driver)
 {
 	g_return_val_if_fail(driver != NULL, -1);
+
+	nugu_info("set default pcm driver: '%s'", driver->name);
 
 	_default_driver = driver;
 

--- a/src/base/nugu_player.c
+++ b/src/base/nugu_player.c
@@ -95,8 +95,10 @@ EXPORT_API int nugu_player_driver_register(NuguPlayerDriver *driver)
 	}
 
 	_player_drivers = g_list_append(_player_drivers, driver);
+
 	if (!_default_driver)
 		nugu_player_driver_set_default(driver);
+
 	return 0;
 }
 
@@ -124,6 +126,8 @@ EXPORT_API int nugu_player_driver_remove(NuguPlayerDriver *driver)
 EXPORT_API int nugu_player_driver_set_default(NuguPlayerDriver *driver)
 {
 	g_return_val_if_fail(driver != NULL, -1);
+
+	nugu_info("set default player driver: '%s'", driver->name);
 
 	_default_driver = driver;
 

--- a/src/base/nugu_plugin.c
+++ b/src/base/nugu_plugin.c
@@ -256,6 +256,8 @@ EXPORT_API void nugu_plugin_deinitialize(void)
 	if (_plugin_list == NULL)
 		return;
 
+	_plugin_list = g_list_reverse(_plugin_list);
+
 	for (cur = _plugin_list; cur; cur = cur->next) {
 		NuguPlugin *p = cur->data;
 

--- a/src/base/nugu_recorder.c
+++ b/src/base/nugu_recorder.c
@@ -98,8 +98,10 @@ EXPORT_API int nugu_recorder_driver_register(NuguRecorderDriver *driver)
 	}
 
 	_recorder_drivers = g_list_append(_recorder_drivers, driver);
+
 	if (!_default_driver)
 		nugu_recorder_driver_set_default(driver);
+
 	return 0;
 }
 
@@ -127,6 +129,8 @@ EXPORT_API int nugu_recorder_driver_remove(NuguRecorderDriver *driver)
 EXPORT_API int nugu_recorder_driver_set_default(NuguRecorderDriver *driver)
 {
 	g_return_val_if_fail(driver != NULL, -1);
+
+	nugu_info("set default recorder driver: '%s'", driver->name);
 
 	_default_driver = driver;
 


### PR DESCRIPTION
Currently, the plugin initialization order is applied equally to the
deinitialization order, which can cause problems when there is a
dependency relationship.

Therefore, when deinitialization, change to call `unload` function
in reverse order.

As-is:

    init a -> init b -> ... -> de-init a -> de-init b

To-be:

    init a -> init b -> ... -> de-init b -> de-init a

Signed-off-by: Inho Oh <inho.oh@sk.com>