### PR TITLE
NuguClient:add getCapabilityHandler

### DIFF
--- a/include/clientkit/nugu_client.hh
+++ b/include/clientkit/nugu_client.hh
@@ -121,6 +121,12 @@ public:
      */
     INetworkManager* getNetworkManager();
 
+    /**
+     * @brief Get instance of CapabilityAgent
+     * @return ICapabilityInterface the instance which is related to requested CapabilityAgent, otherwise nullptr
+     */
+    ICapabilityInterface* getCapabilityHandler(const std::string& cname);
+
 private:
     std::unique_ptr<NuguClientImpl> impl;
     CapabilityBuilder* cap_builder;

--- a/src/clientkit/nugu_client.cc
+++ b/src/clientkit/nugu_client.cc
@@ -91,4 +91,9 @@ INetworkManager* NuguClient::getNetworkManager()
     return impl->getNetworkManager();
 }
 
+ICapabilityInterface* NuguClient::getCapabilityHandler(const std::string& cname)
+{
+    return impl->getCapabilityHandler(cname);
+}
+
 } // NuguClientKit


### PR DESCRIPTION
It add the getCapabilityHandler method in NuguClient for retrieving

requested instance of CapabilityAgent.

```
auto nugu_client(std::make_shared<NuguClient>());
auto text_handler(dynamic_cast<ITextHandler*>(nugu_client->getCapabilityHandler("Text")));
```

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>