### PR TITLE
playstack:add reset test for PlayStackManager

### DIFF
--- a/src/core/playstack_manager.cc
+++ b/src/core/playstack_manager.cc
@@ -253,6 +253,11 @@ const PlayStackManager::PlayStack& PlayStackManager::getPlayStackContainer()
     return playstack_container;
 }
 
+std::set<bool> PlayStackManager::getFlagSet()
+{
+    return { has_long_timer, has_holding, is_expect_speech, is_stacked };
+}
+
 PlayStackLayer PlayStackManager::extractPlayStackLayer(NuguDirective* ndir)
 {
     std::string groups = nugu_directive_peek_groups(ndir);

--- a/src/core/playstack_manager.hh
+++ b/src/core/playstack_manager.hh
@@ -18,6 +18,7 @@
 #define __NUGU_PLAYSTACK_MANAGER_H__
 
 #include <memory>
+#include <set>
 
 #include "clientkit/playstack_manager_interface.hh"
 #include "nugu_timer.hh"
@@ -71,6 +72,7 @@ public:
     PlayStackLayer getPlayStackLayer(const std::string& ps_id);
     std::vector<std::string> getAllPlayStackItems();
     const PlayStack& getPlayStackContainer();
+    std::set<bool> getFlagSet();
 
 private:
     class StackTimer final : public IStackTimer {

--- a/tests/core/test_core_playstack_manager.cc
+++ b/tests/core/test_core_playstack_manager.cc
@@ -245,6 +245,21 @@ static void test_playstack_manager_checkExpectSpeech(TestFixture* fixture, gcons
     g_assert(fixture->playstack_manager->hasExpectSpeech(fixture->ndir_expect_speech));
 }
 
+static void test_playstack_manager_reset(TestFixture* fixture, gconstpointer ignored)
+{
+    const auto& playstack_container = fixture->playstack_manager->getPlayStackContainer();
+
+    fixture->playstack_manager->add("ps_id_1", fixture->ndir_expect_speech);
+    auto flag_set_before = fixture->playstack_manager->getFlagSet();
+    g_assert(flag_set_before.find(true) != flag_set_before.cend());
+    g_assert(!playstack_container.first.empty());
+
+    fixture->playstack_manager->reset();
+    auto flag_set_after = fixture->playstack_manager->getFlagSet();
+    g_assert(flag_set_after.find(true) == flag_set_after.cend());
+    g_assert(playstack_container.first.empty());
+}
+
 int main(int argc, char* argv[])
 {
 #if !GLIB_CHECK_VERSION(2, 36, 0)
@@ -262,6 +277,7 @@ int main(int argc, char* argv[])
     G_TEST_ADD_FUNC("/core/PlayStackManager/controlHolding", test_playstack_manager_controlHolding);
     G_TEST_ADD_FUNC("/core/PlayStackManager/checkStack", test_playstack_manager_checkStack);
     G_TEST_ADD_FUNC("/core/PlayStackManager/checkExpectSpeech", test_playstack_manager_checkExpectSpeech);
+    G_TEST_ADD_FUNC("/core/PlayStackManager/reset", test_playstack_manager_reset);
 
     return g_test_run();
 }


### PR DESCRIPTION
It add the reset test for PlayStackManager in unit test.

Also, it add the getFlagSet method in PlayStackManager
for retrieving inner private flags.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>