### PR TITLE
SpeakerAgent:compose SpeakerType and name string maps

### DIFF
--- a/src/capability/speaker_agent.cc
+++ b/src/capability/speaker_agent.cc
@@ -28,6 +28,23 @@ SpeakerAgent::SpeakerAgent()
     : Capability(CAPABILITY_NAME, CAPABILITY_VERSION)
     , speaker_listener(nullptr)
 {
+    // compose maps for SpeakerType and name string
+    speaker_names_for_types = {
+        { SpeakerType::NUGU, "NUGU" },
+        { SpeakerType::MUSIC, "MUSIC" },
+        { SpeakerType::RINGTON, "RINGTON" },
+        { SpeakerType::CALL, "CALL" },
+        { SpeakerType::NOTIFICATION, "NOTIFICATION" },
+        { SpeakerType::ALARM, "ALARM" },
+        { SpeakerType::VOICE_COMMAND, "VOICE_COMMAND" },
+        { SpeakerType::NAVIGATION, "NAVIGATION" },
+        { SpeakerType::SYSTEM_SOUND, "SYSTEM_SOUND" },
+    };
+
+    std::for_each(speaker_names_for_types.cbegin(), speaker_names_for_types.cend(),
+        [&](const std::pair<SpeakerType, std::string>& element) {
+            speaker_types_for_names.emplace(element.second, element.first);
+        });
 }
 
 void SpeakerAgent::initialize()
@@ -195,59 +212,21 @@ void SpeakerAgent::updateSpeakerMute(SpeakerType type, bool mute)
 
 bool SpeakerAgent::getSpeakerType(const std::string& name, SpeakerType& type)
 {
-    if (name == "NUGU") {
-        type = SpeakerType::NUGU;
+    try {
+        type = speaker_types_for_names.at(name);
         return true;
-    } else if (name == "MUSIC") {
-        type = SpeakerType::MUSIC;
-        return true;
-    } else if (name == "RINGTON") {
-        type = SpeakerType::RINGTON;
-        return true;
-    } else if (name == "CALL") {
-        type = SpeakerType::CALL;
-        return true;
-    } else if (name == "NOTIFICATION") {
-        type = SpeakerType::NOTIFICATION;
-        return true;
-    } else if (name == "ALARM") {
-        type = SpeakerType::ALARM;
-        return true;
-    } else if (name == "VOICE_COMMAND") {
-        type = SpeakerType::VOICE_COMMAND;
-        return true;
-    } else if (name == "NAVIGATION") {
-        type = SpeakerType::NAVIGATION;
-        return true;
-    } else if (name == "SYSTEM_SOUND") {
-        type = SpeakerType::SYSTEM_SOUND;
-        return true;
+    } catch (const std::out_of_range& oor) {
+        return false;
     }
-    return false;
 }
 
 std::string SpeakerAgent::getSpeakerName(const SpeakerType& type)
 {
-    if (type == SpeakerType::NUGU)
+    try {
+        return speaker_names_for_types.at(type);
+    } catch (const std::out_of_range& oor) {
         return "NUGU";
-    else if (type == SpeakerType::MUSIC)
-        return "MUSIC";
-    else if (type == SpeakerType::RINGTON)
-        return "RINGTON";
-    else if (type == SpeakerType::CALL)
-        return "CALL";
-    else if (type == SpeakerType::NOTIFICATION)
-        return "NOTIFICATION";
-    else if (type == SpeakerType::ALARM)
-        return "ALARM";
-    else if (type == SpeakerType::VOICE_COMMAND)
-        return "VOICE_COMMAND";
-    else if (type == SpeakerType::NAVIGATION)
-        return "NAVIGATION";
-    else if (type == SpeakerType::SYSTEM_SOUND)
-        return "SYSTEM_SOUND";
-    else
-        return "NUGU";
+    }
 }
 
 void SpeakerAgent::sendEventSetVolumeSucceeded(const std::string& ps_id, EventResultCallback cb)

--- a/src/capability/speaker_agent.hh
+++ b/src/capability/speaker_agent.hh
@@ -60,6 +60,8 @@ private:
     std::string getSpeakerName(const SpeakerType& type);
 
     std::map<SpeakerType, std::unique_ptr<SpeakerInfo>> speakers;
+    std::map<SpeakerType, std::string> speaker_names_for_types;
+    std::map<std::string, SpeakerType> speaker_types_for_names;
     ISpeakerListener* speaker_listener;
 };
 


### PR DESCRIPTION
It add the maps of SpeakerType and name string for improving
to retrieve the matched SpeakerType and name string efficiently.

Someday, if it needs to add new SpeakerType, it's done just adding
new SpeakerType and name string item to speaker_names_for_types map.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>