### PR TITLE
core: add cancel callback to DirectiveSequencer

### DIFF
--- a/include/clientkit/capability.hh
+++ b/include/clientkit/capability.hh
@@ -235,13 +235,19 @@ public:
     std::string getPlayServiceIdInStackControl(const Json::Value& playstack_control);
 
     /**
-     * @brief Preprocess directive received from Directive Sequencer.
+     * @brief Receive a directive preprocessing request from Directive sequencer.
      * @param[in] ndir directive
      */
     void preprocessDirective(NuguDirective* ndir) override;
 
     /**
-     * @brief Process directive received from Directive Sequencer.
+     * @brief Receive a directive cancellation from the Directive sequencer.
+     * @param[in] ndir directive
+     */
+    void cancelDirective(NuguDirective* ndir) override;
+
+    /**
+     * @brief Receive a directive processing request from Directive sequencer.
      * @param[in] ndir directive
      */
     void processDirective(NuguDirective* ndir) override final;

--- a/include/clientkit/capability_interface.hh
+++ b/include/clientkit/capability_interface.hh
@@ -147,13 +147,19 @@ public:
     virtual std::string getVersion() = 0;
 
     /**
-     * @brief Preprocess directive received from Directive Sequencer.
+     * @brief Receive a directive preprocessing request from Directive sequencer.
      * @param[in] ndir directive
      */
     virtual void preprocessDirective(NuguDirective* ndir) = 0;
 
     /**
-     * @brief Process directive received from Directive Sequencer.
+     * @brief Receive a directive cancellation from the Directive sequencer.
+     * @param[in] ndir directive
+     */
+    virtual void cancelDirective(NuguDirective* ndir) = 0;
+
+    /**
+     * @brief Receive a directive processing request from Directive sequencer.
      * @param[in] ndir directive
      */
     virtual void processDirective(NuguDirective* ndir) = 0;

--- a/include/clientkit/directive_sequencer_interface.hh
+++ b/include/clientkit/directive_sequencer_interface.hh
@@ -75,6 +75,12 @@ public:
      * @retval false There was a problem with the directive processing.
      */
     virtual bool onHandleDirective(NuguDirective* ndir) = 0;
+
+    /**
+     * @brief Notify the directive to cancel
+     * @param[in] ndir NuguDirective object
+     */
+    virtual void onCancelDirective(NuguDirective* ndir) = 0;
 };
 
 /**

--- a/src/clientkit/capability.cc
+++ b/src/clientkit/capability.cc
@@ -274,6 +274,10 @@ void Capability::preprocessDirective(NuguDirective* ndir)
 {
 }
 
+void Capability::cancelDirective(NuguDirective* ndir)
+{
+}
+
 void Capability::processDirective(NuguDirective* ndir)
 {
     if (ndir) {

--- a/src/core/capability_manager.cc
+++ b/src/core/capability_manager.cc
@@ -101,6 +101,18 @@ bool CapabilityManager::onHandleDirective(NuguDirective* ndir)
     return true;
 }
 
+void CapabilityManager::onCancelDirective(NuguDirective* ndir)
+{
+    ICapabilityInterface* cap = findCapability(nugu_directive_peek_namespace(ndir));
+    if (cap == nullptr) {
+        nugu_warn("capability(%s) is not support", nugu_directive_peek_namespace(ndir));
+        return;
+    }
+
+    nugu_info("cancelDirective - [%s.%s]", cap->getName().c_str(), nugu_directive_peek_name(ndir));
+    cap->cancelDirective(ndir);
+}
+
 void CapabilityManager::addCapability(const std::string& cname, ICapabilityInterface* cap)
 {
     caps.emplace(cname, cap);

--- a/src/core/capability_manager.hh
+++ b/src/core/capability_manager.hh
@@ -72,6 +72,7 @@ public:
     // overriding IDirectiveSequencerListener
     bool onPreHandleDirective(NuguDirective* ndir) override;
     bool onHandleDirective(NuguDirective* ndir) override;
+    void onCancelDirective(NuguDirective* ndir) override;
 
 private:
     ICapabilityInterface* findCapability(const std::string& cname);

--- a/src/core/directive_sequencer.cc
+++ b/src/core/directive_sequencer.cc
@@ -278,6 +278,18 @@ void DirectiveSequencer::handleDirective(NuguDirective* ndir)
     }
 }
 
+void DirectiveSequencer::cancelDirective(NuguDirective* ndir)
+{
+    const char* name_space = nugu_directive_peek_namespace(ndir);
+    const char* name = nugu_directive_peek_name(ndir);
+
+    nugu_dbg("cancel the directive '%s.%s'", name_space, name);
+
+    for (auto& listener : listeners_map[name_space]) {
+        listener->onCancelDirective(ndir);
+    }
+}
+
 bool DirectiveSequencer::add(NuguDirective* ndir)
 {
     if (ndir == nullptr) {
@@ -456,6 +468,8 @@ bool DirectiveSequencer::cancel(const std::string& dialog_id)
             if (msgid_iter != msgid_directive_map.end())
                 msgid_directive_map.erase(msgid_iter);
 
+            cancelDirective(ndir);
+
             /* Destroy the directive */
             nugu_directive_unref(ndir);
         }
@@ -473,6 +487,8 @@ bool DirectiveSequencer::cancel(const std::string& dialog_id)
             msgid_iter = msgid_directive_map.find(nugu_directive_peek_msg_id(ndir));
             if (msgid_iter != msgid_directive_map.end())
                 msgid_directive_map.erase(msgid_iter);
+
+            cancelDirective(ndir);
 
             /* Destroy the directive */
             nugu_directive_unref(ndir);

--- a/src/core/directive_sequencer.hh
+++ b/src/core/directive_sequencer.hh
@@ -89,6 +89,7 @@ private:
 
     bool preHandleDirective(NuguDirective* ndir);
     void handleDirective(NuguDirective* ndir);
+    void cancelDirective(NuguDirective* ndir);
 
     /* Network manager callback */
     static void onDirective(NuguDirective* ndir, void* userdata);

--- a/tests/core/test_core_directive_sequencer.cc
+++ b/tests/core/test_core_directive_sequencer.cc
@@ -73,6 +73,10 @@ public:
         return false;
     }
 
+    void onCancelDirective(NuguDirective* ndir) override
+    {
+    }
+
     bool onHandleDirective(NuguDirective* ndir) override
     {
         value++;
@@ -92,6 +96,10 @@ public:
          * The directive is handled in the pre-handle callback.
          */
         return true;
+    }
+
+    void onCancelDirective(NuguDirective* ndir) override
+    {
     }
 
     bool onHandleDirective(NuguDirective* ndir) override
@@ -171,6 +179,10 @@ public:
     bool onPreHandleDirective(NuguDirective* ndir) override
     {
         return false;
+    }
+
+    void onCancelDirective(NuguDirective* ndir) override
+    {
     }
 
     bool onHandleDirective(NuguDirective* ndir) override
@@ -261,6 +273,12 @@ public:
         return false;
     }
 
+    void onCancelDirective(NuguDirective* ndir) override
+    {
+        g_assert_cmpstr(nugu_directive_peek_namespace(ndir), ==, "TTS");
+        cancel_flag++;
+    }
+
     bool onHandleDirective(NuguDirective* ndir) override
     {
         /* Allow only 'TTS' namespace */
@@ -277,7 +295,9 @@ public:
                 g_assert_cmpstr(nugu_directive_peek_dialog_id(speak_dir), !=, nugu_directive_peek_dialog_id(ndir));
 
                 /* Cancel(destroy) the previous dialog */
+                cancel_flag = 0;
                 seq->cancel(nugu_directive_peek_dialog_id(speak_dir));
+                g_assert(cancel_flag != 0);
 
                 if (idler)
                     g_source_remove(idler);
@@ -322,6 +342,7 @@ public:
     GMainLoop* loop;
     NuguDirective* speak_dir;
     guint idler;
+    int cancel_flag;
 };
 
 class AudioPlayerAgent : public IDirectiveSequencerListener {
@@ -336,6 +357,10 @@ public:
     bool onPreHandleDirective(NuguDirective* ndir) override
     {
         return false;
+    }
+
+    void onCancelDirective(NuguDirective* ndir) override
+    {
     }
 
     bool onHandleDirective(NuguDirective* ndir) override
@@ -408,6 +433,10 @@ public:
     bool onPreHandleDirective(NuguDirective* ndir) override
     {
         return false;
+    }
+
+    void onCancelDirective(NuguDirective* ndir) override
+    {
     }
 
     bool onHandleDirective(NuguDirective* ndir) override


### PR DESCRIPTION
There is currently no callback for directive cancel, so the Capability
agent has no way of know if the directive has been canceled.

Therefore, in order to solve the above issue, a directive cancellation
event is added.

Signed-off-by: Inho Oh <inho.oh@sk.com>