### PR TITLE
ASRAgent: remove unused field

### DIFF
--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -442,13 +442,7 @@ void ASRAgent::parsingExpectSpeech(std::string&& dialog_id, const char* message)
         return;
     }
 
-    if (root["timeoutInMilliseconds"].empty()) {
-        nugu_error("There is no mandatory data in directive message");
-        return;
-    }
-
     es_attr.is_handle = true;
-    es_attr.timeout = root["timeoutInMilliseconds"].asString();
     es_attr.play_service_id = root["playServiceId"].asString();
     es_attr.domain_types = root["domainTypes"];
     es_attr.asr_context = root["asrContext"];

--- a/src/capability/asr_agent.hh
+++ b/src/capability/asr_agent.hh
@@ -28,7 +28,6 @@ namespace NuguCapability {
 typedef struct expect_speech_attr {
     bool is_handle;
     std::string dialog_id;
-    std::string timeout;
     std::string play_service_id;
     Json::Value domain_types;
     Json::Value asr_context;


### PR DESCRIPTION
The `timeoutInMilliseconds` field is removed because it is no longer
needed.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>