### PR TITLE
sample:update for compatibility about build environment

### DIFF
--- a/examples/standalone/nugu_sample_manager.cc
+++ b/examples/standalone/nugu_sample_manager.cc
@@ -175,7 +175,7 @@ void NuguSampleManager::reset()
     commands.first.clear();
     commands.second.clear();
     commander = {};
-    command_text = {};
+    command_text = std::make_pair("", "");
     is_show_prompt = true;
 }
 


### PR DESCRIPTION
It change NuguSampleManager codes about reset std::pair
for guarantee compatibility about build environment.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>