### PR TITLE
playstack:update PlayStackManager

### DIFF
--- a/include/clientkit/playstack_manager_interface.hh
+++ b/include/clientkit/playstack_manager_interface.hh
@@ -104,8 +104,9 @@ public:
      * @brief Add play service id to playstack.
      * @param[in] ps_id play service id
      * @param[in] ndir directive
+     * @return true if the play service id is added, otherwise false
      */
-    virtual void add(const std::string& ps_id, NuguDirective* ndir) = 0;
+    virtual bool add(const std::string& ps_id, NuguDirective* ndir) = 0;
 
     /**
      * @brief Remove play service id from playstack.


### PR DESCRIPTION
It change return type of add() for checking result.

It expose IStackTimer which is used as context holding timer
to be able to replace to customized timer (It's used for test, mainly).

It apply stack replacement and notification flow.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>