### PR TITLE
TTS:fix handling sync state result

### DIFF
--- a/include/clientkit/capability.hh
+++ b/include/clientkit/capability.hh
@@ -269,8 +269,9 @@ public:
     /**
      * @brief Destroy directive received from Directive Sequencer.
      * @param[in] ndir directive
+     * @param[in] is_cancel whether to destroy by cancel
      */
-    void destroyDirective(NuguDirective* ndir);
+    void destroyDirective(NuguDirective* ndir, bool is_cancel = false);
 
     /**
      * @brief Get directive received from Directive Sequencer.

--- a/src/capability/tts_agent.hh
+++ b/src/capability/tts_agent.hh
@@ -65,6 +65,7 @@ private:
     // parsing directive
     void parsingSpeak(const char* message);
     void parsingStop(const char* message);
+    void postProcessDirective(bool is_cancel = false);
 
     void checkAndUpdateVolume();
     void mediaStateChanged(MediaPlayerState state) override;

--- a/src/clientkit/capability.cc
+++ b/src/clientkit/capability.cc
@@ -349,12 +349,14 @@ void Capability::processDirective(NuguDirective* ndir)
     }
 }
 
-void Capability::destroyDirective(NuguDirective* ndir)
+void Capability::destroyDirective(NuguDirective* ndir, bool is_cancel)
 {
     if (ndir == pimpl->cur_ndir)
         pimpl->cur_ndir = NULL;
 
-    directive_sequencer->complete(ndir);
+    is_cancel
+        ? directive_sequencer->cancel(nugu_directive_peek_dialog_id(ndir))
+        : directive_sequencer->complete(ndir);
 }
 
 NuguDirective* Capability::getNuguDirective()


### PR DESCRIPTION
As some capability agents are operated with sync, there are cases
which need to to handle sync state result separately.

So, it fix not to handle the sync state result
if the condition is not satisfied in TTSAgent.

Also, it update to cancel previous directive
if the sync state result needs to suspend TTS play.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>