### PR TITLE
ASRAgent:remove unnecessary method

### DIFF
--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -133,19 +133,12 @@ void ASRAgent::startRecognition(float power_noise, float power_speech, AsrRecogn
 
 void ASRAgent::startRecognition(AsrRecognizeCallback callback)
 {
-    if (callback != nullptr)
+    if (callback)
         rec_callback = std::move(callback);
-
-    startRecognition(false);
-}
-
-void ASRAgent::startRecognition(bool expected)
-{
-    nugu_dbg("startRecognition(%d)", expected);
 
     if (speech_recognizer->isMute()) {
         nugu_warn("recorder is mute state");
-        if (rec_callback != nullptr)
+        if (rec_callback)
             rec_callback("");
         return;
     }

--- a/src/capability/asr_agent.hh
+++ b/src/capability/asr_agent.hh
@@ -49,7 +49,6 @@ public:
 
     void startRecognition(float power_noise, float power_speech, AsrRecognizeCallback callback = nullptr) override;
     void startRecognition(AsrRecognizeCallback callback = nullptr) override;
-    void startRecognition(bool expected);
     void stopRecognition() override;
 
     void preprocessDirective(NuguDirective* ndir) override;


### PR DESCRIPTION
The paremeter 'expected' of startRecognition(bool expected)
is never used in method, and that method is not defined in IASRHandler.
So, there are no need to define that method separately.

That method is merged to startRecognition(AsrRecognizeCallback callback).

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>