### PR TITLE
playstack:fix to stop timer when resetting PlayStackManager

### DIFF
--- a/src/core/playstack_manager.cc
+++ b/src/core/playstack_manager.cc
@@ -91,6 +91,8 @@ PlayStackManager::~PlayStackManager()
 
 void PlayStackManager::reset()
 {
+    timer->stop();
+
     clearContainer();
 
     has_long_timer = false;

--- a/tests/core/test_core_playstack_manager.cc
+++ b/tests/core/test_core_playstack_manager.cc
@@ -254,10 +254,14 @@ static void test_playstack_manager_reset(TestFixture* fixture, gconstpointer ign
     g_assert(flag_set_before.find(true) != flag_set_before.cend());
     g_assert(!playstack_container.first.empty());
 
+    fixture->playstack_manager->remove("ps_id_1");
+    g_assert(fixture->playstack_manager->isActiveHolding());
+
     fixture->playstack_manager->reset();
     auto flag_set_after = fixture->playstack_manager->getFlagSet();
     g_assert(flag_set_after.find(true) == flag_set_after.cend());
     g_assert(playstack_container.first.empty());
+    g_assert(!fixture->playstack_manager->isActiveHolding());
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
It fix to stop inner timer when resetting PlayStackManager
by calling reset method.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>