### PR TITLE
session:apply session clearance

### DIFF
--- a/include/clientkit/session_manager_interface.hh
+++ b/include/clientkit/session_manager_interface.hh
@@ -73,6 +73,11 @@ public:
      * @return session info which is formatted to json type
      */
     virtual Json::Value getActiveSessionInfo() = 0;
+
+    /**
+     * @brief Clear all session info.
+     */
+    virtual void clear() = 0;
 };
 
 /**

--- a/src/clientkit/capability.cc
+++ b/src/clientkit/capability.cc
@@ -293,6 +293,7 @@ void Capability::processDirective(NuguDirective* ndir)
             } else {
                 nugu_dbg("cancel previous dialog");
                 directive_sequencer->cancel(nugu_directive_peek_dialog_id(pimpl->cur_ndir));
+                session_manager->clear();
             }
         }
 

--- a/src/core/session_manager.cc
+++ b/src/core/session_manager.cc
@@ -23,8 +23,7 @@ namespace NuguCore {
 
 SessionManager::~SessionManager()
 {
-    session_map.clear();
-    active_list.clear();
+    clear();
 }
 
 void SessionManager::set(const std::string& dialog_id, Session&& session)
@@ -98,6 +97,12 @@ Json::Value SessionManager::getActiveSessionInfo()
     }
 
     return session_info_list;
+}
+
+void SessionManager::clear()
+{
+    session_map.clear();
+    active_list.clear();
 }
 
 const SessionManager::ActiveDialogs& SessionManager::getActiveList()

--- a/src/core/session_manager.hh
+++ b/src/core/session_manager.hh
@@ -39,6 +39,7 @@ public:
     void activate(const std::string& dialog_id) override;
     void deactivate(const std::string& dialog_id) override;
     Json::Value getActiveSessionInfo() override;
+    void clear() override;
 
     const ActiveDialogs& getActiveList();
     const Sessions& getAllSessions();

--- a/tests/core/test_core_session_manager.cc
+++ b/tests/core/test_core_session_manager.cc
@@ -147,6 +147,17 @@ static void test_session_manager_multi_agent_participation(TestFixture* fixture,
     g_assert(fixture->session_manager->getActiveSessionInfo().empty());
 }
 
+static void test_session_manager_clear(TestFixture* fixture, gconstpointer ignored)
+{
+    fixture->session_manager->activate("dialog_id_1");
+    fixture->session_manager->set("dialog_id_1", { "session_id_1", "ps_id_1" });
+    fixture->session_manager->set("dialog_id_2", { "session_id_2", "ps_id_2" });
+    g_assert(!fixture->session_manager->getActiveSessionInfo().empty());
+
+    fixture->session_manager->clear();
+    g_assert(fixture->session_manager->getActiveSessionInfo().empty());
+}
+
 int main(int argc, char* argv[])
 {
 #if !GLIB_CHECK_VERSION(2, 36, 0)
@@ -161,6 +172,7 @@ int main(int argc, char* argv[])
     G_TEST_ADD_FUNC("/core/SessionManager/singleActive", test_session_manager_single_active);
     G_TEST_ADD_FUNC("/core/SessionManager/multiActive", test_session_manager_multi_active);
     G_TEST_ADD_FUNC("/core/SessionManager/multiAgentParticipation", test_session_manager_multi_agent_participation);
+    G_TEST_ADD_FUNC("/core/SessionManager/clear", test_session_manager_clear);
 
     return g_test_run();
 }


### PR DESCRIPTION
It add clear method in SessionManager for removing
all session info if necessary.

That is applied in handling previous directive.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>