### PR TITLE
capability: fix typo in the audio_player_agent

### DIFF
--- a/include/capability/audio_player_interface.hh
+++ b/include/capability/audio_player_interface.hh
@@ -197,21 +197,21 @@ public:
      * @param[in] current_favorite current favorite value
      * @return dialog request id if a NUGU service request succeeds with user text, otherwise empty string
      */
-    virtual std::string requestFavoriteCommmand(bool current_favorite) = 0;
+    virtual std::string requestFavoriteCommand(bool current_favorite) = 0;
 
     /**
      * @brief Send to request repeat command event with current repeat value.
      * @param[in] current_repeat current repeat value
      * @return dialog request id if a NUGU service request succeeds with user text, otherwise empty string
      */
-    virtual std::string requestRepeatCommmand(RepeatType current_repeat) = 0;
+    virtual std::string requestRepeatCommand(RepeatType current_repeat) = 0;
 
     /**
      * @brief Send to request shuffle command event with current shuffle value.
      * @param[in] current_shuffle current shuffle value
      * @return dialog request id if a NUGU service request succeeds with user text, otherwise empty string
      */
-    virtual std::string requestShuffleCommmand(bool current_shuffle) = 0;
+    virtual std::string requestShuffleCommand(bool current_shuffle) = 0;
 
     /**
      * @brief set media player's volume

--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -329,7 +329,7 @@ void AudioPlayerAgent::seek(int msec)
         cur_player->seek(msec * 1000);
 }
 
-std::string AudioPlayerAgent::requestFavoriteCommmand(bool current_favorite)
+std::string AudioPlayerAgent::requestFavoriteCommand(bool current_favorite)
 {
     std::string ename = "FavoriteCommandIssued";
     std::string payload = "";
@@ -350,7 +350,7 @@ std::string AudioPlayerAgent::requestFavoriteCommmand(bool current_favorite)
     return id;
 }
 
-std::string AudioPlayerAgent::requestRepeatCommmand(RepeatType current_repeat)
+std::string AudioPlayerAgent::requestRepeatCommand(RepeatType current_repeat)
 {
     std::string ename = "RepeatCommandIssued";
     std::string payload = "";
@@ -381,7 +381,7 @@ std::string AudioPlayerAgent::requestRepeatCommmand(RepeatType current_repeat)
     return id;
 }
 
-std::string AudioPlayerAgent::requestShuffleCommmand(bool current_shuffle)
+std::string AudioPlayerAgent::requestShuffleCommand(bool current_shuffle)
 {
     std::string ename = "ShuffleCommandIssued";
     std::string payload = "";

--- a/src/capability/audio_player_agent.hh
+++ b/src/capability/audio_player_agent.hh
@@ -63,9 +63,9 @@ public:
     std::string pause() override;
     std::string resume() override;
     void seek(int msec) override;
-    std::string requestFavoriteCommmand(bool current_favorite) override;
-    std::string requestRepeatCommmand(RepeatType current_repeat) override;
-    std::string requestShuffleCommmand(bool current_shuffle) override;
+    std::string requestFavoriteCommand(bool current_favorite) override;
+    std::string requestRepeatCommand(RepeatType current_repeat) override;
+    std::string requestShuffleCommand(bool current_shuffle) override;
     bool setVolume(int volume) override;
     bool setMute(bool mute) override;
 


### PR DESCRIPTION
fix the 'commmand' to 'command'

Signed-off-by: Inho Oh <inho.oh@sk.com>