### PR TITLE
Capability&Core:improve SDK life cycle handling

### DIFF
--- a/examples/standalone/nugu_sample_manager.cc
+++ b/examples/standalone/nugu_sample_manager.cc
@@ -174,7 +174,6 @@ void NuguSampleManager::reset()
 {
     commands.first.clear();
     commands.second.clear();
-    commander = {};
     command_text = std::make_pair("", "");
     is_show_prompt = true;
 }

--- a/examples/standalone/nugu_sdk_manager.hh
+++ b/examples/standalone/nugu_sdk_manager.hh
@@ -74,6 +74,7 @@ private:
     std::function<void()> on_fail_func = nullptr;
 
     bool sdk_initialized = false;
+    bool is_network_error = false;
 };
 
 #endif /* __NUGU_SDK_MANAGER_H__ */

--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -28,24 +28,11 @@ static const char* CAPABILITY_VERSION = "1.3";
 
 ASRAgent::ASRAgent()
     : Capability(CAPABILITY_NAME, CAPABILITY_VERSION)
-    , es_attr({})
-    , rec_event(nullptr)
-    , timer(nullptr)
-    , uniq(0)
-    , focus_state(FocusState::NONE)
-    , cur_state(ASRState::IDLE)
-    , asr_cancel(false)
     , model_path("")
     , epd_type(NUGU_ASR_EPD_TYPE)
     , asr_encoding(NUGU_ASR_ENCODING)
     , response_timeout(NUGU_SERVER_RESPONSE_TIMEOUT_SEC)
     , epd_attribute({})
-    , wakeup_power_noise(0)
-    , wakeup_power_speech(0)
-{
-}
-
-ASRAgent::~ASRAgent()
 {
 }
 
@@ -74,6 +61,22 @@ void ASRAgent::initialize()
         nugu_info("It's already initialized.");
         return;
     }
+
+    Capability::initialize();
+
+    es_attr = {};
+    rec_event = nullptr;
+    all_context_info = "";
+    dialog_id = "";
+    uniq = 0;
+    focus_state = FocusState::NONE;
+    prev_listening_state = ListeningState::DONE;
+    rec_callback = nullptr;
+    cur_state = ASRState::IDLE;
+    request_listening_id = "";
+    asr_cancel = false;
+    wakeup_power_noise = 0;
+    wakeup_power_speech = 0;
 
     speech_recognizer = std::unique_ptr<ISpeechRecognizer>(core_container->createSpeechRecognizer(model_path, epd_attribute));
     speech_recognizer->setListener(this);

--- a/src/capability/asr_agent.hh
+++ b/src/capability/asr_agent.hh
@@ -39,7 +39,7 @@ class ASRAgent final : public Capability,
                        public IFocusResourceListener {
 public:
     ASRAgent();
-    virtual ~ASRAgent();
+    virtual ~ASRAgent() = default;
 
     void setAttribute(ASRAttribute&& attribute) override;
     void initialize() override;
@@ -112,11 +112,14 @@ private:
     int uniq;
     FocusState focus_state;
     std::vector<IASRListener*> asr_listeners;
-    ListeningState prev_listening_state = ListeningState::DONE;
+    ListeningState prev_listening_state;
     AsrRecognizeCallback rec_callback;
     ASRState cur_state;
     std::string request_listening_id;
     bool asr_cancel;
+
+    float wakeup_power_noise;
+    float wakeup_power_speech;
 
     // attribute
     std::string model_path;
@@ -124,9 +127,6 @@ private:
     std::string asr_encoding;
     int response_timeout;
     EpdAttribute epd_attribute;
-
-    float wakeup_power_noise;
-    float wakeup_power_speech;
 };
 
 } // NuguCapability

--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -27,31 +27,7 @@ static const char* CAPABILITY_VERSION = "1.4";
 
 AudioPlayerAgent::AudioPlayerAgent()
     : Capability(CAPABILITY_NAME, CAPABILITY_VERSION)
-    , cur_player(nullptr)
-    , media_player(nullptr)
-    , tts_player(nullptr)
-    , speak_dir(nullptr)
-    , focus_state(FocusState::NONE)
-    , is_tts_activate(false)
-    , is_next_play(false)
-    , cur_aplayer_state(AudioPlayerState::IDLE)
-    , prev_aplayer_state(AudioPlayerState::IDLE)
-    , is_paused(false)
-    , is_paused_by_unfocus(false)
-    , ps_id("")
-    , report_delay_time(-1)
-    , report_interval_time(-1)
-    , cur_token("")
-    , cur_url("")
-    , pre_ref_dialog_id("")
-    , is_finished(false)
-    , volume_update(false)
-    , volume(-1)
     , display_listener(nullptr)
-{
-}
-
-AudioPlayerAgent::~AudioPlayerAgent()
 {
 }
 
@@ -61,6 +37,30 @@ void AudioPlayerAgent::initialize()
         nugu_info("It's already initialized.");
         return;
     }
+
+    Capability::initialize();
+
+    speak_dir = nullptr;
+    focus_state = FocusState::NONE;
+    is_tts_activate = false;
+    is_next_play = false;
+    cur_aplayer_state = AudioPlayerState::IDLE;
+    prev_aplayer_state = AudioPlayerState::IDLE;
+    is_paused = false;
+    is_paused_by_unfocus = false;
+    ps_id = "";
+    report_delay_time = -1;
+    report_interval_time = -1;
+    cur_token = "";
+    cur_url = "";
+    pre_ref_dialog_id = "";
+    cur_dialog_id = "";
+    is_finished = false;
+    volume_update = false;
+    volume = -1;
+    template_id = "";
+    template_view = "";
+    template_type = "";
 
     std::string volume_str;
     if (capa_helper->getCapabilityProperty("Speaker", "music", volume_str))
@@ -122,7 +122,6 @@ void AudioPlayerAgent::initialize()
 
 void AudioPlayerAgent::deInitialize()
 {
-    aplayer_listeners.clear();
     render_infos.clear();
 
     if (media_player) {
@@ -137,9 +136,9 @@ void AudioPlayerAgent::deInitialize()
         tts_player = nullptr;
     }
 
-    playsync_manager->removeListener(getName());
-
     cur_player = nullptr;
+
+    playsync_manager->removeListener(getName());
 
     initialized = false;
 }

--- a/src/capability/audio_player_agent.hh
+++ b/src/capability/audio_player_agent.hh
@@ -45,7 +45,7 @@ public:
 
 public:
     AudioPlayerAgent();
-    virtual ~AudioPlayerAgent();
+    virtual ~AudioPlayerAgent() = default;
     void initialize() override;
     void deInitialize() override;
     void suspend() override;

--- a/src/capability/display_agent.cc
+++ b/src/capability/display_agent.cc
@@ -31,20 +31,17 @@ DisplayAgent::DisplayAgent()
 {
 }
 
-DisplayAgent::~DisplayAgent()
-{
-    for (auto info : render_info)
-        delete info.second;
-
-    render_info.clear();
-}
-
 void DisplayAgent::initialize()
 {
     if (initialized) {
         nugu_info("It's already initialized.");
         return;
     }
+
+    Capability::initialize();
+
+    disp_cur_ps_id = "";
+    disp_cur_token = "";
 
     playsync_manager->addListener(getName(), this);
 
@@ -54,6 +51,11 @@ void DisplayAgent::initialize()
 void DisplayAgent::deInitialize()
 {
     playsync_manager->removeListener(getName());
+
+    for (auto info : render_info)
+        delete info.second;
+
+    render_info.clear();
 
     initialized = false;
 }

--- a/src/capability/display_agent.hh
+++ b/src/capability/display_agent.hh
@@ -37,7 +37,7 @@ class DisplayAgent : public Capability,
                      public IPlaySyncManagerListener {
 public:
     DisplayAgent();
-    virtual ~DisplayAgent();
+    virtual ~DisplayAgent() = default;
 
     void initialize() override;
     void deInitialize() override;

--- a/src/capability/mic_agent.cc
+++ b/src/capability/mic_agent.cc
@@ -28,11 +28,6 @@ MicAgent::MicAgent()
     : Capability(CAPABILITY_NAME, CAPABILITY_VERSION)
     , mic_listener(nullptr)
     , cur_status(MicStatus::ON)
-    , ps_id("")
-{
-}
-
-MicAgent::~MicAgent()
 {
 }
 
@@ -42,6 +37,11 @@ void MicAgent::initialize()
         nugu_info("It's already initialized.");
         return;
     }
+
+    Capability::initialize();
+
+    cur_status = MicStatus::ON;
+    ps_id = "";
 
     addReferrerEvents("SetMicSucceeded", "SetMic");
     addReferrerEvents("SetMicFailed", "SetMic");

--- a/src/capability/mic_agent.hh
+++ b/src/capability/mic_agent.hh
@@ -26,7 +26,7 @@ class MicAgent final : public Capability,
                        public IMicHandler {
 public:
     MicAgent();
-    virtual ~MicAgent();
+    virtual ~MicAgent() = default;
 
     void initialize() override;
 

--- a/src/capability/session_agent.cc
+++ b/src/capability/session_agent.cc
@@ -36,6 +36,11 @@ void SessionAgent::initialize()
         return;
     }
 
+    Capability::initialize();
+
+    play_service_id = "";
+    session_id = "";
+
     session_manager->addListener(this);
 
     initialized = true;

--- a/src/capability/sound_agent.cc
+++ b/src/capability/sound_agent.cc
@@ -36,6 +36,10 @@ void SoundAgent::initialize()
         return;
     }
 
+    Capability::initialize();
+
+    play_service_id = "";
+
     addBlockingPolicy("Beep", { BlockingMedium::AUDIO, true });
 
     initialized = true;

--- a/src/capability/speaker_agent.cc
+++ b/src/capability/speaker_agent.cc
@@ -30,17 +30,14 @@ SpeakerAgent::SpeakerAgent()
 {
 }
 
-SpeakerAgent::~SpeakerAgent()
-{
-    speakers.clear();
-}
-
 void SpeakerAgent::initialize()
 {
     if (initialized) {
         nugu_info("It's already initialized.");
         return;
     }
+
+    Capability::initialize();
 
     addReferrerEvents("SetVolumeSucceeded", "SetVolume");
     addReferrerEvents("SetVolumeFailed", "SetVolume");
@@ -51,6 +48,11 @@ void SpeakerAgent::initialize()
     addBlockingPolicy("SetMute", { BlockingMedium::AUDIO, true });
 
     initialized = true;
+}
+
+void SpeakerAgent::deInitialize()
+{
+    speakers.clear();
 }
 
 void SpeakerAgent::parsingDirective(const char* dname, const char* message)

--- a/src/capability/speaker_agent.hh
+++ b/src/capability/speaker_agent.hh
@@ -26,9 +26,10 @@ class SpeakerAgent final : public Capability,
                            public ISpeakerHandler {
 public:
     SpeakerAgent();
-    virtual ~SpeakerAgent();
+    virtual ~SpeakerAgent() = default;
 
     void initialize() override;
+    void deInitialize() override;
 
     void parsingDirective(const char* dname, const char* message) override;
     void updateInfoForContext(Json::Value& ctx) override;

--- a/src/capability/system_agent.cc
+++ b/src/capability/system_agent.cc
@@ -32,7 +32,6 @@ static const char* CAPABILITY_VERSION = "1.3";
 SystemAgent::SystemAgent()
     : Capability(CAPABILITY_NAME, CAPABILITY_VERSION)
     , system_listener(nullptr)
-    , timer(nullptr)
 {
     nugu_network_manager_set_handoff_status_callback(
         [](NuguNetworkHandoffStatus status, void* userdata) {
@@ -57,16 +56,14 @@ SystemAgent::SystemAgent()
         this);
 }
 
-SystemAgent::~SystemAgent()
-{
-}
-
 void SystemAgent::initialize()
 {
     if (initialized) {
         nugu_info("It's already initialized.");
         return;
     }
+
+    Capability::initialize();
 
     timer = core_container->createNuguTimer();
     timer->setInterval(DEFAULT_INACTIVITY_TIMEOUT * NUGU_TIMER_UNIT_SEC);

--- a/src/capability/system_agent.hh
+++ b/src/capability/system_agent.hh
@@ -26,7 +26,7 @@ class SystemAgent final : public Capability,
                           public ISystemHandler {
 public:
     SystemAgent();
-    virtual ~SystemAgent();
+    virtual ~SystemAgent() = default;
 
     void initialize() override;
     void deInitialize() override;

--- a/src/capability/text_agent.cc
+++ b/src/capability/text_agent.cc
@@ -27,14 +27,7 @@ static const char* CAPABILITY_VERSION = "1.3";
 TextAgent::TextAgent()
     : Capability(CAPABILITY_NAME, CAPABILITY_VERSION)
     , text_listener(nullptr)
-    , timer(nullptr)
-    , cur_state(TextState::IDLE)
-    , cur_dialog_id("")
     , response_timeout(NUGU_SERVER_RESPONSE_TIMEOUT_SEC)
-{
-}
-
-TextAgent::~TextAgent()
 {
 }
 
@@ -50,6 +43,12 @@ void TextAgent::initialize()
         nugu_info("It's already initialized.");
         return;
     }
+
+    Capability::initialize();
+
+    cur_state = TextState::IDLE;
+    cur_dialog_id = "";
+    dir_groups = "";
 
     timer = core_container->createNuguTimer();
     timer->setInterval(response_timeout * NUGU_TIMER_UNIT_SEC);

--- a/src/capability/text_agent.hh
+++ b/src/capability/text_agent.hh
@@ -26,7 +26,7 @@ class TextAgent final : public Capability,
                         public ITextHandler {
 public:
     TextAgent();
-    virtual ~TextAgent();
+    virtual ~TextAgent() = default;
 
     void setAttribute(TextAttribute&& attribute) override;
     void initialize() override;

--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -31,23 +31,8 @@ static const char* CAPABILITY_VERSION = "1.2";
 
 TTSAgent::TTSAgent()
     : Capability(CAPABILITY_NAME, CAPABILITY_VERSION)
-    , player(nullptr)
-    , cur_state(MediaPlayerState::IDLE)
-    , focus_state(FocusState::NONE)
-    , cur_token("")
-    , is_prehandling(false)
-    , is_finished(false)
-    , volume_update(false)
-    , volume(-1)
-    , speak_dir(nullptr)
-    , dialog_id("")
-    , ps_id("")
     , tts_listener(nullptr)
     , tts_engine(NUGU_TTS_ENGINE)
-{
-}
-
-TTSAgent::~TTSAgent()
 {
 }
 
@@ -63,6 +48,20 @@ void TTSAgent::initialize()
         nugu_info("It's already initialized.");
         return;
     }
+
+    Capability::initialize();
+
+    cur_state = MediaPlayerState::IDLE;
+    focus_state = FocusState::NONE;
+    cur_token = "";
+    is_prehandling = false;
+    is_finished = false;
+    volume_update = false;
+    volume = -1;
+    speak_dir = nullptr;
+    dialog_id = "";
+    ps_id = "";
+    playstackctl_ps_id = "";
 
     std::string volume_str;
     if (capa_helper->getCapabilityProperty("Speaker", "voice_command", volume_str))

--- a/src/capability/tts_agent.hh
+++ b/src/capability/tts_agent.hh
@@ -29,7 +29,7 @@ class TTSAgent final : public Capability,
                        public IPlaySyncManagerListener {
 public:
     TTSAgent();
-    virtual ~TTSAgent();
+    virtual ~TTSAgent() = default;
 
     void setAttribute(TTSAttribute&& attribute) override;
     void initialize() override;

--- a/src/clientkit/capability.cc
+++ b/src/clientkit/capability.cc
@@ -156,10 +156,20 @@ void Capability::setNuguCoreContainer(INuguCoreContainer* core_container)
 
 void Capability::initialize()
 {
+    has_attachment = false;
+    suspended = false;
+    suspend_policy = SuspendPolicy::STOP;
+
+    pimpl->ref_dialog_id = "";
+    pimpl->cur_ndir = nullptr;
+    pimpl->referrer_events.clear();
+    pimpl->referrer_dirs.clear();
+    event_result_cbs.clear();
 }
 
 void Capability::deInitialize()
 {
+    initialized = false;
 }
 
 void Capability::setSuspendPolicy(SuspendPolicy policy)

--- a/src/clientkit/nugu_client_impl.cc
+++ b/src/clientkit/nugu_client_impl.cc
@@ -45,6 +45,7 @@ NuguClientImpl::NuguClientImpl()
 
 NuguClientImpl::~NuguClientImpl()
 {
+    nugu_core_container->destoryAudioRecorderManager();
     nugu_core_container->destroyInstance();
 
     if (plugin_loaded)
@@ -211,23 +212,20 @@ void NuguClientImpl::deInitialize(void)
         return;
     }
 
-    // release capabilities
+    // deinitialize capabilities
     for (auto& capability : icapability_map) {
         std::string cname = capability.second->getName();
         nugu_dbg("'%s' capability de-initializing...", cname.c_str());
 
-        if (!cname.empty())
-            nugu_core_container->removeCapability(cname);
-
         capability.second->deInitialize();
+
         nugu_dbg("'%s' capability de-initialized", cname.c_str());
     }
 
-    icapability_map.clear();
-
-    nugu_core_container->destoryAudioRecorderManager();
+    nugu_core_container->resetInstance();
 
     nugu_dbg("NuguClientImpl deInitialize success.");
+
     initialized = false;
 }
 

--- a/src/core/capability_manager.cc
+++ b/src/core/capability_manager.cc
@@ -62,6 +62,18 @@ void CapabilityManager::destroyInstance()
     }
 }
 
+void CapabilityManager::resetInstance()
+{
+    events.clear();
+    events_cname_map.clear();
+
+    playsync_manager->reset();
+    focus_manager->reset();
+    session_manager->reset();
+    directive_sequencer->reset();
+    interaction_control_manager->reset();
+}
+
 bool CapabilityManager::onPreHandleDirective(NuguDirective* ndir)
 {
     ICapabilityInterface* cap = findCapability(nugu_directive_peek_namespace(ndir));

--- a/src/core/capability_manager.hh
+++ b/src/core/capability_manager.hh
@@ -40,6 +40,7 @@ private:
 public:
     static CapabilityManager* getInstance();
     static void destroyInstance();
+    void resetInstance();
 
     PlaySyncManager* getPlaySyncManager();
     FocusManager* getFocusManager();
@@ -84,11 +85,11 @@ private:
     std::map<std::string, std::string> events;
     std::map<std::string, std::string> events_cname_map;
     std::string wword;
-    std::unique_ptr<PlaySyncManager> playsync_manager = nullptr;
-    std::unique_ptr<FocusManager> focus_manager = nullptr;
-    std::unique_ptr<SessionManager> session_manager = nullptr;
-    std::unique_ptr<DirectiveSequencer> directive_sequencer = nullptr;
-    std::unique_ptr<InteractionControlManager> interaction_control_manager = nullptr;
+    std::unique_ptr<PlaySyncManager> playsync_manager;
+    std::unique_ptr<FocusManager> focus_manager;
+    std::unique_ptr<SessionManager> session_manager;
+    std::unique_ptr<DirectiveSequencer> directive_sequencer;
+    std::unique_ptr<InteractionControlManager> interaction_control_manager;
 };
 
 } // NuguCore

--- a/src/core/directive_sequencer.cc
+++ b/src/core/directive_sequencer.cc
@@ -100,6 +100,12 @@ DirectiveSequencer::DirectiveSequencer()
 
 DirectiveSequencer::~DirectiveSequencer()
 {
+    nugu_network_manager_set_directive_callback(NULL, NULL);
+    nugu_network_manager_set_attachment_callback(NULL, NULL);
+}
+
+void DirectiveSequencer::reset()
+{
     /* Cancel the pending idler */
     if (idler_src != 0)
         g_source_remove(idler_src);
@@ -113,8 +119,12 @@ DirectiveSequencer::~DirectiveSequencer()
         nugu_directive_unref(ndir);
     }
 
-    nugu_network_manager_set_directive_callback(NULL, NULL);
-    nugu_network_manager_set_attachment_callback(NULL, NULL);
+    idler_src = 0;
+    policy_map.clear();
+    msgid_directive_map.clear();
+    audio_map.clear();
+    visual_map.clear();
+    scheduled_list.clear();
 }
 
 /* Callback by network-manager */

--- a/src/core/directive_sequencer.hh
+++ b/src/core/directive_sequencer.hh
@@ -35,6 +35,7 @@ public:
     DirectiveSequencer();
     virtual ~DirectiveSequencer();
 
+    void reset();
     void addListener(const std::string& name_space, IDirectiveSequencerListener* listener) override;
     void removeListener(const std::string& name_space, IDirectiveSequencerListener* listener) override;
 

--- a/src/core/focus_manager.cc
+++ b/src/core/focus_manager.cc
@@ -61,8 +61,10 @@ FocusManager::FocusManager()
     printConfigurations();
 }
 
-FocusManager::~FocusManager()
+void FocusManager::reset()
 {
+    focus_resource_ordered_map.clear();
+    focus_hold_map.clear();
 }
 
 bool FocusManager::requestFocus(const std::string& type, const std::string& name, IFocusResourceListener* listener)
@@ -106,7 +108,7 @@ bool FocusManager::requestFocus(const std::string& type, const std::string& name
     }
 
     bool higher_hold = false;
-    for(const auto& hold : focus_hold_map) {
+    for (const auto& hold : focus_hold_map) {
         if (!hold.second)
             continue;
 

--- a/src/core/focus_manager.hh
+++ b/src/core/focus_manager.hh
@@ -57,8 +57,9 @@ class FocusManager : public IFocusManager,
                      public IFocusResourceObserver {
 public:
     FocusManager();
-    virtual ~FocusManager();
+    virtual ~FocusManager() = default;
 
+    void reset();
     bool requestFocus(const std::string& type, const std::string& name, IFocusResourceListener* listener) override;
     bool releaseFocus(const std::string& type, const std::string& name) override;
 

--- a/src/core/interaction_control_manager.cc
+++ b/src/core/interaction_control_manager.cc
@@ -27,6 +27,11 @@ InteractionControlManager::~InteractionControlManager()
     listeners.clear();
 }
 
+void InteractionControlManager::reset()
+{
+    clearContainer();
+}
+
 void InteractionControlManager::addListener(IInteractionControlManagerListener* listener)
 {
     if (!listener) {

--- a/src/core/interaction_control_manager.hh
+++ b/src/core/interaction_control_manager.hh
@@ -31,6 +31,7 @@ public:
     InteractionControlManager() = default;
     virtual ~InteractionControlManager();
 
+    void reset();
     void addListener(IInteractionControlManagerListener* listener) override;
     void removeListener(IInteractionControlManagerListener* listener) override;
     int getListenerCount();

--- a/src/core/nugu_core_container.cc
+++ b/src/core/nugu_core_container.cc
@@ -94,6 +94,11 @@ void NuguCoreContainer::removeCapability(const std::string& cname)
     CapabilityManager::getInstance()->removeCapability(cname);
 }
 
+void NuguCoreContainer::resetInstance()
+{
+    CapabilityManager::getInstance()->resetInstance();
+}
+
 void NuguCoreContainer::destroyInstance()
 {
     CapabilityManager::destroyInstance();

--- a/src/core/nugu_core_container.hh
+++ b/src/core/nugu_core_container.hh
@@ -41,6 +41,7 @@ public:
     void setWakeupWord(const std::string& wakeup_word);
     void addCapability(const std::string& cname, ICapabilityInterface* cap);
     void removeCapability(const std::string& cname);
+    void resetInstance();
     void destroyInstance();
     INetworkManagerListener* getNetworkManagerListener();
 

--- a/src/core/playstack_manager.cc
+++ b/src/core/playstack_manager.cc
@@ -89,6 +89,16 @@ PlayStackManager::~PlayStackManager()
     listeners.clear();
 }
 
+void PlayStackManager::reset()
+{
+    clearContainer();
+
+    has_long_timer = false;
+    has_holding = false;
+    is_expect_speech = false;
+    is_stacked = false;
+}
+
 void PlayStackManager::addListener(IPlayStackManagerListener* listener)
 {
     if (!listener) {

--- a/src/core/playstack_manager.hh
+++ b/src/core/playstack_manager.hh
@@ -54,6 +54,7 @@ public:
     PlayStackManager();
     virtual ~PlayStackManager();
 
+    void reset();
     void addListener(IPlayStackManagerListener* listener);
     void removeListener(IPlayStackManagerListener* listener);
     int getListenerCount();

--- a/src/core/playsync_manager.cc
+++ b/src/core/playsync_manager.cc
@@ -33,6 +33,14 @@ PlaySyncManager::~PlaySyncManager()
     listener_map.clear();
 }
 
+void PlaySyncManager::reset()
+{
+    clearPostPonedRelease();
+    clearContainer();
+
+    playstack_manager->reset();
+}
+
 void PlaySyncManager::setPlayStackManager(PlayStackManager* playstack_manager)
 {
     if (!playstack_manager) {

--- a/src/core/playsync_manager.hh
+++ b/src/core/playsync_manager.hh
@@ -37,6 +37,7 @@ public:
     PlaySyncManager();
     virtual ~PlaySyncManager();
 
+    void reset();
     void setPlayStackManager(PlayStackManager* playstack_manager);
     void setInteractionControlManager(InteractionControlManager* interaction_control_manager);
     void addListener(const std::string& requester, IPlaySyncManagerListener* listener) override;
@@ -76,8 +77,8 @@ private:
 
     std::unique_ptr<PlayStackManager> playstack_manager = nullptr;
     InteractionControlManager* interaction_control_manager = nullptr;
-    std::function<void()> postponed_release_func = nullptr;
     std::map<std::string, IPlaySyncManagerListener*> listener_map;
+    std::function<void()> postponed_release_func = nullptr;
     PlayStacks playstack_map;
     bool release_postponed = false;
 };

--- a/src/core/session_manager.cc
+++ b/src/core/session_manager.cc
@@ -27,6 +27,11 @@ SessionManager::~SessionManager()
     listeners.clear();
 }
 
+void SessionManager::reset()
+{
+    clearContainer();
+}
+
 void SessionManager::addListener(ISessionManagerListener* listener)
 {
     if (!listener) {

--- a/src/core/session_manager.hh
+++ b/src/core/session_manager.hh
@@ -35,6 +35,7 @@ public:
     SessionManager() = default;
     virtual ~SessionManager();
 
+    void reset();
     void addListener(ISessionManagerListener* listener) override;
     void removeListener(ISessionManagerListener* listener) override;
     int getListenerCount();


### PR DESCRIPTION
It change to reuse instances of CapabilityAgents and
various managers during initializing/deinitializing SDK.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>