### PR TITLE
Capability: add display interface

### DIFF
--- a/examples/standalone/capability/audio_player_listener.cc
+++ b/examples/standalone/capability/audio_player_listener.cc
@@ -97,3 +97,47 @@ bool AudioPlayerListener::requestToGetCachedContent(const std::string& key, std:
 {
     return false;
 }
+
+void AudioPlayerListener::renderDisplay(const std::string& id, const std::string& type, const std::string& json_payload, const std::string& dialog_id)
+{
+    std::cout << "[AudioPlayer][id:" << id << "] renderDisplay - type: " << type << std::endl;
+}
+
+bool AudioPlayerListener::clearDisplay(const std::string& id, bool unconditionally)
+{
+    std::cout << "[AudioPlayer][id:" << id << "] clearDisplay - unconditionally: " << (int)unconditionally << std::endl;
+    return false;
+}
+
+void AudioPlayerListener::controlDisplay(const std::string& id, ControlType type, ControlDirection direction)
+{
+    std::cout << "[AudioPlayer][id:" << id << "] controlDisplay" << std::endl;
+}
+
+void AudioPlayerListener::updateDisplay(const std::string& id, const std::string& json_payload)
+{
+    std::cout << "[AudioPlayer][id:" << id << "] updateDisplay" << std::endl;
+}
+
+bool AudioPlayerListener::requestLyricsPageAvailable(const std::string& id, bool& visible)
+{
+    std::cout << "[AudioPlayer] requestLyricsPageAvailable" << std::endl;
+    return false;
+}
+
+bool AudioPlayerListener::showLyrics(const std::string& id)
+{
+    std::cout << "[AudioPlayer] showLyrics" << std::endl;
+    return false;
+}
+
+bool AudioPlayerListener::hideLyrics(const std::string& id)
+{
+    std::cout << "[AudioPlayer] hideLyrics" << std::endl;
+    return false;
+}
+
+void AudioPlayerListener::updateMetaData(const std::string& id, const std::string& json_payload)
+{
+    std::cout << "[AudioPlayer][id:" << id << "] updateMetaData - json: " << json_payload << std::endl;
+}

--- a/examples/standalone/capability/audio_player_listener.hh
+++ b/examples/standalone/capability/audio_player_listener.hh
@@ -36,6 +36,16 @@ public:
     void repeatChanged(RepeatType repeat, const std::string& dialog_id) override;
     void requestContentCache(const std::string& key, const std::string& playurl) override;
     bool requestToGetCachedContent(const std::string& key, std::string& filepath) override;
+
+    // implements IAudioPlayerDisplayListener
+    void renderDisplay(const std::string& id, const std::string& type, const std::string& json_payload, const std::string& dialog_id) override;
+    bool clearDisplay(const std::string& id, bool unconditionally) override;
+    void controlDisplay(const std::string& id, ControlType type, ControlDirection direction) override;
+    void updateDisplay(const std::string& id, const std::string& json_payload) override;
+    bool requestLyricsPageAvailable(const std::string& id, bool& visible) override;
+    bool showLyrics(const std::string& id) override;
+    bool hideLyrics(const std::string& id) override;
+    void updateMetaData(const std::string& id, const std::string& json_payload) override;
 };
 
 #endif /* __AUDIO_PLAYER_LISTENER_H__ */

--- a/include/capability/audio_player_interface.hh
+++ b/include/capability/audio_player_interface.hh
@@ -17,6 +17,7 @@
 #ifndef __NUGU_AUDIO_PLAYER_INTERFACE_H__
 #define __NUGU_AUDIO_PLAYER_INTERFACE_H__
 
+#include <capability/display_interface.hh>
 #include <clientkit/capability_interface.hh>
 
 namespace NuguCapability {
@@ -66,18 +67,10 @@ enum class RepeatType {
 };
 
 /**
- * @brief ControlLyricsDirection
- */
-enum class ControlLyricsDirection {
-    PREVIOUS, /**< Previous direction */
-    NEXT /**< Next direction */
-};
-
-/**
  * @brief audioplayer listener interface
  * @see IAudioPlayerHandler
  */
-class IAudioPlayerListener : public ICapabilityListener {
+class IAudioPlayerListener : public IAudioPlayerDisplayListener {
 public:
     virtual ~IAudioPlayerListener() = default;
 
@@ -146,7 +139,8 @@ public:
  * @brief audioplayer handler interface
  * @see IAudioPlayerListener
  */
-class IAudioPlayerHandler : virtual public ICapabilityInterface {
+class IAudioPlayerHandler : virtual public ICapabilityInterface,
+                            virtual public IDisplayHandler {
 public:
     virtual ~IAudioPlayerHandler() = default;
 

--- a/include/capability/display_interface.hh
+++ b/include/capability/display_interface.hh
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NUGU_DISPLAY_INTERFACE_H__
+#define __NUGU_DISPLAY_INTERFACE_H__
+
+#include <clientkit/capability_interface.hh>
+
+namespace NuguCapability {
+
+using namespace NuguClientKit;
+
+/**
+ * @file display_interface.hh
+ * @defgroup DisplayInterface DisplayInterface
+ * @ingroup SDKNuguCapability
+ * @brief Display capability interface
+ *
+ * Manage rendering and erasing according to metadata delivery and
+ * context management policies to show the graphical user interface (GUI) on devices with displays.
+ *
+ * @{
+ */
+
+enum class ControlDirection {
+    PREVIOUS, /**< Previous direction */
+    NEXT /**< Next direction */
+};
+
+enum class ControlType {
+    Focus, /**< Focus type */
+    Scroll, /**< Scroll type */
+};
+
+/**
+ * @brief display listener interface
+ * @see IDisplayHandler
+ */
+class IDisplayListener : public ICapabilityListener {
+public:
+    virtual ~IDisplayListener() = default;
+    /**
+     * @brief Request rendering by passing metadata so that the device with the display can draw on the screen.
+     * @param[in] id display template id
+     * @param[in] type display template type
+     * @param[in] json_payload template in json format for display
+     * @param[in] dialog_id dialog request id
+     */
+    virtual void renderDisplay(const std::string& id, const std::string& type, const std::string& json_payload, const std::string& dialog_id) = 0;
+
+    /**
+     * @brief The SDK will ask you to delete the rendered display on the display according to the service context maintenance policy.
+     * @param[in] id display template id
+     * @param[in] unconditionally whether clear display unconditionally or not
+     * @return true if display is cleared
+     */
+    virtual bool clearDisplay(const std::string& id, bool unconditionally) = 0;
+
+    /**
+     * @brief Request to control the display with type and direction
+     * @param[in] id display template id
+     * @param[in] type control type
+     * @param[in] direction control direction
+     */
+    virtual void controlDisplay(const std::string& id, ControlType type, ControlDirection direction) = 0;
+
+    /**
+     * @brief Request to update the current display
+     * @param[in] id display template id
+     * @param[in] json_payload template in json format for display
+     */
+    virtual void updateDisplay(const std::string& id, const std::string& json_payload) = 0;
+};
+
+/**
+ * @brief audioplayer's display listener interface
+ * @see IDisplayListener
+ */
+class IAudioPlayerDisplayListener : public IDisplayListener {
+public:
+    virtual ~IAudioPlayerDisplayListener() = default;
+
+    /**
+     * @brief SDK request information about device's lyrics page available
+     * @param[in] id display template id
+     * @param[out] visible show lyrics page visible
+     * @return return device's lyrics page available
+     */
+    virtual bool requestLyricsPageAvailable(const std::string& id, bool& visible) = 0;
+
+    /**
+     * @brief Request to the user to show the lyrics page.
+     * @param[in] id display template id
+     * @return return true if show lyrics success, otherwise false.
+     */
+    virtual bool showLyrics(const std::string& id) = 0;
+
+    /**
+     * @brief Request to the user to hide the lyrics page.
+     * @param[in] id display template id
+     * @return return true if hide lyrics success, otherwise false.
+     */
+    virtual bool hideLyrics(const std::string& id) = 0;
+
+    /**
+     * @brief Request to update metadata the current display
+     * @param[in] id display template id
+     * @param[in] json_payload template in json format for display
+     */
+    virtual void updateMetaData(const std::string& id, const std::string& json_payload) = 0;
+};
+
+/**
+ * @brief display handler interface
+ * @see IDisplayListener
+ */
+class IDisplayHandler : virtual public ICapabilityInterface {
+public:
+    virtual ~IDisplayHandler() = default;
+
+    /**
+     * @brief The user reports that the display was rendered.
+     * @param[in] id display template id
+     */
+    virtual void displayRendered(const std::string& id) = 0;
+
+    /**
+     * @brief The user reports that the display is cleared.
+     * @param[in] id display template id
+     */
+    virtual void displayCleared(const std::string& id) = 0;
+
+    /**
+     * @brief The user informs the selected item of the list and reports the token information of the item.
+     * @param[in] id display template id
+     * @param[in] item_token parsed token from metadata
+     */
+    virtual void elementSelected(const std::string& id, const std::string& item_token) = 0;
+
+    /**
+     * @brief The user informs the control result
+     * @param[in] id display template id
+     * @param[in] type control type
+     * @param[in] direction control direction
+     */
+    virtual void informControlResult(const std::string& id, ControlType type, ControlDirection direction) = 0;
+
+    /**
+     * @brief Set the Listener object
+     * @param[in] listener listener object
+     */
+    virtual void setListener(IDisplayListener* listener) = 0;
+
+    /**
+     * @brief Remove the Listener object
+     */
+    virtual void removeListener(IDisplayListener* listener) = 0;
+
+    /**
+     * @brief Stop display rendering hold timer.
+     * @param[in] id display template id
+     */
+    virtual void stopRenderingTimer(const std::string& id) = 0;
+};
+
+/**
+ * @}
+ */
+
+} // NuguCapability
+
+#endif /* __NUGU_DISPLAY_INTERFACE_H__ */

--- a/src/capability/audio_player_agent.hh
+++ b/src/capability/audio_player_agent.hh
@@ -18,6 +18,7 @@
 #define __NUGU_AUDIO_PLAYER_AGENT_H__
 
 #include "capability/audio_player_interface.hh"
+#include "capability/display_interface.hh"
 #include "clientkit/capability.hh"
 
 namespace NuguCapability {
@@ -72,6 +73,14 @@ public:
     void onFocusChanged(FocusState state) override;
     void executeOnForegroundAction();
     void executeOnBackgroundAction();
+
+    void displayRendered(const std::string& id) override;
+    void displayCleared(const std::string& id) override;
+    void elementSelected(const std::string& id, const std::string& item_token) override;
+    void informControlResult(const std::string& id, ControlType type, ControlDirection direction) override;
+    void setListener(IDisplayListener* listener) override;
+    void removeListener(IDisplayListener* listener) override;
+    void stopRenderingTimer(const std::string& id) override;
 
     void sendEventPlaybackStarted(EventResultCallback cb = nullptr);
     void sendEventPlaybackFinished(EventResultCallback cb = nullptr);
@@ -145,7 +154,11 @@ private:
     bool is_finished;
     bool volume_update;
     int volume;
+    std::string template_id;
+    std::string template_view;
+    std::string template_type;
     std::vector<IAudioPlayerListener*> aplayer_listeners;
+    IAudioPlayerDisplayListener* display_listener;
 };
 
 } // NuguCapability


### PR DESCRIPTION
Display Interface was added to support display devices. When creating
a DisplayAgent outside the SDK, refer to it, and the Application can
receive Display-related information by registering a Listener to
the AudioPlayerAgent.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>