### PR TITLE
AudioPlayerAgent: Notify event

### DIFF
--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -1335,7 +1335,10 @@ void AudioPlayerAgent::mediaStateChanged(MediaPlayerState state)
         break;
     case MediaPlayerState::PLAYING:
         cur_aplayer_state = AudioPlayerState::PLAYING;
-        if (!is_paused_by_unfocus) {
+        if (is_paused_by_unfocus) {
+            nugu_dbg("force setting previous state for notify to application");
+            prev_aplayer_state = AudioPlayerState::PAUSED;
+        } else {
             if (prev_aplayer_state == AudioPlayerState::PAUSED)
                 sendEventPlaybackResumed();
             else


### PR DESCRIPTION
Fixed the AudioPlayerAgent not notifying application of the `Playing`
state in the following cases:

when the audioplayer paused due to wakeup and then resumes playing.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>