### PR TITLE
Text:add token parameter on requestTextInput

### DIFF
--- a/examples/standalone/nugu_sample_manager.cc
+++ b/examples/standalone/nugu_sample_manager.cc
@@ -313,7 +313,7 @@ gboolean NuguSampleManager::onKeyInput(GIOChannel* src, GIOCondition con, gpoint
 
     if (ns_mgr->commander.text_input) {
         if (ns_mgr->commander.text_handler)
-            ns_mgr->commander.text_handler->requestTextInput(keybuf, (ns_mgr->commander.text_input == 1));
+            ns_mgr->commander.text_handler->requestTextInput(keybuf, "", (ns_mgr->commander.text_input == 1));
 
         ns_mgr->commander.text_input = 0;
     } else {

--- a/include/capability/text_interface.hh
+++ b/include/capability/text_interface.hh
@@ -107,10 +107,11 @@ public:
     /**
      * @brief Request NUGU services based on text input.
      * @param[in] text text command
+     * @param[in] token received token
      * @param[in] include_dialog_attribute whether including dialog attribute
      * @return dialog request id if a NUGU service request succeeds with user text, otherwise empty string
      */
-    virtual std::string requestTextInput(const std::string& text, bool include_dialog_attribute = true) = 0;
+    virtual std::string requestTextInput(const std::string& text, const std::string& token = "", bool include_dialog_attribute = true) = 0;
 
     /**
      * @brief Set attribute about response

--- a/src/capability/text_agent.cc
+++ b/src/capability/text_agent.cc
@@ -145,7 +145,7 @@ void TextAgent::setCapabilityListener(ICapabilityListener* clistener)
         text_listener = dynamic_cast<ITextListener*>(clistener);
 }
 
-std::string TextAgent::requestTextInput(const std::string& text, bool include_dialog_attribute)
+std::string TextAgent::requestTextInput(const std::string& text, const std::string& token, bool include_dialog_attribute)
 {
     nugu_dbg("receive text interface : %s from user app", text.c_str());
     if (cur_state == TextState::BUSY) {
@@ -166,7 +166,7 @@ std::string TextAgent::requestTextInput(const std::string& text, bool include_di
 
     cur_state = TextState::BUSY;
 
-    sendEventTextInput({ text }, include_dialog_attribute);
+    sendEventTextInput({ text, token }, include_dialog_attribute);
 
     nugu_dbg("user request id: %s", cur_dialog_id.c_str());
     if (text_listener)

--- a/src/capability/text_agent.hh
+++ b/src/capability/text_agent.hh
@@ -37,7 +37,7 @@ public:
     void receiveCommandAll(const std::string& command, const std::string& param) override;
     void setCapabilityListener(ICapabilityListener* clistener) override;
 
-    std::string requestTextInput(const std::string& text, bool include_dialog_attribute = true) override;
+    std::string requestTextInput(const std::string& text, const std::string& token = "", bool include_dialog_attribute = true) override;
     void notifyResponseTimeout();
 
 private:


### PR DESCRIPTION
As another agents or components have to send token when sending TextInput event,
it add token parameter on requestTextInput method.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>