### PR TITLE
log: fix ansi code for normal mode

### DIFF
--- a/include/base/nugu_log.h
+++ b/include/base/nugu_log.h
@@ -45,7 +45,11 @@ extern "C" {
  */
 
 #ifndef NUGU_ANSI_COLOR_NORMAL
+#ifdef NUGU_LOG_USE_ANSICOLOR
 #define NUGU_ANSI_COLOR_NORMAL       "\e[0m"
+#else
+#define NUGU_ANSI_COLOR_NORMAL       ""
+#endif
 #endif
 
 #ifndef NUGU_ANSI_COLOR_BLACK


### PR DESCRIPTION
Fixed an error in ANSI code being output due to NORMAL macro even when
ANSI mode was not used.

Signed-off-by: Inho Oh <inho.oh@sk.com>