### PR TITLE
Remove static analysis(clang-tidy) report

### DIFF
--- a/examples/profiling/main_prof.cc
+++ b/examples/profiling/main_prof.cc
@@ -263,16 +263,16 @@ int main(int argc, char* argv[])
             output_file = optarg;
             break;
         case 'n':
-            test_iteration_max = atoi(optarg);
+            test_iteration_max = std::strtol(optarg, nullptr, 10);
             break;
         case 'm':
             model_path = optarg;
             break;
         case 'd':
-            test_delay = atoi(optarg);
+            test_delay = std::strtol(optarg, nullptr, 10);
             break;
         case 't':
-            test_timeout = atoi(optarg);
+            test_timeout = std::strtol(optarg, nullptr, 10);
             break;
         default:
             usage(argv[0]);

--- a/plugins/portaudio_pcm_async.c
+++ b/plugins/portaudio_pcm_async.c
@@ -498,8 +498,10 @@ static int _pcm_push_data(NuguPcmDriver *driver, NuguPcm *pcm, const char *data,
 	struct pa_audio_param *pcm_param = nugu_pcm_get_driver_data(pcm);
 	int playing_flag = 0;
 
-	if (pcm_param == NULL)
+	if (pcm_param == NULL) {
 		nugu_error("pcm is not started");
+		return -1;
+	}
 
 	if (pcm_param->is_first == 1)
 		playing_flag = 1;

--- a/plugins/portaudio_pcm_sync.c
+++ b/plugins/portaudio_pcm_sync.c
@@ -540,8 +540,10 @@ static int _pcm_push_data(NuguPcmDriver *driver, NuguPcm *pcm, const char *data,
 	struct pa_audio_param *pcm_param = nugu_pcm_get_driver_data(pcm);
 	int playing_flag = 0;
 
-	if (pcm_param == NULL)
+	if (pcm_param == NULL) {
 		nugu_error("pcm is not started");
+		return -1;
+	}
 
 	if (pcm_param->is_first == 1)
 		playing_flag = 1;

--- a/src/core/directive_sequencer.cc
+++ b/src/core/directive_sequencer.cc
@@ -197,14 +197,14 @@ bool DirectiveSequencer::complete(NuguDirective* ndir)
 
     DirectiveSequencer::DialogQueueMap* qmap = nullptr;
 
-    if (policy.medium == BlockingMedium::NONE) {
-        /* NONE type does not need to check the queue */
-        nugu_directive_unref(ndir);
-        return true;
-    } else if (policy.medium == BlockingMedium::AUDIO) {
+    if (policy.medium == BlockingMedium::AUDIO) {
         qmap = &audio_map;
     } else if (policy.medium == BlockingMedium::VISUAL) {
         qmap = &visual_map;
+    } else {
+        /* NONE type does not need to check the queue */
+        nugu_directive_unref(ndir);
+        return true;
     }
 
     const char* dialog_id = nugu_directive_peek_dialog_id(ndir);
@@ -311,14 +311,14 @@ bool DirectiveSequencer::add(NuguDirective* ndir)
 
     DialogQueueMap* qmap = nullptr;
 
-    if (policy.medium == BlockingMedium::NONE) {
-        nugu_dbg("BlockingMedium::NONE type - handle immediately");
-        handleDirective(ndir);
-        return true;
-    } else if (policy.medium == BlockingMedium::AUDIO) {
+    if (policy.medium == BlockingMedium::AUDIO) {
         qmap = &audio_map;
     } else if (policy.medium == BlockingMedium::VISUAL) {
         qmap = &visual_map;
+    } else {
+        nugu_dbg("BlockingMedium::NONE type - handle immediately");
+        handleDirective(ndir);
+        return true;
     }
 
     const char* dialog_id = nugu_directive_peek_dialog_id(ndir);

--- a/src/core/playstack_manager.cc
+++ b/src/core/playstack_manager.cc
@@ -26,6 +26,7 @@ namespace NuguCore {
  ******************************************************************************/
 
 namespace Debug {
+    // NOLINTNEXTLINE (cert-err58-cpp)
     const std::map<PlayStackLayer, std::string> PLAYSTACK_LAYER_TEXT {
         { PlayStackLayer::Alert, "[Alert] " },
         { PlayStackLayer::Call, "[Call] " },
@@ -39,7 +40,7 @@ namespace Debug {
 
         for (const auto& item : playstack_container.second) {
             try {
-                std::string layer = PLAYSTACK_LAYER_TEXT.at(playstack_container.first.at(item));
+                const std::string& layer = PLAYSTACK_LAYER_TEXT.at(playstack_container.first.at(item));
                 playstack_log.append(layer).append(item).append("\n");
             } catch (std::out_of_range& exception) {
                 // pass silently


### PR DESCRIPTION
Removed reported issue as belows:
* clang-analyzer-core.CallAndMessage
* performance-unnecessary-copy-initialization
* clang-analyzer-core.NullDereference
* cert-err34-c
* cert-err58-cpp

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>