### PR TITLE
examples: fix memory leak in the asr/text filter

### DIFF
--- a/examples/response_filter/filter.cc
+++ b/examples/response_filter/filter.cc
@@ -74,6 +74,7 @@ public:
                       << nugu_directive_peek_namespace(ndir) << ":"
                       << nugu_directive_peek_name(ndir) << std::endl;
 
+            nugu_directive_unref(ndir);
             return true;
         }
 
@@ -164,6 +165,7 @@ int filter_register(NuguClientKit::NuguClient* client)
     sequencer->addListener("TTS", dir_listener);
     sequencer->addListener("Text", dir_listener);
     sequencer->addListener("AudioPlayer", dir_listener);
+    sequencer->addListener("Display", dir_listener);
 
     net_listener = new NetworkListener();
     client->getNetworkManager()->addListener(net_listener);

--- a/examples/response_filter/main.cc
+++ b/examples/response_filter/main.cc
@@ -20,6 +20,7 @@ static std::shared_ptr<ITextHandler> text_handler = nullptr;
 static std::shared_ptr<IASRHandler> asr_handler = nullptr;
 
 static std::string text_value;
+static GMainLoop* loop;
 
 class MyTTSListener : public ITTSListener {
 public:
@@ -30,6 +31,7 @@ public:
         switch (state) {
         case TTSState::TTS_SPEECH_FINISH:
             std::cout << "TTS Finish" << std::endl;
+            g_main_loop_quit(loop);
             break;
         default:
             break;
@@ -105,6 +107,7 @@ public:
             std::cout << "ASR unknown error, request dialog id: " << dialog_id << std::endl;
             break;
         }
+        g_main_loop_quit(loop);
     }
 
     void onCancel(const std::string& dialog_id)
@@ -125,6 +128,7 @@ public:
         switch (status) {
         case NetworkStatus::DISCONNECTED:
             std::cout << "Network disconnected !" << std::endl;
+            g_main_loop_quit(loop);
             break;
         case NetworkStatus::CONNECTED:
             std::cout << "Network connected !" << std::endl;
@@ -227,7 +231,7 @@ int main(int argc, char* argv[])
     network_manager->connect();
 
     /* Start GMainLoop */
-    GMainLoop* loop = g_main_loop_new(NULL, FALSE);
+    loop = g_main_loop_new(NULL, FALSE);
 
     std::cout << "Start the eventloop" << std::endl
               << std::endl;


### PR DESCRIPTION
There is a memory leak bug for NuguDirective in onPreHandle callback.
So fixed it.

Signed-off-by: Inho Oh <inho.oh@sk.com>