### PR TITLE
playsync:fix playsync postpone release

### DIFF
--- a/src/core/playsync_manager.cc
+++ b/src/core/playsync_manager.cc
@@ -92,12 +92,12 @@ int PlaySyncManager::getListenerCount()
 
 void PlaySyncManager::prepareSync(const std::string& ps_id, NuguDirective* ndir)
 {
+    clearPostPonedRelease();
+
     if (!playstack_manager->add(ps_id, ndir)) {
         nugu_warn("The condition is not satisfied to prepare sync.");
         return;
     }
-
-    clearPostPonedRelease();
 
     if (!playstack_manager->isStackedCondition(ndir))
         clearContainer();


### PR DESCRIPTION
It fix to execute clearPostPonedRelease firstly,
when preparing sync for suspending previous release action.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>