### PR TITLE
text:apply default value on sendEventTextInput parameter

### DIFF
--- a/src/capability/text_agent.cc
+++ b/src/capability/text_agent.cc
@@ -269,7 +269,7 @@ void TextAgent::parsingTextSource(const char* message)
 
     cur_state = TextState::BUSY;
 
-    sendEventTextInput({ text, token, ps_id }, true);
+    sendEventTextInput({ text, token, ps_id });
 
     setReferrerDialogRequestId(nugu_directive_peek_name(getNuguDirective()), "");
 

--- a/src/capability/text_agent.hh
+++ b/src/capability/text_agent.hh
@@ -47,7 +47,7 @@ private:
         std::string ps_id;
     };
 
-    void sendEventTextInput(TextInputParam&& text_input_param, bool include_dialog_attribute, EventResultCallback cb = nullptr);
+    void sendEventTextInput(TextInputParam&& text_input_param, bool include_dialog_attribute = true, EventResultCallback cb = nullptr);
     void parsingTextSource(const char* message);
 
     ITextListener* text_listener;


### PR DESCRIPTION
It apply the default value(true) on include_dialog_attribute parameter
of sendEventTextInput method.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>