### PR TITLE
network: fix event send callback

### DIFF
--- a/examples/standalone/nugu_sample.cc
+++ b/examples/standalone/nugu_sample.cc
@@ -102,19 +102,38 @@ public:
         nugu_sample_manager->handleNetworkResult(false);
     }
 
-    void onEventSent(const char* ename, const char* msg_id, const char* dialog_id, const char* referrer_id)
+    void onEventSend(NuguEvent *nev)
     {
         std::string msg;
         msg.append("send event(")
-            .append(ename)
-            .append(") msg_id - ")
-            .append(msg_id)
+            .append(nugu_event_peek_namespace(nev))
+            .append(".")
+            .append(nugu_event_peek_name(nev))
+            .append(")\n\tmsg_id: ")
+            .append(nugu_event_peek_msg_id(nev))
             .append("\n\tdialog_id: ")
-            .append(dialog_id);
+            .append(nugu_event_peek_dialog_id(nev));
 
-        if (referrer_id)
-            msg.append(", referrer_id: ")
-                .append(referrer_id);
+        if (nugu_event_peek_referrer_id(nev))
+            msg.append("\n\treferrer_id: ")
+                .append(nugu_event_peek_referrer_id(nev));
+
+        msg_info(std::move(msg));
+    }
+
+    void onEventAttachmentSend(NuguEvent* nev, int seq, bool is_end, size_t length, unsigned char* data)
+    {
+        std::string msg;
+        msg.append("send attachment(")
+                    .append(nugu_event_peek_namespace(nev))
+            .append(".")
+            .append(nugu_event_peek_name(nev))
+            .append(", seq=")
+            .append(std::to_string(seq))
+            .append(", is_end=")
+            .append(std::to_string(is_end))
+            .append(", length=")
+            .append(std::to_string(length));
 
         msg_info(std::move(msg));
     }

--- a/include/base/nugu_network_manager.h
+++ b/include/base/nugu_network_manager.h
@@ -97,6 +97,15 @@ typedef void (*NuguNetworkManagerEventSendNotifyCallback)(NuguEvent *nev,
 							  void *userdata);
 
 /**
+ * @brief Callback prototype for notification of event data sending requests
+ * @see nugu_network_manager_send_event_data()
+ * @see nugu_network_manager_set_event_data_send_notify_callback()
+ */
+typedef void (*NuguNetworkManagerEventDataSendNotifyCallback)(
+	NuguEvent *nev, int is_end, size_t length, unsigned char *data,
+	void *userdata);
+
+/**
  * @brief Callback prototype for result of event transfer request.
  * @see nugu_network_manager_send_event()
  * @see nugu_network_manager_set_event_result_callback()
@@ -189,6 +198,17 @@ int nugu_network_manager_set_handoff_status_callback(
  */
 int nugu_network_manager_set_event_send_notify_callback(
 	NuguNetworkManagerEventSendNotifyCallback callback, void *userdata);
+
+/**
+ * @brief Set event data send notify callback
+ * @param[in] callback callback function
+ * @param[in] userdata data to pass to the user callback
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ */
+int nugu_network_manager_set_event_data_send_notify_callback(
+	NuguNetworkManagerEventDataSendNotifyCallback callback, void *userdata);
 
 /**
  * @brief Set event send result callback

--- a/include/clientkit/network_manager_interface.hh
+++ b/include/clientkit/network_manager_interface.hh
@@ -18,6 +18,7 @@
 #define __NUGU_INETWORK_MANAGER_INTERFACE_H__
 
 #include <string>
+#include <base/nugu_event.h>
 
 namespace NuguClientKit {
 
@@ -65,13 +66,16 @@ public:
     virtual void onError(NetworkError error);
 
     /**
-     * @brief Report that an event has been sent to the server.
-     * @param[in] ename event name
-     * @param[in] msg_id event message id
-     * @param[in] dialog_id event dialog request id
-     * @param[in] referrer_id event referrer dialog request id
+     * @brief Report that the event will be sent to the server.
+     * @param[in] nev NuguEvent object
      */
-    virtual void onEventSent(const char* ename, const char* msg_id, const char* dialog_id, const char* referrer_id);
+    virtual void onEventSend(NuguEvent *nev);
+
+    /**
+     * @brief Report that the attachment will be sent to the server.
+     * @param[in] nev NuguEvent object
+     */
+    virtual void onEventAttachmentSend(NuguEvent *nev, int seq, bool is_end, size_t length, unsigned char *data);
 
     /**
      * @brief Report the result of sending an event from the server.

--- a/src/clientkit/network_manager_interface.cc
+++ b/src/clientkit/network_manager_interface.cc
@@ -19,7 +19,8 @@ namespace NuguClientKit {
 
 void INetworkManagerListener::onStatusChanged(NetworkStatus status) {}
 void INetworkManagerListener::onError(NetworkError error) {}
-void INetworkManagerListener::onEventSent(const char* ename, const char* msg_id, const char* dialog_id, const char* referrer_id) {}
+void INetworkManagerListener::onEventSend(NuguEvent *nev) {}
+void INetworkManagerListener::onEventAttachmentSend(NuguEvent *nev, int seq, bool is_end, size_t length, unsigned char *data) {}
 void INetworkManagerListener::onEventSendResult(const char* msg_id, bool success, int code) {}
 void INetworkManagerListener::onEventResponse(const char* msg_id, const char* data, bool success) {}
 


### PR DESCRIPTION
There is no place where the onEventSent callback is used, and it seems
more useful to use the callback before sending the event and before
sending the attachment.

Signed-off-by: Inho Oh <inho.oh@sk.com>