### PR TITLE
capability: add playServiceId to Text.TextSource

### DIFF
--- a/src/capability/text_agent.hh
+++ b/src/capability/text_agent.hh
@@ -42,6 +42,7 @@ public:
 
 private:
     void sendEventTextInput(const std::string& text, const std::string& token, bool include_dialog_attribute, EventResultCallback cb = nullptr);
+    void sendEventTextInput(const std::string& text, const std::string& token, const std::string& ps_id, EventResultCallback cb = nullptr);
     void parsingTextSource(const char* message);
 
     ITextListener* text_listener;


### PR DESCRIPTION
If the `playServiceId` field exists in the `Text.TextSource` directive,
the `Text.TextInput` event must be transmitted by forcibly setting it
to a newly received value instead of the internally managed
`playServiceId` value.

Also, `playServiceId`, `domainTypes`, `asrContext` fields received from
`ASR.ExpecSpeech` must not be included in `Text.TextInput` event.

Signed-off-by: Inho Oh <inho.oh@sk.com>