### PR TITLE
nugu_sample:add to show playstack info

### DIFF
--- a/examples/standalone/nugu_sample_manager.cc
+++ b/examples/standalone/nugu_sample_manager.cc
@@ -27,6 +27,7 @@
 #include "nugu_sample_manager.hh"
 
 const char* NuguSampleManager::C_RED = "\033[1;91m";
+const char* NuguSampleManager::C_GREEN = "\033[1;92m";
 const char* NuguSampleManager::C_YELLOW = "\033[1;93m";
 const char* NuguSampleManager::C_BLUE = "\033[1;94m";
 const char* NuguSampleManager::C_CYAN = "\033[1;96m";
@@ -128,6 +129,11 @@ void NuguSampleManager::setTextCommander(TextCommander&& text_commander)
     commander.text_commander = text_commander;
 }
 
+void NuguSampleManager::setPlayStackRetriever(PlayStackRetriever&& playstack_retriever)
+{
+    commander.playstack_retriever = playstack_retriever;
+}
+
 const std::string& NuguSampleManager::getModelPath()
 {
     return model_path;
@@ -213,8 +219,16 @@ void NuguSampleManager::showPrompt(void)
         // display commands about sdk life cycle control
         std::cout << command_text.second
                   << C_YELLOW
-                  << "-------------------------------------------------------\n"
-                  << C_WHITE
+                  << "-------------------------------------------------------\n";
+
+        // show current PlayStack info
+        if (commander.is_connected) {
+            std::cout << C_GREEN << "[PlayStack] "
+                      << (commander.playstack_retriever ? commander.playstack_retriever() : "")
+                      << std::endl;
+        }
+
+        std::cout << C_WHITE
                   << "Select Command > "
                   << C_RESET;
     }

--- a/examples/standalone/nugu_sample_manager.hh
+++ b/examples/standalone/nugu_sample_manager.hh
@@ -28,12 +28,14 @@
 class NuguSampleManager {
 public:
     using TextCommander = std::function<void(const std::string&, bool)>;
+    using PlayStackRetriever = std::function<std::string()>;
     using Command = std::pair<std::string, std::function<void(int& flag)>>;
     using Commands = std::pair<std::vector<std::string>, std::map<std::string, Command>>;
     using Commander = struct {
         bool is_connected;
         int text_input;
         TextCommander text_commander;
+        PlayStackRetriever playstack_retriever;
     };
 
     class CommandBuilder {
@@ -60,6 +62,7 @@ public:
     bool handleArguments(const int& argc, char** argv);
     void handleNetworkResult(bool is_connected, bool is_show_cmd = true);
     void setTextCommander(TextCommander&& text_commander);
+    void setPlayStackRetriever(PlayStackRetriever&& playstack_retriever);
 
     const std::string& getModelPath();
     CommandBuilder* getCommandBuilder();
@@ -78,6 +81,7 @@ private:
     static gboolean onKeyInput(GIOChannel* src, GIOCondition con, gpointer userdata);
 
     static const char* C_RED;
+    static const char* C_GREEN;
     static const char* C_YELLOW;
     static const char* C_BLUE;
     static const char* C_CYAN;

--- a/examples/standalone/nugu_sdk_manager.hh
+++ b/examples/standalone/nugu_sdk_manager.hh
@@ -48,8 +48,9 @@ public:
 private:
     void composeExecuteCommands();
     void composeSDKCommands();
-    void registerCapabilities();
     void createInstance();
+    void registerCapabilities();
+    void setAdditionalExecutor();
     void deleteInstance();
 
     void initSDK();
@@ -65,6 +66,7 @@ private:
     std::shared_ptr<CapabilityCollection> capa_collection = nullptr;
     std::shared_ptr<IWakeupHandler> wakeup_handler = nullptr;
     INuguCoreContainer* nugu_core_container = nullptr;
+    IPlaySyncManager* playsync_manager = nullptr;
     INetworkManager* network_manager = nullptr;
     SpeechOperator* speech_operator = nullptr;
     ITextHandler* text_handler = nullptr;


### PR DESCRIPTION
It add to show current playstack info on nugu sample UI.
The playstack info is shown on above select command input.

```
=======================================================
NUGU SDK Command (Connected)
=======================================================
[ w] : start listening with wakeup
[ l] : start listening
[ s] : stop listening/wakeup
[ t] : text input
[t2] : text input (ignore dialog attribute)
[ m] : set mic mute
[sa] : suspend all
[ra] : restore all
-------------------------------------------------------
[ i] : initialize
[ d] : deinitialize
[ q] : quit
-------------------------------------------------------
[PlayStack] nugu.builtin.music   <-- This is current playstack info.
Select Command > 
```

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>