### PR TITLE
build: add missing install files to package

### DIFF
--- a/packaging/bionic/libnugu-examples.install
+++ b/packaging/bionic/libnugu-examples.install
@@ -1,2 +1,3 @@
 debian/tmp/usr/bin/*
 debian/tmp/lib/*
+debian/tmp/usr/share/*

--- a/packaging/xenial/libnugu-examples.install
+++ b/packaging/xenial/libnugu-examples.install
@@ -1,2 +1,3 @@
 debian/tmp/usr/bin/*
 debian/tmp/lib/*
+debian/tmp/usr/share/*


### PR DESCRIPTION
Some example programs are use the '/usr/share/' path to load data files.
But, the path is not listed in the instalation description file for
DEB package.

Signed-off-by: Inho Oh <inho.oh@sk.com>