### PR TITLE
base: add Last-Asr-Event-Time HTTP header

### DIFF
--- a/include/base/nugu_network_manager.h
+++ b/include/base/nugu_network_manager.h
@@ -413,6 +413,12 @@ int nugu_network_manager_set_useragent(const char *app_version,
 const char *nugu_network_manager_peek_useragent(void);
 
 /**
+ * @brief Get the last ASR event time information.
+ * @return Last-Asr-Event-Time. Please do not modify the data manually.
+ */
+const char *nugu_network_manager_peek_last_asr_time(void);
+
+/**
  * @}
  */
 

--- a/src/base/network/dg_server.c
+++ b/src/base/network/dg_server.c
@@ -244,6 +244,8 @@ DGServer *dg_server_new(const NuguNetworkServerPolicy *policy)
 	}
 #endif
 
+	dg_server_update_last_asr_time(server);
+
 	http2_network_set_token(server->net, nugu_network_manager_peek_token());
 	http2_network_enable_curl_log(server->net);
 	http2_network_start(server->net);
@@ -452,6 +454,21 @@ int dg_server_force_close_event(DGServer *server, NuguEvent *nev)
 
 	g_hash_table_remove(server->pending_events,
 			    nugu_event_peek_msg_id(nev));
+
+	return 0;
+}
+
+int dg_server_update_last_asr_time(DGServer *server)
+{
+	const char *last_asr_time;
+
+	g_return_val_if_fail(server != NULL, -1);
+
+	last_asr_time = nugu_network_manager_peek_last_asr_time();
+	if (last_asr_time == NULL)
+		return 0;
+
+	http2_network_set_last_asr_time(server->net, last_asr_time);
 
 	return 0;
 }

--- a/src/base/network/dg_server.h
+++ b/src/base/network/dg_server.h
@@ -55,6 +55,8 @@ int dg_server_send_attachment(DGServer *server, NuguEvent *nev, int is_end,
 			      size_t length, unsigned char *data);
 int dg_server_force_close_event(DGServer *server, NuguEvent *nev);
 
+int dg_server_update_last_asr_time(DGServer *server);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/base/network/http2/http2_network.c
+++ b/src/base/network/http2/http2_network.c
@@ -70,6 +70,9 @@ struct _http2_network {
 	/* authorization header */
 	gchar *token;
 
+	/* Last-Asr-Event-Time header */
+	gchar *last_asr;
+
 	/* thread creation check */
 	ThreadSync *sync_init;
 };
@@ -431,6 +434,7 @@ void http2_network_free(HTTP2Network *net)
 		thread_sync_free(net->sync_init);
 
 	g_free(net->token);
+	g_free(net->last_asr);
 
 	memset(net, 0, sizeof(HTTP2Network));
 	free(net);
@@ -446,6 +450,21 @@ int http2_network_set_token(HTTP2Network *net, const char *token)
 		net->token = g_strdup_printf("authorization: Bearer %s", token);
 	else
 		net->token = NULL;
+
+	return 0;
+}
+
+int http2_network_set_last_asr_time(HTTP2Network *net, const char *timestr)
+{
+	g_return_val_if_fail(net != NULL, -1);
+
+	g_free(net->last_asr);
+
+	if (timestr)
+		net->last_asr =
+			g_strdup_printf("Last-Asr-Event-Time: %s", timestr);
+	else
+		net->last_asr = NULL;
 
 	return 0;
 }
@@ -482,6 +501,9 @@ int http2_network_add_request(HTTP2Network *net, HTTP2Request *req)
 
 	if (net->token)
 		http2_request_add_header(req, net->token);
+
+	if (net->last_asr)
+		http2_request_add_header(req, net->last_asr);
 
 	http2_request_set_useragent(req, net->useragent);
 

--- a/src/base/network/http2/http2_network.h
+++ b/src/base/network/http2/http2_network.h
@@ -39,6 +39,7 @@ int http2_network_start(HTTP2Network *net);
 int http2_network_wakeup(HTTP2Network *net);
 
 int http2_network_set_token(HTTP2Network *net, const char *token);
+int http2_network_set_last_asr_time(HTTP2Network *net, const char *timestr);
 
 void http2_network_enable_curl_log(HTTP2Network *net);
 void http2_network_disable_curl_log(HTTP2Network *net);

--- a/src/base/nugu_event.c
+++ b/src/base/nugu_event.c
@@ -144,14 +144,12 @@ EXPORT_API const char *nugu_event_peek_version(NuguEvent *nev)
 EXPORT_API int nugu_event_set_context(NuguEvent *nev, const char *context)
 {
 	g_return_val_if_fail(nev != NULL, -1);
+	g_return_val_if_fail(context != NULL, -1);
 
 	if (nev->context)
 		free(nev->context);
 
-	if (!context)
-		nev->context = NULL;
-	else
-		nev->context = strdup(context);
+	nev->context = strdup(context);
 
 	return 0;
 }
@@ -170,10 +168,10 @@ EXPORT_API int nugu_event_set_json(NuguEvent *nev, const char *json)
 	if (nev->json)
 		free(nev->json);
 
-	if (!json)
-		nev->json = NULL;
-	else
+	if (json)
 		nev->json = strdup(json);
+	else
+		nev->json = NULL;
 
 	return 0;
 }
@@ -214,12 +212,14 @@ EXPORT_API int nugu_event_set_referrer_id(NuguEvent *nev,
 					  const char *referrer_id)
 {
 	g_return_val_if_fail(nev != NULL, -1);
-	g_return_val_if_fail(referrer_id != NULL, -1);
 
 	if (nev->referrer_id)
 		free(nev->referrer_id);
 
-	nev->referrer_id = strdup(referrer_id);
+	if (referrer_id)
+		nev->referrer_id = strdup(referrer_id);
+	else
+		nev->referrer_id = NULL;
 
 	return 0;
 }
@@ -272,7 +272,7 @@ EXPORT_API char *nugu_event_generate_payload(NuguEvent *nev)
 	return buf;
 }
 
-int nugu_event_set_type(NuguEvent *nev, enum nugu_event_type type)
+EXPORT_API int nugu_event_set_type(NuguEvent *nev, enum nugu_event_type type)
 {
 	g_return_val_if_fail(nev != NULL, -1);
 
@@ -281,7 +281,7 @@ int nugu_event_set_type(NuguEvent *nev, enum nugu_event_type type)
 	return 0;
 }
 
-enum nugu_event_type nugu_event_get_type(NuguEvent *nev)
+EXPORT_API enum nugu_event_type nugu_event_get_type(NuguEvent *nev)
 {
 	g_return_val_if_fail(nev != NULL, NUGU_EVENT_TYPE_DEFAULT);
 

--- a/tests/test_nugu_event.c
+++ b/tests/test_nugu_event.c
@@ -27,6 +27,7 @@
 static void test_nugu_event_default(void)
 {
 	NuguEvent *ev;
+	char *payload;
 
 	g_assert(nugu_event_new(NULL, NULL, NULL) == NULL);
 	g_assert(nugu_event_new("ASR", NULL, NULL) == NULL);
@@ -39,20 +40,59 @@ static void test_nugu_event_default(void)
 	g_assert_cmpstr(nugu_event_peek_name(ev), ==, "Recognize");
 	g_assert_cmpstr(nugu_event_peek_version(ev), ==, "1.0");
 
+	/* msg_id != dialog_id */
 	g_assert(nugu_event_peek_msg_id(ev) != NULL);
 	g_assert(nugu_event_peek_dialog_id(ev) != NULL);
 	g_assert_cmpstr(nugu_event_peek_msg_id(ev), !=,
 			nugu_event_peek_dialog_id(ev));
 
+	/* dialog_id is mandatory */
 	g_assert(nugu_event_set_dialog_id(ev, "1234") == 0);
 	g_assert(nugu_event_set_dialog_id(ev, TEST_UUID) == 0);
 	g_assert_cmpstr(nugu_event_peek_dialog_id(ev), ==, TEST_UUID);
+	g_assert(nugu_event_set_dialog_id(ev, NULL) == -1);
+	g_assert(nugu_event_peek_dialog_id(ev) != NULL);
+	g_assert_cmpstr(nugu_event_peek_dialog_id(ev), ==, TEST_UUID);
+
+	/* context is mandatory */
+	g_assert(nugu_event_set_context(ev, "{1}") == 0);
+	g_assert(nugu_event_set_context(ev, "{2}") == 0);
+	g_assert_cmpstr(nugu_event_peek_context(ev), ==, "{2}");
+	g_assert(nugu_event_set_context(ev, NULL) == -1);
+	g_assert(nugu_event_peek_context(ev) != NULL);
+	g_assert_cmpstr(nugu_event_peek_context(ev), ==, "{2}");
+
+	/* json is optional */
+	g_assert(nugu_event_peek_json(ev) == NULL);
+	g_assert(nugu_event_set_json(ev, "{1}") == 0);
+	g_assert(nugu_event_set_json(ev, "{2}") == 0);
+	g_assert_cmpstr(nugu_event_peek_json(ev), ==, "{2}");
+	g_assert(nugu_event_set_json(ev, NULL) == 0);
+	g_assert(nugu_event_peek_json(ev) == NULL);
+
+	/* referrer_id is optional */
+	g_assert(nugu_event_peek_referrer_id(ev) == NULL);
+	g_assert(nugu_event_set_referrer_id(ev, "1234") == 0);
+	g_assert(nugu_event_set_referrer_id(ev, "5678") == 0);
+	g_assert_cmpstr(nugu_event_peek_referrer_id(ev), ==, "5678");
+	g_assert(nugu_event_set_referrer_id(ev, NULL) == 0);
+	g_assert(nugu_event_peek_referrer_id(ev) == NULL);
 
 	g_assert(nugu_event_get_seq(ev) == 0);
 	g_assert(nugu_event_increase_seq(ev) == 1);
 	g_assert(nugu_event_get_seq(ev) == 1);
 	g_assert(nugu_event_increase_seq(ev) == 2);
 	g_assert(nugu_event_get_seq(ev) == 2);
+
+	g_assert(nugu_event_get_type(ev) == NUGU_EVENT_TYPE_DEFAULT);
+	g_assert(nugu_event_set_type(ev, NUGU_EVENT_TYPE_WITH_ATTACHMENT) == 0);
+	g_assert(nugu_event_get_type(ev) == NUGU_EVENT_TYPE_WITH_ATTACHMENT);
+	g_assert(nugu_event_set_type(ev, NUGU_EVENT_TYPE_DEFAULT) == 0);
+	g_assert(nugu_event_get_type(ev) == NUGU_EVENT_TYPE_DEFAULT);
+
+	payload = nugu_event_generate_payload(ev);
+	g_assert(payload != NULL);
+	free(payload);
 
 	nugu_event_free(ev);
 }


### PR DESCRIPTION
The following 'Last-Asr-Event-Time' HTTP header field was added in
the device-gateway server protocol specification.

    Last-Asr-Event-Time: {IMF-fixdate format}

Example:

    Last-Asr-Event-Time: Sun, 06 Nov 1994 08:49:37 GMT

This field is updated whenever there is an ASR event transmission.
And, if the ASR event has not yet occurred, it is not sent.

Signed-off-by: Inho Oh <inho.oh@sk.com>