### PR TITLE
interaction:notify whether directive has multi-turn

### DIFF
--- a/examples/standalone/nugu_sample.cc
+++ b/examples/standalone/nugu_sample.cc
@@ -105,7 +105,12 @@ public:
 
 class InteractionControlManagerListener : public IInteractionControlManagerListener {
 public:
-    void onModeChanged(bool is_multi_turn)
+    void onHasMultiTurn() override
+    {
+        std::cout << "[multi-turn] has multi-turn\n";
+    }
+
+    void onModeChanged(bool is_multi_turn) override
     {
         std::cout << "[multi-turn] " << (is_multi_turn ? "started" : "finished") << std::endl;
     }

--- a/include/clientkit/interaction_control_manager_interface.hh
+++ b/include/clientkit/interaction_control_manager_interface.hh
@@ -53,6 +53,11 @@ public:
      * @param[in] is_multi_turn whether current mode is multi-turn or not
      */
     virtual void onModeChanged(bool is_multi_turn) = 0;
+
+    /**
+     * @brief Receive callback when the current directive has multi-turn
+     */
+    virtual void onHasMultiTurn() = 0;
 };
 
 /**
@@ -88,6 +93,11 @@ public:
      * @param[in] requester a object which request interaction mode
      */
     virtual void finish(InteractionMode mode, const std::string& requester) = 0;
+
+    /**
+     * @brief Notify the current directive has multi-turn
+     */
+    virtual void notifyHasMultiTurn() = 0;
 
     /**
      * @brief Clear all about interaction mode

--- a/src/core/capability_manager.cc
+++ b/src/core/capability_manager.cc
@@ -35,6 +35,8 @@ CapabilityManager::CapabilityManager()
     , interaction_control_manager(std::unique_ptr<InteractionControlManager>(new InteractionControlManager()))
 {
     wword = WAKEUP_WORD;
+
+    playsync_manager->setInteractionControlManager(interaction_control_manager.get());
 }
 
 CapabilityManager::~CapabilityManager()

--- a/src/core/interaction_control_manager.cc
+++ b/src/core/interaction_control_manager.cc
@@ -58,6 +58,12 @@ int InteractionControlManager::getListenerCount()
     return listeners.size();
 }
 
+void InteractionControlManager::notifyHasMultiTurn()
+{
+    for (const auto& listener : listeners)
+        listener->onHasMultiTurn();
+}
+
 void InteractionControlManager::start(InteractionMode mode, const std::string& requester)
 {
     if (mode != InteractionMode::MULTI_TURN) {

--- a/src/core/interaction_control_manager.hh
+++ b/src/core/interaction_control_manager.hh
@@ -35,6 +35,7 @@ public:
     void removeListener(IInteractionControlManagerListener* listener) override;
     int getListenerCount();
 
+    void notifyHasMultiTurn() override;
     void start(InteractionMode mode, const std::string& requester) override;
     void finish(InteractionMode mode, const std::string& requester) override;
     void clear() override;

--- a/src/core/playsync_manager.cc
+++ b/src/core/playsync_manager.cc
@@ -44,6 +44,12 @@ void PlaySyncManager::setPlayStackManager(PlayStackManager* playstack_manager)
     this->playstack_manager->addListener(this);
 }
 
+void PlaySyncManager::setInteractionControlManager(InteractionControlManager* interaction_control_manager)
+{
+    if (interaction_control_manager)
+        this->interaction_control_manager = interaction_control_manager;
+}
+
 void PlaySyncManager::addListener(const std::string& requester, IPlaySyncManagerListener* listener)
 {
     if (requester.empty() || !listener) {
@@ -91,6 +97,10 @@ void PlaySyncManager::prepareSync(const std::string& ps_id, NuguDirective* ndir)
     playstack_map.emplace(ps_id, playsync_container);
 
     notifyStateChanged(ps_id, PlaySyncState::Prepared);
+
+    // notify whether the current directive has ASR.ExpectSpeech
+    if (interaction_control_manager && playstack_manager->hasExpectSpeech(ndir))
+        interaction_control_manager->notifyHasMultiTurn();
 }
 
 void PlaySyncManager::startSync(const std::string& ps_id, const std::string& requester, void* extra_data)

--- a/src/core/playsync_manager.hh
+++ b/src/core/playsync_manager.hh
@@ -24,6 +24,7 @@
 #include <base/nugu_directive.h>
 
 #include "clientkit/playsync_manager_interface.hh"
+#include "interaction_control_manager.hh"
 #include "playstack_manager.hh"
 
 namespace NuguCore {
@@ -37,6 +38,7 @@ public:
     virtual ~PlaySyncManager();
 
     void setPlayStackManager(PlayStackManager* playstack_manager);
+    void setInteractionControlManager(InteractionControlManager* interaction_control_manager);
     void addListener(const std::string& requester, IPlaySyncManagerListener* listener) override;
     void removeListener(const std::string& requester) override;
     int getListenerCount();
@@ -73,6 +75,7 @@ private:
     const std::vector<std::string> SYNC_CAPABILITAY_LIST { "TTS", "AudioPlayer", "Display" };
 
     std::unique_ptr<PlayStackManager> playstack_manager = nullptr;
+    InteractionControlManager* interaction_control_manager = nullptr;
     std::function<void()> postponed_release_func = nullptr;
     std::map<std::string, IPlaySyncManagerListener*> listener_map;
     PlayStacks playstack_map;

--- a/tests/core/test_core_interaction_control_manager.cc
+++ b/tests/core/test_core_interaction_control_manager.cc
@@ -29,12 +29,20 @@ public:
     using InteractionModeChecker = std::pair<bool, int>;
 
 public:
+    void onHasMultiTurn() override
+    {
+        has_multi_turn = true;
+    }
+
     void onModeChanged(bool is_multi_turn) override
     {
         if (mode_checker.first == is_multi_turn)
             mode_checker.second++;
         else
             mode_checker = { is_multi_turn, 1 };
+
+        if (!is_multi_turn)
+            has_multi_turn = false;
     };
 
     InteractionModeChecker getModeChecker()
@@ -42,8 +50,14 @@ public:
         return mode_checker;
     }
 
+    bool hasMultiTurn()
+    {
+        return has_multi_turn;
+    }
+
 private:
     InteractionModeChecker mode_checker = { false, 0 };
+    bool has_multi_turn = false;
 };
 
 using TestModeChecker = InteractionControlManagerListener::InteractionModeChecker;
@@ -150,6 +164,15 @@ static void test_interaction_control_manager_multi_requester(TestFixture* fixtur
     g_assert(fixture->ic_manager_listener->getModeChecker() == (TestModeChecker { false, 1 }));
 }
 
+static void test_interaction_control_manager_has_multi_turn(TestFixture* fixture, gconstpointer ignored)
+{
+    fixture->ic_manager->addListener(fixture->ic_manager_listener.get());
+    g_assert(!fixture->ic_manager_listener->hasMultiTurn());
+
+    fixture->ic_manager->notifyHasMultiTurn();
+    g_assert(fixture->ic_manager_listener->hasMultiTurn());
+}
+
 static void test_interaction_control_manager_clear(TestFixture* fixture, gconstpointer ignored)
 {
     fixture->ic_manager->addListener(fixture->ic_manager_listener.get());
@@ -177,6 +200,7 @@ int main(int argc, char* argv[])
     G_TEST_ADD_FUNC("/core/InteractionControlManager/listener", test_interaction_control_manager_listener);
     G_TEST_ADD_FUNC("/core/InteractionControlManager/singleRequester", test_interaction_control_manager_single_requester);
     G_TEST_ADD_FUNC("/core/InteractionControlManager/multiRequester", test_interaction_control_manager_multi_requester);
+    G_TEST_ADD_FUNC("/core/InteractionControlManager/hasMultiTurn", test_interaction_control_manager_has_multi_turn);
     G_TEST_ADD_FUNC("/core/InteractionControlManager/clear", test_interaction_control_manager_clear);
 
     return g_test_run();


### PR DESCRIPTION
It add the callback which is possible to be notified
when the received directive has multi-turn (ASR.ExpectSpeech).

It could be checked before ASR states is changed from busy to idle.

```
==================================================
[Dialog - ASR] FOREGROUND (priority: 100)
==================================================
[ASR][id:0cadf95d9d01d9dfebc42a0e0791125b] LISTENING
[ASR][id:0cadf95d9d01d9dfebc42a0e0791125b] RECOGNIZING
[ASR][id:0cadf95d9d01d9dfebc42a0e0791125b] BUSY
[ASR][id:0cadf95d9d01d9dfebc42a0e0791125b] onComplete > NUGU DJ 열어줘
>>> [multi-turn] has multi-turn
[ASR][id:0cadf95d9d01d9dfebc42a0e0791125b] IDLE
==================================================
[Dialog - ASR] NONE (priority: 100)
==================================================
==================================================
[Dialog - TTS] FOREGROUND (priority: 100)
==================================================
[TTS][id:0cadf95d9d01d9dfebc42a0e0791125b] TEXT > 안녕하세요~ 제가 라디오 디제이로 활동하고 있는 누구 디제이 에요~  에피소드를 들려드릴까요?
>>> [multi-turn] started
```

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>