### PR TITLE
FocusManager: Added focus request priority

### DIFF
--- a/include/clientkit/focus_manager_interface.hh
+++ b/include/clientkit/focus_manager_interface.hh
@@ -134,9 +134,10 @@ public:
 
     /**
      * @brief Set focus configurations.
-     * @param[in] configurations focus configurations
+     * @param[in] request configurations for focus request
+     * @param[in] release configurations for focus release
      */
-    virtual void setConfigurations(std::vector<FocusConfiguration>& configurations) = 0;
+    virtual void setConfigurations(std::vector<FocusConfiguration>& request, std::vector<FocusConfiguration>& release) = 0;
 
     /**
      * @brief Stop all focus.

--- a/src/core/focus_manager.hh
+++ b/src/core/focus_manager.hh
@@ -36,7 +36,7 @@ public:
 
 class FocusResource {
 public:
-    FocusResource(const std::string& type, const std::string& name, int priority, IFocusResourceListener* listener, IFocusResourceObserver* observer);
+    FocusResource(const std::string& type, const std::string& name, int request_priority, int release_priority, IFocusResourceListener* listener, IFocusResourceObserver* observer);
     virtual ~FocusResource() = default;
 
     void setState(FocusState state);
@@ -47,7 +47,8 @@ public:
 public:
     std::string type;
     std::string name;
-    int priority;
+    int request_priority;
+    int release_priority;
     FocusState state;
     IFocusResourceListener* listener;
     IFocusResourceObserver* observer;
@@ -66,7 +67,7 @@ public:
     bool holdFocus(const std::string& type) override;
     bool unholdFocus(const std::string& type) override;
 
-    void setConfigurations(std::vector<FocusConfiguration>& configurations) override;
+    void setConfigurations(std::vector<FocusConfiguration>& request, std::vector<FocusConfiguration>& release) override;
     void stopAllFocus() override;
     void stopForegroundFocus() override;
 
@@ -81,9 +82,10 @@ public:
     void printConfigurations();
 
 private:
-    std::map<std::string, int> configuration_map;
+    std::map<std::string, int> request_configuration_map;
+    std::map<std::string, int> release_configuration_map;
     std::map<int, std::shared_ptr<FocusResource>> focus_resource_ordered_map;
-    std::map<std::string, bool> focus_hold_map;
+    int focus_hold_priority;
     std::vector<IFocusManagerObserver*> observers;
 };
 


### PR DESCRIPTION
The NUGU sound policy is changed that focus has request and release
priority as belows. The focus manager is added focus request priority
for this feature.

| Num | Request Order |  Release Order |
|:----------:|:-------------:|:------:|
| 1 | Call, ASR(User) | Call |
| 2 | Alerts, Info | ASR(User) |
| 3 | Media | ASR(DM), Alerts, Info |
| 4 | ASR(DM) | ASRBeep |
| 5 | ASRBeep, Sound | Media, Sound, Dummy |
| 6 | Dummy | Empty |

For examples, `Info` focus is can steal the `ASR(Users)` focus even
if it is lower release priority than `ASR(Users)` focus.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>