### PR TITLE
capability:add condition about processing previous directive

### DIFF
--- a/include/clientkit/playstack_manager_interface.hh
+++ b/include/clientkit/playstack_manager_interface.hh
@@ -122,6 +122,14 @@ public:
     virtual bool isStackedCondition(NuguDirective* ndir) = 0;
 
     /**
+     * @brief Check whether it has ASR-ExpectSpeech directive.
+     * @param[in] ndir directive
+     * @return true if it has, otherwise false
+     */
+
+    virtual bool hasExpectSpeech(NuguDirective* ndir) = 0;
+
+    /**
      * @brief Stop timer for removing playstack.
      */
     virtual void stopHolding() = 0;

--- a/src/clientkit/capability.cc
+++ b/src/clientkit/capability.cc
@@ -287,7 +287,7 @@ void Capability::processDirective(NuguDirective* ndir)
         if (pimpl->cur_ndir) {
             nugu_directive_remove_data_callback(pimpl->cur_ndir);
 
-            if (playstack_manager->isStackedCondition(ndir)) {
+            if (playstack_manager->isStackedCondition(ndir) && !playstack_manager->hasExpectSpeech(pimpl->cur_ndir)) {
                 nugu_dbg("complete previous dialog");
                 directive_sequencer->complete(pimpl->cur_ndir);
             } else {

--- a/src/core/playstack_manager.cc
+++ b/src/core/playstack_manager.cc
@@ -178,6 +178,19 @@ bool PlayStackManager::isStackedCondition(NuguDirective* ndir)
     return ndir && isStackedCondition(extractPlayStackLayer(ndir));
 }
 
+bool PlayStackManager::hasExpectSpeech(NuguDirective* ndir)
+{
+    if (!ndir) {
+        nugu_warn("The directive is empty.");
+        return false;
+    }
+
+    const char* tmp_ndir_groups = nugu_directive_peek_groups(ndir);
+    std::string ndir_groups = tmp_ndir_groups ? tmp_ndir_groups : "";
+
+    return ndir_groups.find("ASR.ExpectSpeech") != std::string::npos;
+}
+
 void PlayStackManager::stopHolding()
 {
     if (timer->isStarted()) {
@@ -278,14 +291,6 @@ bool PlayStackManager::isStackedCondition(PlayStackLayer layer)
 bool PlayStackManager::isStackedCondition(const std::string& ps_id)
 {
     return isStackedCondition(getPlayStackLayer(ps_id));
-}
-
-bool PlayStackManager::hasExpectSpeech(NuguDirective* ndir)
-{
-    const char* tmp_ndir_groups = nugu_directive_peek_groups(ndir);
-    std::string ndir_groups = tmp_ndir_groups ? tmp_ndir_groups : "";
-
-    return ndir_groups.find("ASR.ExpectSpeech") != std::string::npos;
 }
 
 template <typename T>

--- a/src/core/playstack_manager.hh
+++ b/src/core/playstack_manager.hh
@@ -39,6 +39,7 @@ public:
     void add(const std::string& ps_id, NuguDirective* ndir) override;
     void remove(const std::string& ps_id, PlayStackRemoveMode mode = PlayStackRemoveMode::Normal) override;
     bool isStackedCondition(NuguDirective* ndir) override;
+    bool hasExpectSpeech(NuguDirective* ndir) override;
     void stopHolding() override;
     void resetHolding() override;
     bool isActiveHolding();
@@ -65,7 +66,6 @@ private:
     void clearContainer();
     bool isStackedCondition(PlayStackLayer layer);
     bool isStackedCondition(const std::string& ps_id);
-    bool hasExpectSpeech(NuguDirective* ndir);
 
     template <typename T>
     void removeItemInList(std::vector<T>& list, const T& item);

--- a/tests/core/test_core_playstack_manager.cc
+++ b/tests/core/test_core_playstack_manager.cc
@@ -61,6 +61,7 @@ typedef struct {
 
     NuguDirective* ndir_info;
     NuguDirective* ndir_media;
+    NuguDirective* ndir_expect_speech;
 } TestFixture;
 
 static void setup(TestFixture* fixture, gconstpointer user_data)
@@ -71,12 +72,14 @@ static void setup(TestFixture* fixture, gconstpointer user_data)
 
     fixture->ndir_info = createDirective("TTS", "test", "{ \"directives\": [\"TTS.Speak\"] }");
     fixture->ndir_media = createDirective("AudioPlayer", "test", "{ \"directives\": [\"AudioPlayer.Play\"] }");
+    fixture->ndir_expect_speech = createDirective("ASR", "test", "{ \"directives\": [\"TTS.Speak\", \"ASR.ExpectSpeech\", \"Session.Set\"] }");
 }
 
 static void teardown(TestFixture* fixture, gconstpointer user_data)
 {
     nugu_directive_unref(fixture->ndir_info);
     nugu_directive_unref(fixture->ndir_media);
+    nugu_directive_unref(fixture->ndir_expect_speech);
 
     fixture->playstack_manager_listener.reset();
     fixture->playstack_manager_listener_snd.reset();
@@ -235,6 +238,13 @@ static void test_playstack_manager_checkStack(TestFixture* fixture, gconstpointe
     g_assert(!fixture->playstack_manager->isStackedCondition(fixture->ndir_media));
 }
 
+static void test_playstack_manager_checkExpectSpeech(TestFixture* fixture, gconstpointer ignored)
+{
+    g_assert(!fixture->playstack_manager->hasExpectSpeech(nullptr));
+    g_assert(!fixture->playstack_manager->hasExpectSpeech(fixture->ndir_info));
+    g_assert(fixture->playstack_manager->hasExpectSpeech(fixture->ndir_expect_speech));
+}
+
 int main(int argc, char* argv[])
 {
 #if !GLIB_CHECK_VERSION(2, 36, 0)
@@ -251,6 +261,7 @@ int main(int argc, char* argv[])
     G_TEST_ADD_FUNC("/core/PlayStackManager/layerPolicy", test_playstack_manager_layerPolicy);
     G_TEST_ADD_FUNC("/core/PlayStackManager/controlHolding", test_playstack_manager_controlHolding);
     G_TEST_ADD_FUNC("/core/PlayStackManager/checkStack", test_playstack_manager_checkStack);
+    G_TEST_ADD_FUNC("/core/PlayStackManager/checkExpectSpeech", test_playstack_manager_checkExpectSpeech);
 
     return g_test_run();
 }


### PR DESCRIPTION
Even if the playstack is stacked conditions, if the previous
directive has ASR-ExpectSpeech, that directive has to be canceled.

So, it export hasExpectSpeech method in PlayStackManager
and add to second condition which check to process previous directive.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>