### PR TITLE
TextAgent:apply const reference on requestTextInput

### DIFF
--- a/include/capability/text_interface.hh
+++ b/include/capability/text_interface.hh
@@ -108,7 +108,7 @@ public:
      * @brief Request NUGU services based on text input.
      * @return dialog request id if a NUGU service request succeeds with user text, otherwise empty string
      */
-    virtual std::string requestTextInput(std::string text) = 0;
+    virtual std::string requestTextInput(const std::string& text) = 0;
 
     /**
      * @brief Set attribute about response

--- a/src/capability/text_agent.cc
+++ b/src/capability/text_agent.cc
@@ -145,7 +145,7 @@ void TextAgent::setCapabilityListener(ICapabilityListener* clistener)
         text_listener = dynamic_cast<ITextListener*>(clistener);
 }
 
-std::string TextAgent::requestTextInput(std::string text)
+std::string TextAgent::requestTextInput(const std::string& text)
 {
     nugu_dbg("receive text interface : %s from user app", text.c_str());
     if (cur_state == TextState::BUSY) {

--- a/src/capability/text_agent.hh
+++ b/src/capability/text_agent.hh
@@ -37,7 +37,7 @@ public:
     void receiveCommandAll(const std::string& command, const std::string& param) override;
     void setCapabilityListener(ICapabilityListener* clistener) override;
 
-    std::string requestTextInput(std::string text) override;
+    std::string requestTextInput(const std::string& text) override;
     void notifyResponseTimeout();
 
 private:


### PR DESCRIPTION
It apply const string reference on parameter
of requestTextInput method in ITextHandler and dervied TextAgent.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>