### PR TITLE
ASR:fix to clear ExpectSpeech attributes

### DIFF
--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -214,6 +214,11 @@ void ASRAgent::preprocessDirective(NuguDirective* ndir)
         parsingExpectSpeech(std::string(nugu_directive_peek_dialog_id(ndir)), message);
 }
 
+void ASRAgent::cancelDirective(NuguDirective* ndir)
+{
+    resetExpectSpeechState();
+}
+
 void ASRAgent::parsingDirective(const char* dname, const char* message)
 {
     if (!strcmp(dname, "ExpectSpeech"))

--- a/src/capability/asr_agent.hh
+++ b/src/capability/asr_agent.hh
@@ -52,6 +52,7 @@ public:
     void stopRecognition() override;
 
     void preprocessDirective(NuguDirective* ndir) override;
+    void cancelDirective(NuguDirective* ndir) override;
     void parsingDirective(const char* dname, const char* message) override;
     void updateInfoForContext(Json::Value& ctx) override;
     void saveAllContextInfo();

--- a/src/clientkit/capability.cc
+++ b/src/clientkit/capability.cc
@@ -306,8 +306,6 @@ void Capability::processDirective(NuguDirective* ndir)
             } else {
                 nugu_dbg("cancel previous dialog");
                 directive_sequencer->cancel(nugu_directive_peek_dialog_id(pimpl->cur_ndir));
-                session_manager->clear();
-                interaction_control_manager->clear();
             }
         }
 


### PR DESCRIPTION
When the current handling directive about ASR ExpectSpeech is canceled,
caused by text input command, the previous attributes info is not cleared.

So, it fix to clear that attributes when the current directive is canceled.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>