### PR TITLE
Timer: Add loop property

### DIFF
--- a/include/base/nugu_timer.h
+++ b/include/base/nugu_timer.h
@@ -73,6 +73,22 @@ void nugu_timer_set_interval(NuguTimer *timer, long interval);
 long nugu_timer_get_interval(NuguTimer *timer);
 
 /**
+ * @brief Set loop property
+ * @param[in] timer timer object
+ * @param[in] loop loop
+ * @see nugu_timer_get_repeat()
+ */
+void nugu_timer_set_loop(NuguTimer *timer, int loop);
+
+/**
+ * @brief Get loop property
+ * @param[in] timer timer object
+ * @return loop
+ * @see nugu_timer_set_loop()
+ */
+int nugu_timer_get_loop(NuguTimer *timer);
+
+/**
  * @brief Set repeat count
  * @param[in] timer timer object
  * @param[in] repeat number of times to repeat

--- a/include/clientkit/nugu_timer_interface.hh
+++ b/include/clientkit/nugu_timer_interface.hh
@@ -72,6 +72,16 @@ public:
      */
     virtual unsigned int getRepeat() = 0;
     /**
+     * @brief Set timer's loop property
+     * @param[in] loop loop property
+     */
+    virtual void setLoop(bool loop) = 0;
+    /**
+     * @brief Get timer's loop property
+     * @return loop property
+     */
+    virtual bool getLoop() = 0;
+    /**
      * @brief Get timer's timeout count
      * @return timeout count
      */

--- a/src/base/nugu_timer.c
+++ b/src/base/nugu_timer.c
@@ -27,6 +27,7 @@ struct _nugu_timer {
 	long interval;
 	int repeat;
 	int count;
+	gboolean loop;
 	NuguTimeoutCallback cb;
 	void *userdata;
 };
@@ -38,7 +39,7 @@ static gboolean _nugu_timer_callback(gpointer userdata)
 	timer->count++;
 	timer->cb(timer->userdata);
 
-	if (timer->repeat > timer->count)
+	if (timer->loop || timer->repeat > timer->count)
 		return TRUE;
 	else
 		return FALSE;
@@ -58,6 +59,7 @@ EXPORT_API NuguTimer *nugu_timer_new(long interval, int repeat)
 	timer->interval = interval;
 	timer->repeat = repeat;
 	timer->count = 0;
+	timer->loop = FALSE;
 	timer->cb = NULL;
 	timer->userdata = NULL;
 
@@ -105,6 +107,21 @@ EXPORT_API int nugu_timer_get_repeat(NuguTimer *timer)
 	g_return_val_if_fail(timer != NULL, -1);
 
 	return timer->repeat;
+}
+
+EXPORT_API void nugu_timer_set_loop(NuguTimer *timer, int loop)
+{
+	g_return_if_fail(timer != NULL);
+	g_return_if_fail(loop >= 0);
+
+	timer->loop = loop == 0 ? FALSE : TRUE;
+}
+
+EXPORT_API int nugu_timer_get_loop(NuguTimer *timer)
+{
+	g_return_val_if_fail(timer != NULL, FALSE);
+
+	return timer->loop;
 }
 
 EXPORT_API int nugu_timer_get_count(NuguTimer *timer)

--- a/src/core/nugu_timer.cc
+++ b/src/core/nugu_timer.cc
@@ -84,6 +84,16 @@ unsigned int NUGUTimer::getRepeat()
     return nugu_timer_get_repeat(d->timer);
 }
 
+void NUGUTimer::setLoop(bool loop)
+{
+    nugu_timer_set_loop(d->timer, loop);
+}
+
+bool NUGUTimer::getLoop()
+{
+    return nugu_timer_get_loop(d->timer);
+}
+
 unsigned int NUGUTimer::getCount()
 {
     return nugu_timer_get_count(d->timer);

--- a/src/core/nugu_timer.hh
+++ b/src/core/nugu_timer.hh
@@ -34,6 +34,8 @@ public:
     unsigned int getInterval() override;
     void setRepeat(unsigned int count) override;
     unsigned int getRepeat() override;
+    void setLoop(bool loop) override;
+    bool getLoop() override;
     unsigned int getCount() override;
 
     void stop() override;

--- a/tests/core/test_core_nugu_timer.cc
+++ b/tests/core/test_core_nugu_timer.cc
@@ -124,6 +124,40 @@ static void test_nugutimer_repeat(ntimerFixture* fixture, gconstpointer ignored)
     g_assert(timer->getCount() == (unsigned int)expect_count);
 }
 
+static void test_nugutimer_loop(ntimerFixture* fixture, gconstpointer ignored)
+{
+    NUGUTimer* timer = fixture->timer1;
+    int expect_repeat = 1;
+    int expect_count = 1;
+
+    timer->setCallback([&](int count, int repeat) {
+        g_assert(count == expect_count && repeat == expect_repeat);
+    });
+
+    /* Trigger Timer every time */
+    expect_repeat = 1;
+    timer->setInterval(TIMEOUT_UNIT_SEC);
+    timer->setRepeat(expect_repeat);
+    timer->setLoop(true);
+    timer->start();
+
+    expect_count = 1;
+    TIMER_ELAPSE_SEC(TIMEOUT_UNIT_SEC);
+    g_assert(timer->getCount() == (unsigned int)expect_count);
+    expect_count = 2;
+    TIMER_ELAPSE_SEC(TIMEOUT_UNIT_SEC);
+    g_assert(timer->getCount() == (unsigned int)expect_count);
+    expect_count = 3;
+    TIMER_ELAPSE_SEC(TIMEOUT_UNIT_SEC);
+    g_assert(timer->getCount() == (unsigned int)expect_count);
+    expect_count = 4;
+    TIMER_ELAPSE_SEC(TIMEOUT_UNIT_SEC);
+    g_assert(timer->getCount() == (unsigned int)expect_count);
+    expect_count = 5;
+    TIMER_ELAPSE_SEC(TIMEOUT_UNIT_SEC);
+    g_assert(timer->getCount() == (unsigned int)expect_count);
+}
+
 static void test_nugutimer_multi_trigger(ntimerFixture* fixture, gconstpointer ignored)
 {
     NUGUTimer* timer1 = fixture->timer1;
@@ -232,6 +266,7 @@ int main(int argc, char* argv[])
 
     G_TEST_ADD_FUNC("/core/NuguTimer/Trigger", test_nugutimer_trigger);
     G_TEST_ADD_FUNC("/core/NuguTimer/Repeat", test_nugutimer_repeat);
+    G_TEST_ADD_FUNC("/core/NuguTimer/Loop", test_nugutimer_loop);
     G_TEST_ADD_FUNC("/core/NuguTimer/MultiTrigger", test_nugutimer_multi_trigger);
     G_TEST_ADD_FUNC("/core/NuguTimer/MultiRepeat", test_nugutimer_multi_repeat);
 

--- a/tests/core/test_core_nugu_timer_mock.cc
+++ b/tests/core/test_core_nugu_timer_mock.cc
@@ -29,6 +29,7 @@ struct _nugu_timer {
     int fake_count;
     int repeat;
     int count;
+    gboolean loop;
     NuguTimeoutCallback cb;
     void* userdata;
     int start;
@@ -60,13 +61,12 @@ static void fake_timer_action(gpointer data, gpointer user_data)
     if (timer->start == 0)
         return;
 
-    if (timer->repeat < timer->count)
-        return;
-
     timer->fake_count++;
     if (timer->fake_count >= timer->interval) {
-        if (_nugu_timer_callback(timer) == FALSE)
+        gboolean ret = _nugu_timer_callback(timer);
+        if (!timer->loop && !ret)
             timer->start = 0;
+
         timer->fake_count = 0;
     }
 }
@@ -123,6 +123,16 @@ void nugu_timer_set_repeat(NuguTimer* timer, int repeat)
 int nugu_timer_get_repeat(NuguTimer* timer)
 {
     return timer->repeat;
+}
+
+void nugu_timer_set_loop(NuguTimer* timer, int loop)
+{
+    timer->loop = loop == 0 ? FALSE : TRUE;
+}
+
+int nugu_timer_get_loop(NuguTimer* timer)
+{
+    return timer->loop;
 }
 
 int nugu_timer_get_count(NuguTimer* timer)

--- a/tests/test_nugu_timer.c
+++ b/tests/test_nugu_timer.c
@@ -23,9 +23,10 @@
 #include "base/nugu_timer.h"
 
 #define TIME_UNIT_MS		100
-#define CHECK_SOFT_TIMER_LIMIT	5
-#define CHECK_SOFT_TIMER_COUNT	3
+#define CHECK_SOFT_TIMER_LIMIT_FIVE	5
+#define CHECK_SOFT_TIMER_COUNT_THREE	3
 #define CHECK_SOFT_TIMER_COUNT_ZERO	0
+#define CHECK_SOFT_TIMER_COUNT_ONE	1
 
 static void count_timeout(void *param)
 {
@@ -47,12 +48,12 @@ static void test_timer_default(void)
 
 	loop = g_main_loop_new(NULL, FALSE);
 
-	t1 = nugu_timer_new(TIME_UNIT_MS, CHECK_SOFT_TIMER_COUNT);
+	t1 = nugu_timer_new(TIME_UNIT_MS, CHECK_SOFT_TIMER_COUNT_THREE);
 	g_assert(t1 != NULL);
 
 	nugu_timer_set_callback(t1, count_timeout, (void *)&t1_count);
 
-	t2 = nugu_timer_new(TIME_UNIT_MS * CHECK_SOFT_TIMER_LIMIT, 1);
+	t2 = nugu_timer_new(TIME_UNIT_MS * CHECK_SOFT_TIMER_LIMIT_FIVE, 1);
 	g_assert(t2 != NULL);
 
 	nugu_timer_set_callback(t2, quit_timeout, (void *)loop);
@@ -73,8 +74,54 @@ static void test_timer_default(void)
 	nugu_timer_stop(t2);
 	nugu_timer_stop(t3);
 
-	g_assert(t1_count == CHECK_SOFT_TIMER_COUNT);
+	g_assert(t1_count == CHECK_SOFT_TIMER_COUNT_THREE);
 	g_assert(t3_count == CHECK_SOFT_TIMER_COUNT_ZERO);
+
+	nugu_timer_delete(t1);
+	nugu_timer_delete(t2);
+	nugu_timer_delete(t3);
+}
+
+static void test_timer_loop(void)
+{
+	GMainLoop *loop;
+	NuguTimer *t1, *t2, *t3;
+	int t1_loop_count = 0;
+	int t2_unloop_count = 0;
+
+	loop = g_main_loop_new(NULL, FALSE);
+
+	t1 = nugu_timer_new(TIME_UNIT_MS, CHECK_SOFT_TIMER_COUNT_ONE);
+	g_assert(t1 != NULL);
+	nugu_timer_set_loop(t1, TRUE);
+	g_assert(nugu_timer_get_loop(t1) != 0);
+
+	nugu_timer_set_callback(t1, count_timeout, (void *)&t1_loop_count);
+
+	t2 = nugu_timer_new(TIME_UNIT_MS, CHECK_SOFT_TIMER_COUNT_ONE);
+	g_assert(t2 != NULL);
+	g_assert(nugu_timer_get_loop(t2) != 1);
+
+	nugu_timer_set_callback(t2, count_timeout, (void *)&t2_unloop_count);
+
+	t3 = nugu_timer_new(TIME_UNIT_MS * CHECK_SOFT_TIMER_COUNT_THREE, 1);
+	g_assert(t3 != NULL);
+
+	nugu_timer_set_callback(t3, quit_timeout, (void *)loop);
+
+	nugu_timer_start(t1);
+	nugu_timer_start(t2);
+	nugu_timer_start(t3);
+
+	g_main_loop_run(loop);
+	g_main_loop_unref(loop);
+
+	nugu_timer_stop(t1);
+	nugu_timer_stop(t2);
+	nugu_timer_stop(t3);
+
+	g_assert(t1_loop_count > CHECK_SOFT_TIMER_COUNT_ONE);
+	g_assert(t2_unloop_count == CHECK_SOFT_TIMER_COUNT_ONE);
 
 	nugu_timer_delete(t1);
 	nugu_timer_delete(t2);
@@ -91,6 +138,7 @@ int main(int argc, char *argv[])
 	g_log_set_always_fatal((GLogLevelFlags)G_LOG_FATAL_MASK);
 
 	g_test_add_func("/timer/default", test_timer_default);
+	g_test_add_func("/timer/loop", test_timer_loop);
 
 	return g_test_run();
 }


### PR DESCRIPTION
The NUGU Timer is supported the loop property as below.

    // base/nugu_timer.h
    nugu_timer_set_loop(timer, 1);

    // clientkit/nugu_timer_interface.hh
    INuguTimer::setLoop(true);

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>