### PR TITLE
interaction:add reset test for InteractionControlManager

### DIFF
--- a/src/core/interaction_control_manager.cc
+++ b/src/core/interaction_control_manager.cc
@@ -115,6 +115,11 @@ void InteractionControlManager::clear()
     clearContainer();
 }
 
+const InteractionControlManager::Requesters& InteractionControlManager::getAllRequesters()
+{
+    return requester_set;
+}
+
 void InteractionControlManager::notifyModeChange(bool is_multi_turn)
 {
     for (const auto& listener : listeners)

--- a/src/core/interaction_control_manager.hh
+++ b/src/core/interaction_control_manager.hh
@@ -28,6 +28,9 @@ using namespace NuguClientKit;
 
 class InteractionControlManager : public IInteractionControlManager {
 public:
+    using Requesters = std::set<std::string>;
+
+public:
     InteractionControlManager() = default;
     virtual ~InteractionControlManager();
 
@@ -41,12 +44,14 @@ public:
     void finish(InteractionMode mode, const std::string& requester) override;
     void clear() override;
 
+    const Requesters& getAllRequesters();
+
 private:
     void notifyModeChange(bool is_multi_turn);
     void clearContainer();
 
     std::vector<IInteractionControlManagerListener*> listeners;
-    std::set<std::string> requester_set;
+    Requesters requester_set;
 };
 
 } // NuguCore

--- a/tests/core/test_core_interaction_control_manager.cc
+++ b/tests/core/test_core_interaction_control_manager.cc
@@ -188,6 +188,20 @@ static void test_interaction_control_manager_clear(TestFixture* fixture, gconstp
     g_assert(fixture->ic_manager_listener->getModeChecker() == (TestModeChecker { false, 1 }));
 }
 
+static void test_interaction_control_manager_reset(TestFixture* fixture, gconstpointer ignored)
+{
+    const auto& requesters = fixture->ic_manager->getAllRequesters();
+    fixture->ic_manager->addListener(fixture->ic_manager_listener.get());
+
+    fixture->ic_manager->start(InteractionMode::MULTI_TURN, "requester_1");
+    fixture->ic_manager->start(InteractionMode::MULTI_TURN, "requester_2");
+    g_assert(requesters.size() == 2);
+
+    fixture->ic_manager->reset();
+    g_assert(fixture->ic_manager->getListenerCount() == 1);
+    g_assert(requesters.empty());
+}
+
 int main(int argc, char* argv[])
 {
 #if !GLIB_CHECK_VERSION(2, 36, 0)
@@ -202,6 +216,7 @@ int main(int argc, char* argv[])
     G_TEST_ADD_FUNC("/core/InteractionControlManager/multiRequester", test_interaction_control_manager_multi_requester);
     G_TEST_ADD_FUNC("/core/InteractionControlManager/hasMultiTurn", test_interaction_control_manager_has_multi_turn);
     G_TEST_ADD_FUNC("/core/InteractionControlManager/clear", test_interaction_control_manager_clear);
+    G_TEST_ADD_FUNC("/core/InteractionControlManager/reset", test_interaction_control_manager_reset);
 
     return g_test_run();
 }


### PR DESCRIPTION
It add the reset test for InteractionControlManager in unit test.

Also, it add the getAllRequesters method in InteractionControlManager
for retrieving container of requester.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>