### PR TITLE
SpeakerAgent: Send mute boolean type

### DIFF
--- a/src/capability/speaker_agent.cc
+++ b/src/capability/speaker_agent.cc
@@ -89,7 +89,7 @@ void SpeakerAgent::updateInfoForContext(Json::Value& ctx)
         if (sinfo->step != NUGU_SPEAKER_UNABLE_CONTROL)
             volume["defaultVolumeStep"] = sinfo->step;
         if (sinfo->mute != NUGU_SPEAKER_UNABLE_CONTROL)
-            volume["muted"] = sinfo->mute;
+            volume["muted"] = sinfo->mute ? true : false;
 
         speaker["volumes"].append(volume);
     }


### PR DESCRIPTION
There is a bug that is sending mute field with integer type. I modified
this to be a boolean type.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>