### PR TITLE
fix static analysis report

### DIFF
--- a/src/capability/session_agent.cc
+++ b/src/capability/session_agent.cc
@@ -107,7 +107,7 @@ void SessionAgent::activated(const std::string& dialog_id, Session session)
     // in currently, there are no reason to send session info to application.
     // So, it just leave that session info for handling later.
 
-    nugu_dbg("session activated: %s", dialog_id);
+    nugu_dbg("session activated: %s", dialog_id.c_str());
 
     if (session_listener)
         session_listener->onState(SessionState::ACTIVE, dialog_id);
@@ -115,7 +115,7 @@ void SessionAgent::activated(const std::string& dialog_id, Session session)
 
 void SessionAgent::deactivated(const std::string& dialog_id)
 {
-    nugu_dbg("session deactivated: %s", dialog_id);
+    nugu_dbg("session deactivated: %s", dialog_id.c_str());
 
     if (session_listener)
         session_listener->onState(SessionState::INACTIVE, dialog_id);

--- a/src/core/session_manager.cc
+++ b/src/core/session_manager.cc
@@ -23,7 +23,7 @@ namespace NuguCore {
 
 SessionManager::~SessionManager()
 {
-    clear();
+    clearContainer();
 }
 
 void SessionManager::addListener(ISessionManagerListener* listener)
@@ -147,8 +147,7 @@ void SessionManager::clear()
     for (const auto& item : session_map)
         notifyActiveState(item.first, false);
 
-    session_map.clear();
-    active_list.clear();
+    clearContainer();
 }
 
 const SessionManager::ActiveDialogs& SessionManager::getActiveList()
@@ -178,6 +177,12 @@ void SessionManager::notifyActiveState(const std::string& dialog_id, bool is_act
     if (result != active_list.cend() && session_map.find(dialog_id) != session_map.cend())
         for (const auto& listener : listeners)
             listener->activated(dialog_id, session_map[dialog_id]);
+}
+
+void SessionManager::clearContainer()
+{
+    session_map.clear();
+    active_list.clear();
 }
 
 } // NuguCore

--- a/src/core/session_manager.hh
+++ b/src/core/session_manager.hh
@@ -50,6 +50,7 @@ public:
 
 private:
     void notifyActiveState(const std::string& dialog_id, bool is_active = true);
+    void clearContainer();
 
     std::vector<ISessionManagerListener*> listeners;
     ActiveDialogs active_list;


### PR DESCRIPTION
It fix the issues which are detected from static analysis(clang-tidy).
* call to virtual function during destruction
* cannot pass object of non-trivial type 'const std::string'

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>