### PR TITLE
SpeakerAgent: Set unable control

### DIFF
--- a/examples/standalone/capability_collection.cc
+++ b/examples/standalone/capability_collection.cc
@@ -86,7 +86,7 @@ void CapabilityCollection::composeCapabilityFactory()
 
             // compose SpeakerInfo
             std::map<SpeakerType, SpeakerInfo> speakers {
-                { SpeakerType::NUGU, makeSpeakerInfo(SpeakerType::NUGU, true) },
+                { SpeakerType::NUGU, makeSpeakerInfo(SpeakerType::NUGU, 0, true) },
                 { SpeakerType::MUSIC, makeSpeakerInfo(SpeakerType::MUSIC) },
                 { SpeakerType::RINGTON, makeSpeakerInfo(SpeakerType::RINGTON) },
                 { SpeakerType::CALL, makeSpeakerInfo(SpeakerType::CALL) },
@@ -146,10 +146,11 @@ void CapabilityCollection::composeCapabilityFactory()
     });
 }
 
-SpeakerInfo CapabilityCollection::makeSpeakerInfo(SpeakerType type, bool can_control)
+SpeakerInfo CapabilityCollection::makeSpeakerInfo(SpeakerType type, int muted, bool can_control)
 {
     SpeakerInfo nugu_speaker;
     nugu_speaker.type = type;
+    nugu_speaker.mute = muted;
     nugu_speaker.can_control = can_control;
 
     return nugu_speaker;

--- a/examples/standalone/capability_collection.hh
+++ b/examples/standalone/capability_collection.hh
@@ -51,7 +51,7 @@ public:
 
 private:
     void composeCapabilityFactory();
-    SpeakerInfo makeSpeakerInfo(SpeakerType type, bool can_control = false);
+    SpeakerInfo makeSpeakerInfo(SpeakerType type, int muted = NUGU_SPEAKER_UNABLE_CONTROL, bool can_control = false);
 
     // Capability instance
     std::shared_ptr<ISystemHandler> system_handler = nullptr;

--- a/include/capability/speaker_interface.hh
+++ b/include/capability/speaker_interface.hh
@@ -38,6 +38,7 @@ using namespace NuguClientKit;
 #define NUGU_SPEAKER_MAX_VOLUME 100 /** @def Set speaker maximum volume to 100 */
 #define NUGU_SPEAKER_DEFAULT_VOLUME 50 /** @def Set speaker default volume to 50 */
 #define NUGU_SPEAKER_DEFAULT_STEP 10 /** @def Set speaker default volume step to 10 */
+#define NUGU_SPEAKER_UNABLE_CONTROL -1  /** @def This property is set to be out of control. */
 
 /**
  * @brief SpeakerType
@@ -67,7 +68,7 @@ public:
     int max = NUGU_SPEAKER_MAX_VOLUME; /**< Speaker max volume  */
     int volume = NUGU_SPEAKER_DEFAULT_VOLUME; /**< Speaker current volume  */
     int step = NUGU_SPEAKER_DEFAULT_STEP; /**< Speaker default volume step  */
-    bool mute = false; /**< Speaker mute state  */
+    int mute = NUGU_SPEAKER_UNABLE_CONTROL; /**< Speaker mute state  */
     bool can_control = false; /**< Speaker controllability */
 };
 

--- a/src/capability/speaker_agent.cc
+++ b/src/capability/speaker_agent.cc
@@ -80,11 +80,16 @@ void SpeakerAgent::updateInfoForContext(Json::Value& ctx)
 
         Json::Value volume;
         volume["name"] = getSpeakerName(sinfo->type);
-        volume["volume"] = sinfo->volume;
-        volume["minVolume"] = sinfo->min;
-        volume["maxVolume"] = sinfo->max;
-        volume["defaultVolumeStep"] = sinfo->step;
-        volume["muted"] = sinfo->mute;
+        if (sinfo->volume != NUGU_SPEAKER_UNABLE_CONTROL)
+            volume["volume"] = sinfo->volume;
+        if (sinfo->min != NUGU_SPEAKER_UNABLE_CONTROL)
+            volume["minVolume"] = sinfo->min;
+        if (sinfo->max != NUGU_SPEAKER_UNABLE_CONTROL)
+            volume["maxVolume"] = sinfo->max;
+        if (sinfo->step != NUGU_SPEAKER_UNABLE_CONTROL)
+            volume["defaultVolumeStep"] = sinfo->step;
+        if (sinfo->mute != NUGU_SPEAKER_UNABLE_CONTROL)
+            volume["muted"] = sinfo->mute;
 
         speaker["volumes"].append(volume);
     }
@@ -129,8 +134,8 @@ void SpeakerAgent::setSpeakerInfo(const std::map<SpeakerType, SpeakerInfo>& info
     for (const auto& container : info) {
         speakers.emplace(container.second.type, std::unique_ptr<SpeakerInfo>(new SpeakerInfo(container.second)));
 
-        nugu_dbg("speaker - %s %d[%d - %d], can_control: %d",
-            getSpeakerName(container.second.type).c_str(), container.second.volume, container.second.min, container.second.max, container.second.can_control);
+        nugu_dbg("speaker - %s %d[%d - %d], mute: %d, can_control: %d",
+            getSpeakerName(container.second.type).c_str(), container.second.volume, container.second.min, container.second.max, container.second.mute, container.second.can_control);
     }
 }
 


### PR DESCRIPTION
If the property is set as uncontrollable, the speaker agent transmits
the event with context information excluding the property.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>