### PR TITLE
playsync:add PlaySyncManager

### DIFF
--- a/include/clientkit/playsync_manager_interface.hh
+++ b/include/clientkit/playsync_manager_interface.hh
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NUGU_PLAYSYNC_MANAGER_INTERFACE_H__
+#define __NUGU_PLAYSYNC_MANAGER_INTERFACE_H__
+
+#include <map>
+#include <string>
+
+#include <base/nugu_directive.h>
+#include <clientkit/playstack_manager_interface.hh>
+
+namespace NuguClientKit {
+
+/**
+ * @file playsync_manager_interface.hh
+ * @defgroup PlaySyncManagerInterface PlaySyncManagerInterface
+ * @ingroup SDKNuguClientKit
+ * @brief PlaySyncManager Interface
+ *
+ * Interface of PlaySyncManager which manage context and sync flow between related capability agents.
+ *
+ * @{
+ */
+
+/**
+ * @brief PlaySync State
+ */
+enum class PlaySyncState {
+    None, /**< No State */
+    Prepared, /**< agents are prepared for sync */
+    Synced, /**< agents are synced */
+    Released /**< agents are released */
+};
+
+/**
+ * @brief IPlaySyncManagerListener interface
+ * @see IPlaySyncManager
+ */
+class IPlaySyncManagerListener {
+public:
+    virtual ~IPlaySyncManagerListener() = default;
+
+    /**
+     * @brief Receive callback when sync state is changed.
+     * @param[in] ps_is play service id
+     * @param[in] state play sync state
+     * @param[in] extra_data an extra_data which is sent at starting sync
+     */
+    virtual void onSyncState(const std::string& ps_id, PlaySyncState state, void* extra_data) = 0;
+};
+
+/**
+ * @brief IPlaySyncManager interface
+ * @see IPlaySyncManagerListener
+ */
+class IPlaySyncManager {
+public:
+    using PlaySyncContainer = std::map<std::string, std::pair<PlaySyncState, void*>>;
+    using PlayStacks = std::map<std::string, PlaySyncContainer>;
+
+public:
+    virtual ~IPlaySyncManager() = default;
+
+    /**
+     * @brief Add IPlaySyncManagerListener.
+     * @param[in] requester capability agent name
+     * @param[in] listener IPlaySyncManagerListener instance
+     */
+    virtual void addListener(const std::string& requester, IPlaySyncManagerListener* listener) = 0;
+
+    /**
+     * @brief Remove IPlayStackManagerListener.
+     * @param[in] requester capability agent name
+     */
+    virtual void removeListener(const std::string& requester) = 0;
+
+    /**
+     * @brief Prepare sync capability agents which are included in directive.
+     * @param[in] ps_id play service id
+     * @param[in] ndir directive
+     */
+    virtual void prepareSync(const std::string& ps_id, NuguDirective* ndir) = 0;
+
+    /**
+     * @brief Start sync specific capability agent which was prepared.
+     * @param[in] ps_id play service id
+     * @param[in] requester capability agent name
+     * @param[in] extra_data an extra_data which is used after synced
+     */
+    virtual void startSync(const std::string& ps_id, const std::string& requester, void* extra_data = nullptr) = 0;
+
+    /**
+     * @brief Cancel sync specific capability agent which was synced.
+     * @param[in] ps_id play service id
+     * @param[in] requester capability agent name
+     */
+    virtual void cancelSync(const std::string& ps_id, const std::string& requester) = 0;
+
+    /**
+     * @brief Release sync all capability agents. (Actually, it release sync after context holding time.)
+     * @param[in] ps_id play service id
+     * @param[in] requester capability agent name
+     */
+    virtual void releaseSync(const std::string& ps_id, const std::string& requester) = 0;
+
+    /**
+     * @brief Release sync all capability agents after long time elapsed.
+     * @param[in] ps_id play service id
+     * @param[in] requester capability agent name
+     */
+    virtual void releaseSyncLater(const std::string& ps_id, const std::string& requester) = 0;
+
+    /**
+     * @brief Release sync all capability agents immediately.
+     * @param[in] ps_id play service id
+     * @param[in] requester capability agent name
+     */
+    virtual void releaseSyncImmediately(const std::string& ps_id, const std::string& requester) = 0;
+
+    /**
+     * @brief Postpone already started release if exist.
+     */
+    virtual void postPoneRelease() = 0;
+
+    /**
+     * @brief Continue pending release if exist.
+     */
+    virtual void continueRelease() = 0;
+
+    /**
+     * @brief Stop timer for releasing sync.
+     */
+    virtual void stopHolding() = 0;
+
+    /**
+     * @brief Reset timer for releasing sync.
+     */
+    virtual void resetHolding() = 0;
+
+    /**
+     * @brief Check whether the previous dialog has to be handled or not
+     * @param[in] prev_ndir preivous directive
+     * @param[in] cur_ndir current directive
+     * @return true if has to be handled, otherwise false
+     */
+    virtual bool isConditionToHandlePrevDialog(NuguDirective* prev_ndir, NuguDirective* cur_ndir) = 0;
+
+    /**
+     * @brief Check whether the specific playstack exist.
+     * @param[in] ps_id play service id
+     * @param[in] layer playstack layer
+     * @return true if has to be handled, otherwise false
+     */
+    virtual bool hasLayer(const std::string& ps_id, PlayStackLayer layer) = 0;
+
+    /**
+     * @brief Get all items which are stored in playstack.
+     * @return Playstack items (play service id list)
+     */
+    virtual std::vector<std::string> getAllPlayStackItems() = 0;
+};
+
+/**
+ * @}
+ */
+
+} // NuguClientKit
+
+#endif /* __NUGU_PLAYSYNC_MANAGER_INTERFACE_H__ */

--- a/src/core/playsync_manager.cc
+++ b/src/core/playsync_manager.cc
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+
+#include "base/nugu_log.h"
+#include "playsync_manager.hh"
+
+namespace NuguCore {
+
+PlaySyncManager::PlaySyncManager()
+    : playstack_manager(std::unique_ptr<PlayStackManager>(new PlayStackManager()))
+{
+    playstack_manager->addListener(this);
+}
+
+PlaySyncManager::~PlaySyncManager()
+{
+    clearContainer();
+    listener_map.clear();
+}
+
+void PlaySyncManager::setPlayStackManager(PlayStackManager* playstack_manager)
+{
+    if (!playstack_manager) {
+        nugu_warn("The PlayStackManager instance is not exist.");
+        return;
+    }
+
+    this->playstack_manager.reset(playstack_manager);
+    this->playstack_manager->addListener(this);
+}
+
+void PlaySyncManager::addListener(const std::string& requester, IPlaySyncManagerListener* listener)
+{
+    if (requester.empty() || !listener) {
+        nugu_warn("The requester or listener is not exist.");
+        return;
+    }
+
+    listener_map.emplace(requester, listener);
+}
+
+void PlaySyncManager::removeListener(const std::string& requester)
+{
+    if (requester.empty()) {
+        nugu_warn("The requester is not exist.");
+        return;
+    }
+
+    listener_map.erase(requester);
+}
+
+int PlaySyncManager::getListenerCount()
+{
+    return listener_map.size();
+}
+
+void PlaySyncManager::prepareSync(const std::string& ps_id, NuguDirective* ndir)
+{
+    if (!playstack_manager->add(ps_id, ndir)) {
+        nugu_warn("The condition is not satisfied to prepare sync.");
+        return;
+    }
+
+    clearPostPonedRelease();
+
+    if (!playstack_manager->isStackedCondition(ndir))
+        clearContainer();
+
+    std::string dir_groups = nugu_directive_peek_groups(ndir);
+    PlaySyncContainer playsync_container;
+
+    for (const auto& sync_capability : SYNC_CAPABILITAY_LIST)
+        if (dir_groups.find(sync_capability) != std::string::npos)
+            playsync_container.emplace(sync_capability, std::make_pair(PlaySyncState::Prepared, nullptr));
+
+    playstack_map.emplace(ps_id, playsync_container);
+
+    notifyStateChange(ps_id, PlaySyncState::Prepared);
+}
+
+void PlaySyncManager::startSync(const std::string& ps_id, const std::string& requester, void* extra_data)
+{
+    if (!isConditionToSyncAction(ps_id, requester, PlaySyncState::Synced))
+        return;
+
+    auto& playsync_container = playstack_map.at(ps_id);
+    playsync_container[requester] = std::make_pair(PlaySyncState::Synced, extra_data);
+
+    // It notify synced state only if all elements are synced.
+    for (const auto& element : playsync_container)
+        if (element.second.first != PlaySyncState::Synced)
+            return;
+
+    notifyStateChange(ps_id, PlaySyncState::Synced);
+}
+
+void PlaySyncManager::cancelSync(const std::string& ps_id, const std::string& requester)
+{
+    if (!isConditionToSyncAction(ps_id, requester, PlaySyncState::None))
+        return;
+
+    playstack_map.at(ps_id).erase(requester);
+}
+
+void PlaySyncManager::releaseSync(const std::string& ps_id, const std::string& requester)
+{
+    rawReleaseSync(ps_id, requester, PlayStackRemoveMode::Normal);
+}
+
+void PlaySyncManager::releaseSyncLater(const std::string& ps_id, const std::string& requester)
+{
+    rawReleaseSync(ps_id, requester, PlayStackRemoveMode::Later);
+}
+
+void PlaySyncManager::releaseSyncImmediately(const std::string& ps_id, const std::string& requester)
+{
+    rawReleaseSync(ps_id, requester, PlayStackRemoveMode::Immediately);
+}
+
+void PlaySyncManager::postPoneRelease()
+{
+    release_postponed = true;
+}
+
+void PlaySyncManager::continueRelease()
+{
+    if (release_postponed && postponed_release_func)
+        postponed_release_func();
+
+    clearPostPonedRelease();
+}
+
+void PlaySyncManager::stopHolding()
+{
+    playstack_manager->stopHolding();
+}
+
+void PlaySyncManager::resetHolding()
+{
+    playstack_manager->resetHolding();
+}
+
+bool PlaySyncManager::isConditionToHandlePrevDialog(NuguDirective* prev_ndir, NuguDirective* cur_ndir)
+{
+    return playstack_manager->isStackedCondition(cur_ndir) && !playstack_manager->hasExpectSpeech(prev_ndir);
+}
+
+bool PlaySyncManager::hasLayer(const std::string& ps_id, PlayStackLayer layer)
+{
+    return playstack_manager->getPlayStackLayer(ps_id) == layer;
+}
+
+std::vector<std::string> PlaySyncManager::getAllPlayStackItems()
+{
+    return playstack_manager->getAllPlayStackItems();
+}
+
+const PlaySyncManager::PlayStacks& PlaySyncManager::getPlayStacks()
+{
+    return playstack_map;
+}
+
+void PlaySyncManager::onStackAdded(const std::string& ps_id)
+{
+}
+
+void PlaySyncManager::onStackRemoved(const std::string& ps_id)
+{
+    if (playstack_map.find(ps_id) == playstack_map.cend()) {
+        nugu_warn("The PlaySyncContainer is not exist.");
+        return;
+    }
+
+    auto& playsync_container = playstack_map.at(ps_id);
+
+    for (auto& element : playsync_container)
+        element.second.first = PlaySyncState::Released;
+
+    notifyStateChange(ps_id, PlaySyncState::Released);
+
+    playstack_map.erase(ps_id);
+}
+
+void PlaySyncManager::notifyStateChange(const std::string& ps_id, PlaySyncState state)
+{
+    if (playstack_map.find(ps_id) == playstack_map.cend()) {
+        nugu_warn("The PlaySyncContainer is not exist.");
+        return;
+    }
+
+    const auto& playsync_container = playstack_map.at(ps_id);
+
+    for (const auto& element : playsync_container) {
+        try {
+            listener_map.at(element.first)->onSyncState(ps_id, state, element.second.second);
+        } catch (std::out_of_range& exception) {
+            nugu_warn("The requester is not exist.");
+        }
+    }
+}
+
+bool PlaySyncManager::isConditionToSyncAction(const std::string& ps_id, const std::string& requester, PlaySyncState state)
+{
+    if (ps_id.empty() || requester.empty() || playstack_map.find(ps_id) == playstack_map.cend()) {
+        nugu_warn("The condition is not satisfied to sync action.");
+        return false;
+    }
+
+    try {
+        if (playstack_map.at(ps_id).at(requester).first == state) {
+            nugu_warn("It's already done.");
+            return false;
+        }
+    } catch (std::out_of_range& exception) {
+        nugu_warn("The requester is not exist.");
+        return false;
+    }
+
+    return true;
+}
+
+void PlaySyncManager::rawReleaseSync(const std::string& ps_id, const std::string& requester, PlayStackRemoveMode stack_remove_mode)
+{
+    if (!isConditionToSyncAction(ps_id, requester, PlaySyncState::Released))
+        return;
+
+    auto release_func = [=]() {
+        playstack_manager->stopHolding();
+        playstack_manager->remove(ps_id, stack_remove_mode);
+    };
+
+    if (release_postponed) {
+        postponed_release_func = release_func;
+        return;
+    }
+
+    release_func();
+}
+
+void PlaySyncManager::clearContainer()
+{
+    playstack_map.clear();
+}
+
+void PlaySyncManager::clearPostPonedRelease()
+{
+    postponed_release_func = nullptr;
+    release_postponed = false;
+}
+
+} // NuguCore

--- a/src/core/playsync_manager.hh
+++ b/src/core/playsync_manager.hh
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NUGU_PLAYSYNC_MANAGER_H__
+#define __NUGU_PLAYSYNC_MANAGER_H__
+
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include <base/nugu_directive.h>
+
+#include "clientkit/playsync_manager_interface.hh"
+#include "playstack_manager.hh"
+
+namespace NuguCore {
+
+using namespace NuguClientKit;
+
+class PlaySyncManager : public IPlaySyncManager,
+                        public IPlayStackManagerListener {
+public:
+    PlaySyncManager();
+    virtual ~PlaySyncManager();
+
+    void setPlayStackManager(PlayStackManager* playstack_manager);
+    void addListener(const std::string& requester, IPlaySyncManagerListener* listener) override;
+    void removeListener(const std::string& requester) override;
+    int getListenerCount();
+
+    void prepareSync(const std::string& ps_id, NuguDirective* ndir) override;
+    void startSync(const std::string& ps_id, const std::string& requester, void* extra_data = nullptr) override;
+    void cancelSync(const std::string& ps_id, const std::string& requester) override;
+    void releaseSync(const std::string& ps_id, const std::string& requester) override;
+    void releaseSyncLater(const std::string& ps_id, const std::string& requester) override;
+    void releaseSyncImmediately(const std::string& ps_id, const std::string& requester) override;
+
+    void postPoneRelease() override;
+    void continueRelease() override;
+    void stopHolding() override;
+    void resetHolding() override;
+
+    bool isConditionToHandlePrevDialog(NuguDirective* prev_ndir, NuguDirective* cur_ndir) override;
+    bool hasLayer(const std::string& ps_id, PlayStackLayer layer) override;
+    std::vector<std::string> getAllPlayStackItems() override;
+    const PlayStacks& getPlayStacks();
+
+    // overriding IPlayStackManagerListener
+    void onStackAdded(const std::string& ps_id) override;
+    void onStackRemoved(const std::string& ps_id) override;
+
+private:
+    void notifyStateChange(const std::string& ps_id, PlaySyncState state);
+    bool isConditionToSyncAction(const std::string& ps_id, const std::string& requester, PlaySyncState state);
+    void rawReleaseSync(const std::string& ps_id, const std::string& requester, PlayStackRemoveMode stack_remove_mode);
+    void clearContainer();
+    void clearPostPonedRelease();
+
+    const std::vector<std::string> SYNC_CAPABILITAY_LIST { "TTS", "AudioPlayer", "Display" };
+
+    std::unique_ptr<PlayStackManager> playstack_manager = nullptr;
+    std::function<void()> postponed_release_func = nullptr;
+    std::map<std::string, IPlaySyncManagerListener*> listener_map;
+    PlayStacks playstack_map;
+    bool release_postponed = false;
+};
+
+} // NuguCore
+
+#endif /* __NUGU_PLAYSYNC_MANAGER_H__ */

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -4,6 +4,7 @@ SET(UNIT_TESTS
 	test_core_directive_sequencer
 	test_core_session_manager
 	test_core_playstack_manager
+	test_core_playsync_manager
 	test_core_interaction_control_manager)
 
 # Add Compile Sources with Mock for test
@@ -13,6 +14,7 @@ SET(test_core_focus_manager_srcs ../../src/core/focus_manager.cc)
 SET(test_core_directive_sequencer_srcs ../../src/core/directive_sequencer.cc)
 SET(test_core_session_manager_srcs ../../src/core/session_manager.cc)
 SET(test_core_playstack_manager_srcs ../../src/core/playstack_manager.cc)
+SET(test_core_playsync_manager_srcs ../../src/core/playsync_manager.cc)
 SET(test_core_interaction_control_manager_srcs ../../src/core/interaction_control_manager.cc)
 
 FOREACH(test ${UNIT_TESTS})


### PR DESCRIPTION
It add PlaySyncManager for managing context and sync flow
between related capability agents like TTS, Display, AudioPlayer.

Because, it has to control playstack simultaneously,
the PlayStackManager is included innerly.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>