### PR TITLE
playsync:add flag for check next display to render exists

### DIFF
--- a/examples/standalone/capability/audio_player_listener.cc
+++ b/examples/standalone/capability/audio_player_listener.cc
@@ -108,12 +108,13 @@ void AudioPlayerListener::renderDisplay(const std::string& id, const std::string
               << "\033[0m" << std::endl;
 }
 
-bool AudioPlayerListener::clearDisplay(const std::string& id, bool unconditionally)
+bool AudioPlayerListener::clearDisplay(const std::string& id, bool unconditionally, bool has_next)
 {
     std::cout << "\033[1;94m"
               << "[AudioPlayer] clear display template\n"
               << "\t id:" << id.c_str() << std::endl
-              << "\t unconditionally:" << unconditionally
+              << "\t unconditionally:" << unconditionally << std::endl
+              << "\t has_next:" << has_next
               << "\033[0m" << std::endl;
 
     return false;

--- a/examples/standalone/capability/audio_player_listener.hh
+++ b/examples/standalone/capability/audio_player_listener.hh
@@ -39,7 +39,7 @@ public:
 
     // implements IAudioPlayerDisplayListener
     void renderDisplay(const std::string& id, const std::string& type, const std::string& json_payload, const std::string& dialog_id) override;
-    bool clearDisplay(const std::string& id, bool unconditionally) override;
+    bool clearDisplay(const std::string& id, bool unconditionally, bool has_next) override;
     void controlDisplay(const std::string& id, ControlType type, ControlDirection direction) override;
     void updateDisplay(const std::string& id, const std::string& json_payload) override;
     bool requestLyricsPageAvailable(const std::string& id, bool& visible) override;

--- a/examples/standalone/capability/display_listener.cc
+++ b/examples/standalone/capability/display_listener.cc
@@ -28,12 +28,13 @@ void DisplayListener::renderDisplay(const std::string& id, const std::string& ty
               << "\033[0m" << std::endl;
 }
 
-bool DisplayListener::clearDisplay(const std::string& id, bool unconditionally)
+bool DisplayListener::clearDisplay(const std::string& id, bool unconditionally, bool has_next)
 {
     std::cout << "\033[1;94m"
               << "[Display] clear display template\n"
               << "\t id:" << id.c_str() << std::endl
-              << "\t unconditionally:" << unconditionally
+              << "\t unconditionally:" << unconditionally << std::endl
+              << "\t has_next:" << has_next
               << "\033[0m" << std::endl;
 
     return false;

--- a/examples/standalone/capability/display_listener.hh
+++ b/examples/standalone/capability/display_listener.hh
@@ -28,7 +28,7 @@ public:
     virtual ~DisplayListener() = default;
 
     void renderDisplay(const std::string& id, const std::string& type, const std::string& json, const std::string& dialog_id) override;
-    bool clearDisplay(const std::string& id, bool unconditionally) override;
+    bool clearDisplay(const std::string& id, bool unconditionally, bool has_next) override;
     void controlDisplay(const std::string& id, ControlType type, ControlDirection direction) override;
     void updateDisplay(const std::string& id, const std::string& json_payload) override;
 

--- a/include/capability/display_interface.hh
+++ b/include/capability/display_interface.hh
@@ -65,9 +65,10 @@ public:
      * @brief The SDK will ask you to delete the rendered display on the display according to the service context maintenance policy.
      * @param[in] id display template id
      * @param[in] unconditionally whether clear display unconditionally or not
+     * @param[in] has_next whether has next display to render
      * @return true if display is cleared
      */
-    virtual bool clearDisplay(const std::string& id, bool unconditionally) = 0;
+    virtual bool clearDisplay(const std::string& id, bool unconditionally, bool has_next) = 0;
 
     /**
      * @brief Request to control the display with type and direction

--- a/include/clientkit/playsync_manager_interface.hh
+++ b/include/clientkit/playsync_manager_interface.hh
@@ -192,6 +192,12 @@ public:
     virtual bool hasLayer(const std::string& ps_id, PlayStackLayer layer) = 0;
 
     /**
+     * @brief Check whether the next playstack to handle exists.
+     * @return true if the next playstack exists, otherwise false
+     */
+    virtual bool hasNextPlayStack() = 0;
+
+    /**
      * @brief Get all items which are stored in playstack.
      * @return Playstack items (play service id list)
      */

--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -1524,7 +1524,7 @@ void AudioPlayerAgent::onSyncState(const std::string& ps_id, PlaySyncState state
 
 void AudioPlayerAgent::onDataChanged(const std::string& ps_id, std::pair<void*, void*> extra_datas)
 {
-    clearDisplay(extra_datas.first);
+    clearDisplay(extra_datas.first, (extra_datas.second ? true : false));
     renderDisplay(extra_datas.second);
 }
 
@@ -1541,7 +1541,7 @@ void AudioPlayerAgent::renderDisplay(void* data)
         display_listener->renderDisplay(template_id, template_type, template_view, template_id);
 }
 
-void AudioPlayerAgent::clearDisplay(void* data)
+void AudioPlayerAgent::clearDisplay(void* data, bool has_next_render)
 {
     if (!display_listener || !data) {
         nugu_warn("The DisplayListener or render data is not exist.");
@@ -1552,7 +1552,7 @@ void AudioPlayerAgent::clearDisplay(void* data)
     std::tie(std::ignore, std::ignore, template_id) = *reinterpret_cast<RenderInfo*>(data);
 
     if (!template_id.empty()) {
-        display_listener->clearDisplay(template_id, true);
+        display_listener->clearDisplay(template_id, true, has_next_render || playsync_manager->hasNextPlayStack());
         render_infos.erase(template_id);
     }
 }

--- a/src/capability/audio_player_agent.hh
+++ b/src/capability/audio_player_agent.hh
@@ -143,7 +143,7 @@ private:
     std::string playerActivity(AudioPlayerState state);
 
     void renderDisplay(void* data);
-    void clearDisplay(void* data);
+    void clearDisplay(void* data, bool has_next_render = false);
 
     const unsigned int PAUSE_CONTEXT_HOLD_TIME = 60 * 10;
 

--- a/src/capability/display_agent.cc
+++ b/src/capability/display_agent.cc
@@ -469,7 +469,7 @@ void DisplayAgent::onSyncState(const std::string& ps_id, PlaySyncState state, vo
 
 void DisplayAgent::onDataChanged(const std::string& ps_id, std::pair<void*, void*> extra_datas)
 {
-    clearDisplay(extra_datas.first);
+    clearDisplay(extra_datas.first, (extra_datas.second ? true : false));
     renderDisplay(extra_datas.second);
 }
 
@@ -484,7 +484,7 @@ void DisplayAgent::renderDisplay(void* data)
     display_listener->renderDisplay(render_info->id, render_info->type, render_info->payload, render_info->dialog_id);
 }
 
-void DisplayAgent::clearDisplay(void* data)
+void DisplayAgent::clearDisplay(void* data, bool has_next_render)
 {
     if (!display_listener || !data) {
         nugu_warn("The DisplayListener or render data is not exist.");
@@ -493,7 +493,7 @@ void DisplayAgent::clearDisplay(void* data)
 
     auto render_info = reinterpret_cast<DisplayRenderInfo*>(data);
     this->render_info[render_info->id]->close = true;
-    display_listener->clearDisplay(render_info->id, true);
+    display_listener->clearDisplay(render_info->id, true, has_next_render || playsync_manager->hasNextPlayStack());
 }
 
 } // NuguCapability

--- a/src/capability/display_agent.hh
+++ b/src/capability/display_agent.hh
@@ -80,7 +80,7 @@ private:
     std::string getDirectionString(ControlDirection direction);
 
     void renderDisplay(void* data);
-    void clearDisplay(void* data);
+    void clearDisplay(void* data, bool has_next_render = false);
 
     std::map<std::string, DisplayRenderInfo*> render_info;
     IDisplayListener* display_listener;

--- a/src/core/playstack_manager.cc
+++ b/src/core/playstack_manager.cc
@@ -100,6 +100,7 @@ void PlayStackManager::reset()
     has_holding = false;
     is_expect_speech = false;
     is_stacked = false;
+    has_adding_playstack = false;
 }
 
 void PlayStackManager::addListener(IPlayStackManagerListener* listener)
@@ -155,6 +156,8 @@ bool PlayStackManager::add(const std::string& ps_id, NuguDirective* ndir)
         nugu_warn("%s is already added.", ps_id.c_str());
         return false;
     }
+
+    has_adding_playstack = true;
 
     handlePreviousStack(is_stacked);
     return addToContainer(ps_id, layer);
@@ -233,6 +236,11 @@ bool PlayStackManager::isActiveHolding()
     return timer->isStarted();
 }
 
+bool PlayStackManager::hasAddingPlayStack()
+{
+    return has_adding_playstack;
+}
+
 PlayStackLayer PlayStackManager::getPlayStackLayer(const std::string& ps_id)
 {
     try {
@@ -305,6 +313,8 @@ bool PlayStackManager::addToContainer(const std::string& ps_id, PlayStackLayer l
 
     playstack_container.first.emplace(ps_id, layer);
     playstack_container.second.emplace_back(ps_id);
+
+    has_adding_playstack = false;
 
     for (const auto& listener : listeners)
         listener->onStackAdded(ps_id);

--- a/src/core/playstack_manager.hh
+++ b/src/core/playstack_manager.hh
@@ -68,6 +68,7 @@ public:
     void stopHolding();
     void resetHolding();
     bool isActiveHolding();
+    bool hasAddingPlayStack();
 
     PlayStackLayer getPlayStackLayer(const std::string& ps_id);
     std::vector<std::string> getAllPlayStackItems();
@@ -110,6 +111,7 @@ private:
     bool has_holding = false;
     bool is_expect_speech = false;
     bool is_stacked = false;
+    bool has_adding_playstack = false;
 };
 
 } // NuguCore

--- a/src/core/playsync_manager.cc
+++ b/src/core/playsync_manager.cc
@@ -198,6 +198,11 @@ bool PlaySyncManager::hasLayer(const std::string& ps_id, PlayStackLayer layer)
     return playstack_manager->getPlayStackLayer(ps_id) == layer;
 }
 
+bool PlaySyncManager::hasNextPlayStack()
+{
+    return playstack_manager->hasAddingPlayStack();
+}
+
 std::vector<std::string> PlaySyncManager::getAllPlayStackItems()
 {
     return playstack_manager->getAllPlayStackItems();

--- a/src/core/playsync_manager.hh
+++ b/src/core/playsync_manager.hh
@@ -60,6 +60,7 @@ public:
 
     bool isConditionToHandlePrevDialog(NuguDirective* prev_ndir, NuguDirective* cur_ndir) override;
     bool hasLayer(const std::string& ps_id, PlayStackLayer layer) override;
+    bool hasNextPlayStack() override;
     std::vector<std::string> getAllPlayStackItems() override;
     const PlayStacks& getPlayStacks();
 


### PR DESCRIPTION
It add the flag in clearDisplay method of IDisplayListener
for checking whether the next display to render exists.

Because, the next render info is acquired from playstack,
it add related methods in PlaySyncManager and PlayStackManager.

```
// in nugu_sample log
[Display] clear display template
	 id:1604050384750876
	 unconditionally:1
	 has_next:1 <-- next display to render exists
```
Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>