### PR TITLE
Text:update capability version to 1.3

### DIFF
--- a/src/capability/text_agent.hh
+++ b/src/capability/text_agent.hh
@@ -41,8 +41,13 @@ public:
     void notifyResponseTimeout();
 
 private:
-    void sendEventTextInput(const std::string& text, const std::string& token, bool include_dialog_attribute, EventResultCallback cb = nullptr);
-    void sendEventTextInput(const std::string& text, const std::string& token, const std::string& ps_id, EventResultCallback cb = nullptr);
+    using TextInputParam = struct {
+        std::string text;
+        std::string token;
+        std::string ps_id;
+    };
+
+    void sendEventTextInput(TextInputParam&& text_input_param, bool include_dialog_attribute, EventResultCallback cb = nullptr);
     void parsingTextSource(const char* message);
 
     ITextListener* text_listener;


### PR DESCRIPTION
It update the version of TextAgent from 1.2 to 1.3.

Also, it merge two overloading sendEventTextInput method to one.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>