### PR TITLE
Display:update to refresh display render info

### DIFF
--- a/src/capability/audio_player_agent.hh
+++ b/src/capability/audio_player_agent.hh
@@ -141,6 +141,9 @@ private:
     std::string playbackError(PlaybackError error);
     std::string playerActivity(AudioPlayerState state);
 
+    void renderDisplay(void* data);
+    void clearDisplay(void* data);
+
     const unsigned int PAUSE_CONTEXT_HOLD_TIME = 60 * 10;
 
     IMediaPlayer* cur_player;

--- a/src/capability/display_agent.cc
+++ b/src/capability/display_agent.cc
@@ -459,20 +459,39 @@ std::string DisplayAgent::getDirectionString(ControlDirection direction)
 
 void DisplayAgent::onSyncState(const std::string& ps_id, PlaySyncState state, void* extra_data)
 {
-    if (display_listener && extra_data) {
-        auto render_info = reinterpret_cast<DisplayRenderInfo*>(extra_data);
-
-        if (state == PlaySyncState::Synced) {
-            display_listener->renderDisplay(render_info->id, render_info->type, render_info->payload, render_info->dialog_id);
-        } else if (state == PlaySyncState::Released) {
-            this->render_info[render_info->id]->close = true;
-            display_listener->clearDisplay(render_info->id, true);
-        }
-    }
+    if (state == PlaySyncState::Synced)
+        renderDisplay(extra_data);
+    else if (state == PlaySyncState::Released)
+        clearDisplay(extra_data);
 }
 
 void DisplayAgent::onDataChanged(const std::string& ps_id, std::pair<void*, void*> extra_datas)
 {
+    clearDisplay(extra_datas.first);
+    renderDisplay(extra_datas.second);
+}
+
+void DisplayAgent::renderDisplay(void* data)
+{
+    if (!display_listener || !data) {
+        nugu_warn("The DisplayListener or render data is not exist.");
+        return;
+    }
+
+    auto render_info = reinterpret_cast<DisplayRenderInfo*>(data);
+    display_listener->renderDisplay(render_info->id, render_info->type, render_info->payload, render_info->dialog_id);
+}
+
+void DisplayAgent::clearDisplay(void* data)
+{
+    if (!display_listener || !data) {
+        nugu_warn("The DisplayListener or render data is not exist.");
+        return;
+    }
+
+    auto render_info = reinterpret_cast<DisplayRenderInfo*>(data);
+    this->render_info[render_info->id]->close = true;
+    display_listener->clearDisplay(render_info->id, true);
 }
 
 } // NuguCapability

--- a/src/capability/display_agent.hh
+++ b/src/capability/display_agent.hh
@@ -79,6 +79,9 @@ private:
     std::string getTemplateId(const std::string& ps_id);
     std::string getDirectionString(ControlDirection direction);
 
+    void renderDisplay(void* data);
+    void clearDisplay(void* data);
+
     std::map<std::string, DisplayRenderInfo*> render_info;
     IDisplayListener* display_listener;
     std::string disp_cur_ps_id;


### PR DESCRIPTION
It update to be possible to refresh display render info
when context is already synced in DisplayAgent.

When render datas exist in both Display And AudioPlayer,
it set to have priority in Display, so ignore AudioPlayer's data.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>