### PR TITLE
session:add to remove SessionManagerListener finally

### DIFF
--- a/src/core/session_manager.cc
+++ b/src/core/session_manager.cc
@@ -24,6 +24,7 @@ namespace NuguCore {
 SessionManager::~SessionManager()
 {
     clearContainer();
+    listeners.clear();
 }
 
 void SessionManager::addListener(ISessionManagerListener* listener)


### PR DESCRIPTION
It add to remove all listeners when the destructor
of SessionManager is called.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>