### PR TITLE
Session:notify session state

### DIFF
--- a/examples/standalone/capability/session_listener.cc
+++ b/examples/standalone/capability/session_listener.cc
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+
+#include "session_listener.hh"
+
+void SessionListener::onState(SessionState state, const std::string& dialog_id)
+{
+    std::cout << "[Session][id:" << dialog_id << "] " << SESSION_STATE_TEXT.at(state) << std::endl;
+}

--- a/examples/standalone/capability/session_listener.hh
+++ b/examples/standalone/capability/session_listener.hh
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __SESSION_LISTENER_H__
+#define __SESSION_LISTENER_H__
+
+#include <map>
+
+#include <capability/session_interface.hh>
+
+using namespace NuguCapability;
+
+class SessionListener : public ISessionListener {
+public:
+    virtual ~SessionListener() = default;
+
+    void onState(SessionState state, const std::string& dialog_id) override;
+
+private:
+    const std::map<SessionState, std::string> SESSION_STATE_TEXT {
+        { SessionState::ACTIVE, "activated" },
+        { SessionState::INACTIVE, "deactivated" }
+    };
+};
+
+#endif /* __SESSION_LISTENER_H__ */

--- a/examples/standalone/capability_collection.cc
+++ b/examples/standalone/capability_collection.cc
@@ -137,8 +137,10 @@ void CapabilityCollection::composeCapabilityFactory()
         return sound_handler.get();
     });
     factories.emplace("Session", [&]() {
-        if (!session_handler)
-            session_handler = makeCapability<SessionAgent, ISessionHandler>(nullptr);
+        if (!session_handler) {
+            session_listener = std::make_shared<SessionListener>();
+            session_handler = makeCapability<SessionAgent, ISessionHandler>(session_listener.get());
+        }
 
         return session_handler.get();
     });

--- a/examples/standalone/capability_collection.hh
+++ b/examples/standalone/capability_collection.hh
@@ -25,6 +25,7 @@
 
 #include "audio_player_listener.hh"
 #include "mic_listener.hh"
+#include "session_listener.hh"
 #include "sound_listener.hh"
 #include "speaker_listener.hh"
 #include "speech_operator.hh"
@@ -72,6 +73,7 @@ private:
     std::shared_ptr<SpeakerListener> speaker_listener = nullptr;
     std::shared_ptr<MicListener> mic_listener = nullptr;
     std::shared_ptr<SoundListener> sound_listener = nullptr;
+    std::shared_ptr<SessionListener> session_listener = nullptr;
 
     std::map<std::string, std::function<ICapabilityInterface*()>> factories;
 };

--- a/include/capability/session_interface.hh
+++ b/include/capability/session_interface.hh
@@ -35,12 +35,28 @@ using namespace NuguClientKit;
  */
 
 /**
+ * @brief Session State list
+ * @see ISessionListener::onState
+ */
+enum class SessionState {
+    ACTIVE, /**< Session is activated */
+    INACTIVE /**< Session is deactivated */
+};
+
+/**
  * @brief session listener interface
  * @see ISessionHandler
  */
 class ISessionListener : public ICapabilityListener {
 public:
     virtual ~ISessionListener() = default;
+
+    /**
+     * @brief Receive callback when the session state is changed.
+     * @param[in] state session state
+     * @param[in] dialog_id dialog request id for Session
+     */
+    virtual void onState(SessionState state, const std::string& dialog_id) = 0;
 };
 
 /**

--- a/src/capability/session_agent.hh
+++ b/src/capability/session_agent.hh
@@ -23,17 +23,26 @@
 namespace NuguCapability {
 
 class SessionAgent final : public Capability,
-                           public ISessionHandler {
+                           public ISessionHandler,
+                           public ISessionManagerListener {
 public:
     SessionAgent();
     virtual ~SessionAgent() = default;
 
+    void initialize() override;
+    void deInitialize() override;
+    void setCapabilityListener(ICapabilityListener* clistener) override;
     void updateInfoForContext(Json::Value& ctx) override;
     void parsingDirective(const char* dname, const char* message) override;
 
 private:
     void parsingSet(const char* message);
 
+    // implements ISessionManagerListener
+    void activated(const std::string& dialog_id, Session session);
+    void deactivated(const std::string& dialog_id);
+
+    ISessionListener* session_listener = nullptr;
     std::string play_service_id;
     std::string session_id;
 };

--- a/src/core/session_manager.cc
+++ b/src/core/session_manager.cc
@@ -144,6 +144,9 @@ Json::Value SessionManager::getActiveSessionInfo()
 
 void SessionManager::clear()
 {
+    for (const auto& item : session_map)
+        notifyActiveState(item.first, false);
+
     session_map.clear();
     active_list.clear();
 }

--- a/tests/core/test_core_session_manager.cc
+++ b/tests/core/test_core_session_manager.cc
@@ -269,13 +269,22 @@ static void test_session_manager_notify_multi_active_state(TestFixture* fixture,
 
 static void test_session_manager_clear(TestFixture* fixture, gconstpointer ignored)
 {
+    fixture->session_manager->addListener(fixture->session_manager_listener.get());
+
     fixture->session_manager->activate("dialog_id_1");
     fixture->session_manager->set("dialog_id_1", { "session_id_1", "ps_id_1" });
     fixture->session_manager->set("dialog_id_2", { "session_id_2", "ps_id_2" });
     g_assert(!fixture->session_manager->getActiveSessionInfo().empty());
+    g_assert(fixture->session_manager_listener->getSessionActive("dialog_id_1") == 1);
+
+    fixture->session_manager->activate("dialog_id_2");
+    fixture->session_manager->activate("dialog_id_2");
+    g_assert(fixture->session_manager_listener->getSessionActive("dialog_id_2") == 1);
 
     fixture->session_manager->clear();
     g_assert(fixture->session_manager->getActiveSessionInfo().empty());
+    g_assert(fixture->session_manager_listener->getSessionActive("dialog_id_1") == 0);
+    g_assert(fixture->session_manager_listener->getSessionActive("dialog_id_2") == 0);
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
It add ISessionListener for receiving session state in session_interface.

If the derived class which implements ISessionListener
is added to ISessionHandler, in Application,
it's possible to receive callback about session state.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>