### PR TITLE
playsync:add onDataChanged callback

### DIFF
--- a/include/clientkit/playsync_manager_interface.hh
+++ b/include/clientkit/playsync_manager_interface.hh
@@ -61,6 +61,13 @@ public:
      * @param[in] extra_data an extra_data which is sent at starting sync
      */
     virtual void onSyncState(const std::string& ps_id, PlaySyncState state, void* extra_data) = 0;
+
+    /**
+     * @brief Receive callback when the extra data is changed.
+     * @param[in] ps_is play service id
+     * @param[in] extra_datas the extra_datas which are composed by previous and new
+     */
+    virtual void onDataChanged(const std::string& ps_id, std::pair<void*, void*> extra_datas) = 0;
 };
 
 /**

--- a/src/core/playsync_manager.hh
+++ b/src/core/playsync_manager.hh
@@ -63,7 +63,8 @@ public:
     void onStackRemoved(const std::string& ps_id) override;
 
 private:
-    void notifyStateChange(const std::string& ps_id, PlaySyncState state);
+    void updateExtraData(const std::string& ps_id, const std::string& requester, void* extra_data);
+    void notifyStateChanged(const std::string& ps_id, PlaySyncState state);
     bool isConditionToSyncAction(const std::string& ps_id, const std::string& requester, PlaySyncState state);
     void rawReleaseSync(const std::string& ps_id, const std::string& requester, PlayStackRemoveMode stack_remove_mode);
     void clearContainer();


### PR DESCRIPTION
It add onDataChanged callback in IPlaySyncManagerListener
for receiving changed extra data.

The returned extra datas are composed by previous and new datas.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>