### PR TITLE
AudioPlayer:update to manage render info to container

### DIFF
--- a/src/capability/audio_player_agent.hh
+++ b/src/capability/audio_player_agent.hh
@@ -17,6 +17,8 @@
 #ifndef __NUGU_AUDIO_PLAYER_AGENT_H__
 #define __NUGU_AUDIO_PLAYER_AGENT_H__
 
+#include <map>
+
 #include "capability/audio_player_interface.hh"
 #include "capability/display_interface.hh"
 #include "clientkit/capability.hh"
@@ -133,7 +135,7 @@ private:
     void parsingControlLyricsPage(const char* message);
     void parsingRequestPlayCommand(const char* dname, const char* message);
     void parsingRequestOthersCommand(const char* dname, const char* message);
-    void parsingRenderInfo(NuguDirective* ndir, const char* message);
+    std::string parsingRenderInfo(NuguDirective* ndir, const char* message);
 
     void checkAndUpdateVolume();
     std::string playbackError(PlaybackError error);
@@ -168,7 +170,7 @@ private:
     std::string template_type;
     std::vector<IAudioPlayerListener*> aplayer_listeners;
     IAudioPlayerDisplayListener* display_listener;
-    RenderInfo render_info;
+    std::map<std::string, RenderInfo> render_infos;
 };
 
 } // NuguCapability


### PR DESCRIPTION
Because, the render info is maintained by single object,
it has a problem not to refresh next or previous song's info.

So, it change to manage render info to map container
which is possible to handle multiple render infos.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>