### PR TITLE
Focus: Add hold/unhold functions

### DIFF
--- a/include/clientkit/focus_manager_interface.hh
+++ b/include/clientkit/focus_manager_interface.hh
@@ -119,6 +119,20 @@ public:
     virtual bool releaseFocus(const std::string& type, const std::string& name) = 0;
 
     /**
+     * @brief Hold focus. If requested to hold focus, the low priority focus is not preempted.
+     * @param[in] type focus type
+     * @return if the hold is success, then true otherwise false
+     */
+    virtual bool holdFocus(const std::string& type) = 0;
+
+    /**
+     * @brief Unhold focus
+     * @param[in] type focus type
+     * @return if the unhold is success, then true otherwise false
+     */
+    virtual bool unholdFocus(const std::string& type) = 0;
+
+    /**
      * @brief Set focus configurations.
      * @param[in] configurations focus configurations
      */

--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -150,6 +150,7 @@ void ASRAgent::startRecognition(AsrRecognizeCallback callback)
 void ASRAgent::stopRecognition()
 {
     nugu_dbg("stopRecognition()");
+    focus_manager->unholdFocus(DIALOG_FOCUS_TYPE);
     focus_manager->releaseFocus(DIALOG_FOCUS_TYPE, CAPABILITY_NAME);
     asr_cancel = false;
 }
@@ -450,6 +451,7 @@ void ASRAgent::parsingExpectSpeech(std::string&& dialog_id, const char* message)
     es_attr.dialog_id = dialog_id;
 
     session_manager->activate(es_attr.dialog_id);
+    focus_manager->holdFocus(DIALOG_FOCUS_TYPE);
 }
 
 void ASRAgent::parsingNotifyResult(const char* message)

--- a/src/core/focus_manager.hh
+++ b/src/core/focus_manager.hh
@@ -62,6 +62,9 @@ public:
     bool requestFocus(const std::string& type, const std::string& name, IFocusResourceListener* listener) override;
     bool releaseFocus(const std::string& type, const std::string& name) override;
 
+    bool holdFocus(const std::string& type) override;
+    bool unholdFocus(const std::string& type) override;
+
     void setConfigurations(std::vector<FocusConfiguration>& configurations) override;
     void stopAllFocus() override;
     void stopForegroundFocus() override;
@@ -79,6 +82,7 @@ public:
 private:
     std::map<std::string, int> configuration_map;
     std::map<int, std::shared_ptr<FocusResource>> focus_resource_ordered_map;
+    std::map<std::string, bool> focus_hold_map;
     std::vector<IFocusManagerObserver*> observers;
 };
 


### PR DESCRIPTION
The mediaplayer is played for a while caused by focus when the
text-to-speech is ended during conversation.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>