### PR TITLE
Session:unhold focus when session deactivated

### DIFF
--- a/src/capability/session_agent.cc
+++ b/src/capability/session_agent.cc
@@ -117,6 +117,8 @@ void SessionAgent::deactivated(const std::string& dialog_id)
 {
     nugu_dbg("session deactivated: %s", dialog_id.c_str());
 
+    focus_manager->unholdFocus(DIALOG_FOCUS_TYPE);
+
     if (session_listener)
         session_listener->onState(SessionState::INACTIVE, dialog_id);
 }


### PR DESCRIPTION
It add to unhold DIALOG_FOCUS_TYPE when session is deactived,
regardless of normal condition or canceled situation.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>