### PR TITLE
nugu_sample:remove unnecessary log

### DIFF
--- a/examples/standalone/capability/audio_player_listener.cc
+++ b/examples/standalone/capability/audio_player_listener.cc
@@ -88,11 +88,12 @@ void AudioPlayerListener::repeatChanged(RepeatType repeat, const std::string& di
 
 void AudioPlayerListener::requestContentCache(const std::string& key, const std::string& playurl)
 {
-    std::cout << "[AudioPlayer] request to cache content - key: " << key << ", playurl: " << playurl << std::endl;
+    std::cout << "[AudioPlayer] request to cache content:\n"
+              << "  - key: " << key << std::endl
+              << "  - playurl: " << playurl << std::endl;
 }
 
 bool AudioPlayerListener::requestToGetCachedContent(const std::string& key, std::string& filepath)
 {
-    std::cout << "[AudioPlayer] request to get cached content - key: " << key << std::endl;
     return false;
 }

--- a/examples/standalone/capability/speech_operator.cc
+++ b/examples/standalone/capability/speech_operator.cc
@@ -127,15 +127,10 @@ void SpeechOperator::startListening(float noise, float speech)
         return;
     }
 
-    if (noise && speech) {
-        asr_handler->startRecognition(noise, speech, [&](const std::string& dialog_id) {
-            msg::asr::callback(__FUNCTION__, dialog_id, "startRecognition callback");
-        });
-    } else {
-        asr_handler->startRecognition([&](const std::string& dialog_id) {
-            msg::asr::callback(__FUNCTION__, dialog_id, "startRecognition callback");
-        });
-    }
+    if (noise && speech)
+        asr_handler->startRecognition(noise, speech, [&](const std::string& dialog_id) {});
+    else
+        asr_handler->startRecognition([&](const std::string& dialog_id) {});
 }
 
 void SpeechOperator::stopListeningAndWakeup()

--- a/examples/standalone/capability/system_listener.cc
+++ b/examples/standalone/capability/system_listener.cc
@@ -64,5 +64,4 @@ void SystemListener::onRevoke(RevokeReason reason)
 
 void SystemListener::onNoDirective(const std::string& dialog_id)
 {
-    std::cout << "[SYSTEM][id:" << dialog_id << "] receive no directive" << std::endl;
 }

--- a/examples/standalone/capability/text_listener.cc
+++ b/examples/standalone/capability/text_listener.cc
@@ -20,7 +20,10 @@
 
 void TextListener::onState(TextState state, const std::string& dialog_id)
 {
-    std::cout << "[Text][id:" << dialog_id << "] onState: ";
+    if (state == prev_state && dialog_id == prev_dialog_id)
+        return;
+
+    std::cout << "[Text][id:" << dialog_id << "] ";
 
     switch (state) {
     case TextState::BUSY:
@@ -33,6 +36,9 @@ void TextListener::onState(TextState state, const std::string& dialog_id)
         std::cout << "UNKNOWN STATE" << std::endl;
         break;
     }
+
+    prev_state = state;
+    prev_dialog_id = dialog_id;
 }
 
 void TextListener::onComplete(const std::string& dialog_id)

--- a/examples/standalone/capability/text_listener.hh
+++ b/examples/standalone/capability/text_listener.hh
@@ -28,6 +28,10 @@ public:
     void onComplete(const std::string& dialog_id) override;
     void onError(TextError error, const std::string& dialog_id) override;
     bool handleTextCommand(const std::string& text, const std::string& token) override;
+
+private:
+    TextState prev_state = TextState::IDLE;
+    std::string prev_dialog_id;
 };
 
 #endif /* __TEXT_LISTENER_H__ */

--- a/examples/standalone/nugu_sample.cc
+++ b/examples/standalone/nugu_sample.cc
@@ -101,56 +101,6 @@ public:
 
         nugu_sample_manager->handleNetworkResult(false);
     }
-
-    void onEventSend(NuguEvent *nev)
-    {
-        std::string msg;
-        msg.append("send event(")
-            .append(nugu_event_peek_namespace(nev))
-            .append(".")
-            .append(nugu_event_peek_name(nev))
-            .append(")\n\tmsg_id: ")
-            .append(nugu_event_peek_msg_id(nev))
-            .append("\n\tdialog_id: ")
-            .append(nugu_event_peek_dialog_id(nev));
-
-        if (nugu_event_peek_referrer_id(nev))
-            msg.append("\n\treferrer_id: ")
-                .append(nugu_event_peek_referrer_id(nev));
-
-        msg_info(std::move(msg));
-    }
-
-    void onEventAttachmentSend(NuguEvent* nev, int seq, bool is_end, size_t length, unsigned char* data)
-    {
-        std::string msg;
-        msg.append("send attachment(")
-                    .append(nugu_event_peek_namespace(nev))
-            .append(".")
-            .append(nugu_event_peek_name(nev))
-            .append(", seq=")
-            .append(std::to_string(seq))
-            .append(", is_end=")
-            .append(std::to_string(is_end))
-            .append(", length=")
-            .append(std::to_string(length));
-
-        msg_info(std::move(msg));
-    }
-
-    void onEventResult(const char* msg_id, bool success, int code)
-    {
-        std::string msg;
-        msg.append("result event - ")
-            .append(msg_id)
-            .append("(")
-            .append(std::to_string(success))
-            .append(", code: ")
-            .append(std::to_string(code))
-            .append(")");
-
-        msg_info(std::move(msg));
-    }
 };
 
 void registerCapabilities()

--- a/examples/standalone/nugu_sample_manager.cc
+++ b/examples/standalone/nugu_sample_manager.cc
@@ -234,6 +234,7 @@ void NuguSampleManager::showPrompt(void)
                   << C_RESET;
     else {
         std::cout << C_YELLOW
+                  << std::endl
                   << "=======================================================\n"
                   << C_RED
                   << "NUGU SDK Command (" << (commander.is_connected ? "Connected" : "Disconnected") << ")\n"
@@ -313,8 +314,6 @@ gboolean NuguSampleManager::onKeyInput(GIOChannel* src, GIOCondition con, gpoint
 
         if (ns_mgr->commander.text_handler)
             id = ns_mgr->commander.text_handler->requestTextInput(keybuf);
-
-        std::cout << "[Text][id:" << id << "] requestTextInput" << std::endl;
     } else {
         try {
             // It has to send ns_mgr (NuguSampleManager* instance) parameter mandatorily


### PR DESCRIPTION
Because, it's possible to show full debug log
by nugu sample launch option (./nugusdk_start_sample nugu_sample d),
it doesn't need to show much log by default.

So, it simplify the default log in nugu_sample.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>