### PR TITLE
ASRAgent: Add asr error code

### DIFF
--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -487,7 +487,7 @@ void ASRAgent::parsingNotifyResult(const char* message)
     }
 
     if (state == "ERROR") {
-        nugu_error("NotifyResult.state is ERROR");
+        nugu_error("NotifyResult.state is ERROR (code: %d, desc: %s)", root["asrErrorCode"].asInt(), root["description"].asString().c_str());
         releaseASRFocus(false, ASRError::RECOGNIZE_ERROR);
     }
 }


### PR DESCRIPTION
Asr's error code was added to `ASR.NotifyResult`.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>