### PR TITLE
PlayStack:fix playstack removal condition

### DIFF
--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -153,7 +153,7 @@ void TTSAgent::onFocusChanged(FocusState state)
     case FocusState::NONE:
         stopTTS();
 
-        if (playstack_manager->getPlayStackLayer(playstackctl_ps_id) == PlayStackLayer::Info)
+        if (playstack_manager->getPlayStackLayer(playstackctl_ps_id) != PlayStackLayer::Media)
             playstack_manager->remove(playstackctl_ps_id);
 
         break;


### PR DESCRIPTION
Because, the call or alert layer has related TTS,
when TTS play is finished, that playstack has to be remove also.

So, it fix the removal condition of playstack in TTSAgent.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>