### PR TITLE
TextInterface:add option for dialog attribute on requestTextInput

### DIFF
--- a/examples/standalone/nugu_sample_manager.cc
+++ b/examples/standalone/nugu_sample_manager.cc
@@ -33,7 +33,7 @@ const char* NuguSampleManager::C_RESET = "\033[0m";
 
 // NOLINTNEXTLINE (cert-err58-cpp)
 const NuguSampleManager::CommandKey NuguSampleManager::COMMAND_KEYS {
-    "w", "l", "s", "t", "m", "sa", "ra", "c", "d", "q"
+    "w", "l", "s", "t", "t2", "m", "sa", "ra", "c", "d", "q"
 };
 
 // NOLINTNEXTLINE (cert-err58-cpp)
@@ -54,6 +54,10 @@ const NuguSampleManager::CommandMap NuguSampleManager::COMMAND_MAP {
                 ns_mgr->commander.text_input = 1;
                 ns_mgr->showPrompt();
             } } },
+    { "t2", { "text input (ignore dialog attribute)", [](NuguSampleManager* ns_mgr) {
+                 ns_mgr->commander.text_input = 2;
+                 ns_mgr->showPrompt();
+             } } },
     { "m", { "set mic mute", [](NuguSampleManager* ns_mgr) {
                 static bool mute = false;
                 mute = !mute;
@@ -308,12 +312,10 @@ gboolean NuguSampleManager::onKeyInput(GIOChannel* src, GIOCondition con, gpoint
     }
 
     if (ns_mgr->commander.text_input) {
-        ns_mgr->commander.text_input = 0;
-
-        std::string id;
-
         if (ns_mgr->commander.text_handler)
-            id = ns_mgr->commander.text_handler->requestTextInput(keybuf);
+            ns_mgr->commander.text_handler->requestTextInput(keybuf, (ns_mgr->commander.text_input == 1));
+
+        ns_mgr->commander.text_input = 0;
     } else {
         try {
             // It has to send ns_mgr (NuguSampleManager* instance) parameter mandatorily

--- a/include/capability/text_interface.hh
+++ b/include/capability/text_interface.hh
@@ -106,9 +106,11 @@ public:
 
     /**
      * @brief Request NUGU services based on text input.
+     * @param[in] text text command
+     * @param[in] include_dialog_attribute whether including dialog attribute
      * @return dialog request id if a NUGU service request succeeds with user text, otherwise empty string
      */
-    virtual std::string requestTextInput(const std::string& text) = 0;
+    virtual std::string requestTextInput(const std::string& text, bool include_dialog_attribute = true) = 0;
 
     /**
      * @brief Set attribute about response

--- a/src/capability/text_agent.hh
+++ b/src/capability/text_agent.hh
@@ -37,11 +37,11 @@ public:
     void receiveCommandAll(const std::string& command, const std::string& param) override;
     void setCapabilityListener(ICapabilityListener* clistener) override;
 
-    std::string requestTextInput(const std::string& text) override;
+    std::string requestTextInput(const std::string& text, bool include_dialog_attribute = true) override;
     void notifyResponseTimeout();
 
 private:
-    void sendEventTextInput(const std::string& text, const std::string& token, EventResultCallback cb = nullptr);
+    void sendEventTextInput(const std::string& text, const std::string& token, bool include_dialog_attribute, EventResultCallback cb = nullptr);
     void parsingTextSource(const char* message);
 
     ITextListener* text_listener;


### PR DESCRIPTION
It some case, even if session is progressive,
it has to be possible to handle another text command
which is not related to current session.

So, it add the parameter on requestTextInput in TextHander
which is possible to include dialog attribute selectively.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>