### PR TITLE
AudioPlayer: Clear context information

### DIFF
--- a/src/capability/audio_player_agent.hh
+++ b/src/capability/audio_player_agent.hh
@@ -137,6 +137,7 @@ private:
     void parsingRequestOthersCommand(const char* dname, const char* message);
     std::string parsingRenderInfo(NuguDirective* ndir, const char* message);
 
+    void clearContext();
     void checkAndUpdateVolume();
     std::string playbackError(PlaybackError error);
     std::string playerActivity(AudioPlayerState state);


### PR DESCRIPTION
AudioPlayer keeps context information like token even when the media
services are deactivated.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>