### PR TITLE
playsync:update playsync and playstack management for handling Alerts

### DIFF
--- a/include/clientkit/playsync_manager_interface.hh
+++ b/include/clientkit/playsync_manager_interface.hh
@@ -83,6 +83,12 @@ public:
     virtual ~IPlaySyncManager() = default;
 
     /**
+     * @brief Register capability agent for sync (default:TTS, AudioPlayer, Display)
+     * @param[in] capability_name capability agent name
+     */
+    virtual void registerCapabilityForSync(const std::string& capability_name) = 0;
+
+    /**
      * @brief Add IPlaySyncManagerListener.
      * @param[in] requester capability agent name
      * @param[in] listener IPlaySyncManagerListener instance

--- a/src/core/playstack_manager.cc
+++ b/src/core/playstack_manager.cc
@@ -155,7 +155,7 @@ bool PlayStackManager::add(const std::string& ps_id, NuguDirective* ndir)
         return false;
     }
 
-    handlePreviousStack(layer, is_stacked);
+    handlePreviousStack(is_stacked);
     return addToContainer(ps_id, layer);
 }
 
@@ -274,19 +274,19 @@ PlayStackLayer PlayStackManager::extractPlayStackLayer(NuguDirective* ndir)
         return PlayStackLayer::Info;
 }
 
-std::string PlayStackManager::getSameLayerStack(PlayStackLayer layer)
+std::string PlayStackManager::getNoneMediaLayerStack()
 {
     for (const auto& item : playstack_container.first)
-        if (item.second == layer)
+        if (item.second != PlayStackLayer::Media)
             return item.first;
 
     return "";
 }
 
-void PlayStackManager::handlePreviousStack(PlayStackLayer layer, bool is_stacked)
+void PlayStackManager::handlePreviousStack(bool is_stacked)
 {
     if (is_stacked) {
-        removeFromContainer(getSameLayerStack(layer));
+        removeFromContainer(getNoneMediaLayerStack());
     } else {
         for (const auto& item : playstack_container.second)
             notifyStackRemoved(item);

--- a/src/core/playstack_manager.hh
+++ b/src/core/playstack_manager.hh
@@ -87,8 +87,8 @@ private:
 
 private:
     PlayStackLayer extractPlayStackLayer(NuguDirective* ndir);
-    std::string getSameLayerStack(PlayStackLayer layer);
-    void handlePreviousStack(PlayStackLayer layer, bool is_stacked);
+    std::string getNoneMediaLayerStack();
+    void handlePreviousStack(bool is_stacked);
     bool addToContainer(const std::string& ps_id, PlayStackLayer layer);
     void removeFromContainer(const std::string& ps_id);
     void notifyStackRemoved(const std::string& ps_id);

--- a/src/core/playsync_manager.cc
+++ b/src/core/playsync_manager.cc
@@ -25,6 +25,7 @@ PlaySyncManager::PlaySyncManager()
     : playstack_manager(std::unique_ptr<PlayStackManager>(new PlayStackManager()))
 {
     playstack_manager->addListener(this);
+    sync_capability_list = DEFAULT_SYNC_CAPABILITY_LIST;
 }
 
 PlaySyncManager::~PlaySyncManager()
@@ -56,6 +57,12 @@ void PlaySyncManager::setInteractionControlManager(InteractionControlManager* in
 {
     if (interaction_control_manager)
         this->interaction_control_manager = interaction_control_manager;
+}
+
+void PlaySyncManager::registerCapabilityForSync(const std::string& capability_name)
+{
+    if (!capability_name.empty())
+        sync_capability_list.emplace_back(capability_name);
 }
 
 void PlaySyncManager::addListener(const std::string& requester, IPlaySyncManagerListener* listener)
@@ -98,7 +105,7 @@ void PlaySyncManager::prepareSync(const std::string& ps_id, NuguDirective* ndir)
     std::string dir_groups = nugu_directive_peek_groups(ndir);
     PlaySyncContainer playsync_container;
 
-    for (const auto& sync_capability : SYNC_CAPABILITAY_LIST)
+    for (const auto& sync_capability : sync_capability_list)
         if (dir_groups.find(sync_capability) != std::string::npos)
             playsync_container.emplace(sync_capability, std::make_pair(PlaySyncState::Prepared, nullptr));
 

--- a/src/core/playsync_manager.hh
+++ b/src/core/playsync_manager.hh
@@ -40,6 +40,7 @@ public:
     void reset();
     void setPlayStackManager(PlayStackManager* playstack_manager);
     void setInteractionControlManager(InteractionControlManager* interaction_control_manager);
+    void registerCapabilityForSync(const std::string& capability_name) override;
     void addListener(const std::string& requester, IPlaySyncManagerListener* listener) override;
     void removeListener(const std::string& requester) override;
     int getListenerCount();
@@ -74,7 +75,8 @@ private:
     void clearContainer();
     void clearPostPonedRelease();
 
-    const std::vector<std::string> SYNC_CAPABILITAY_LIST { "TTS", "AudioPlayer", "Display" };
+    const std::vector<std::string> DEFAULT_SYNC_CAPABILITY_LIST { "TTS", "AudioPlayer", "Display" };
+    std::vector<std::string> sync_capability_list;
 
     std::unique_ptr<PlayStackManager> playstack_manager = nullptr;
     InteractionControlManager* interaction_control_manager = nullptr;


### PR DESCRIPTION
It add the registerCapabilityForSync method in PlaySyncManager
which is possible to register capability for sync.

It change the handling previous stack info in PlayStackManager
to remove another stack except Media Layer in stacked condition.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>