### PR TITLE
example:refactoring AudioPlayerListener

### DIFF
--- a/examples/standalone/capability/audio_player_listener.cc
+++ b/examples/standalone/capability/audio_player_listener.cc
@@ -18,6 +18,11 @@
 
 #include "audio_player_listener.hh"
 
+AudioPlayerListener::AudioPlayerListener()
+{
+    capability_name = "AudioPlayer";
+}
+
 void AudioPlayerListener::mediaStateChanged(AudioPlayerState state, const std::string& dialog_id)
 {
     std::cout << "[AudioPlayer][id:" << dialog_id << "] ";
@@ -96,38 +101,6 @@ void AudioPlayerListener::requestContentCache(const std::string& key, const std:
 bool AudioPlayerListener::requestToGetCachedContent(const std::string& key, std::string& filepath)
 {
     return false;
-}
-
-void AudioPlayerListener::renderDisplay(const std::string& id, const std::string& type, const std::string& json_payload, const std::string& dialog_id)
-{
-    std::cout << "\033[1;94m"
-              << "[AudioPlayer] render display template\n"
-              << "\t id:" << id.c_str() << std::endl
-              << "\t type:" << type.c_str() << std::endl
-              << "\t dialog_id:" << dialog_id.c_str()
-              << "\033[0m" << std::endl;
-}
-
-bool AudioPlayerListener::clearDisplay(const std::string& id, bool unconditionally, bool has_next)
-{
-    std::cout << "\033[1;94m"
-              << "[AudioPlayer] clear display template\n"
-              << "\t id:" << id.c_str() << std::endl
-              << "\t unconditionally:" << unconditionally << std::endl
-              << "\t has_next:" << has_next
-              << "\033[0m" << std::endl;
-
-    return false;
-}
-
-void AudioPlayerListener::controlDisplay(const std::string& id, ControlType type, ControlDirection direction)
-{
-    std::cout << "[AudioPlayer][id:" << id << "] controlDisplay" << std::endl;
-}
-
-void AudioPlayerListener::updateDisplay(const std::string& id, const std::string& json_payload)
-{
-    std::cout << "[AudioPlayer][id:" << id << "] updateDisplay" << std::endl;
 }
 
 bool AudioPlayerListener::requestLyricsPageAvailable(const std::string& id, bool& visible)

--- a/examples/standalone/capability/audio_player_listener.hh
+++ b/examples/standalone/capability/audio_player_listener.hh
@@ -17,13 +17,15 @@
 #ifndef __AUDIO_PLAYER_LISTENER_H__
 #define __AUDIO_PLAYER_LISTENER_H__
 
+#include "display_listener.hh"
 #include <capability/audio_player_interface.hh>
 
 using namespace NuguCapability;
 
-class AudioPlayerListener : public IAudioPlayerListener {
+class AudioPlayerListener : public IAudioPlayerListener,
+                            public DisplayListener {
 public:
-    AudioPlayerListener() = default;
+    AudioPlayerListener();
     virtual ~AudioPlayerListener() = default;
 
     // implements IAudioPlayerListener
@@ -38,10 +40,6 @@ public:
     bool requestToGetCachedContent(const std::string& key, std::string& filepath) override;
 
     // implements IAudioPlayerDisplayListener
-    void renderDisplay(const std::string& id, const std::string& type, const std::string& json_payload, const std::string& dialog_id) override;
-    bool clearDisplay(const std::string& id, bool unconditionally, bool has_next) override;
-    void controlDisplay(const std::string& id, ControlType type, ControlDirection direction) override;
-    void updateDisplay(const std::string& id, const std::string& json_payload) override;
     bool requestLyricsPageAvailable(const std::string& id, bool& visible) override;
     bool showLyrics(const std::string& id) override;
     bool hideLyrics(const std::string& id) override;

--- a/examples/standalone/capability/display_listener.cc
+++ b/examples/standalone/capability/display_listener.cc
@@ -18,10 +18,15 @@
 
 #include "display_listener.hh"
 
+DisplayListener::DisplayListener()
+{
+    capability_name = "Display";
+}
+
 void DisplayListener::renderDisplay(const std::string& id, const std::string& type, const std::string& json, const std::string& dialog_id)
 {
     std::cout << "\033[1;94m"
-              << "[Display] render display template\n"
+              << "[" << capability_name << "] render display template\n"
               << "\t id:" << id.c_str() << std::endl
               << "\t type:" << type.c_str() << std::endl
               << "\t dialog_id:" << dialog_id.c_str()
@@ -31,7 +36,7 @@ void DisplayListener::renderDisplay(const std::string& id, const std::string& ty
 bool DisplayListener::clearDisplay(const std::string& id, bool unconditionally, bool has_next)
 {
     std::cout << "\033[1;94m"
-              << "[Display] clear display template\n"
+              << "[" << capability_name << "] clear display template\n"
               << "\t id:" << id.c_str() << std::endl
               << "\t unconditionally:" << unconditionally << std::endl
               << "\t has_next:" << has_next
@@ -42,7 +47,7 @@ bool DisplayListener::clearDisplay(const std::string& id, bool unconditionally, 
 
 void DisplayListener::controlDisplay(const std::string& id, ControlType type, ControlDirection direction)
 {
-    std::cout << "[Display] control display template\n"
+    std::cout << "[" << capability_name << "] control display template\n"
               << "\t id:" << id.c_str() << std::endl
               << "\t type:" << CONTROL_TYPE_TEXT.at(type) << std::endl
               << "\t direction:" << CONTROL_DIRECTION_TEXT.at(direction) << std::endl;
@@ -50,6 +55,6 @@ void DisplayListener::controlDisplay(const std::string& id, ControlType type, Co
 
 void DisplayListener::updateDisplay(const std::string& id, const std::string& json_payload)
 {
-    std::cout << "[Display] update display template\n"
+    std::cout << "[" << capability_name << "] update display template\n"
               << "\t id:" << id.c_str() << std::endl;
 }

--- a/examples/standalone/capability/display_listener.hh
+++ b/examples/standalone/capability/display_listener.hh
@@ -23,14 +23,18 @@
 
 using namespace NuguCapability;
 
-class DisplayListener : public IDisplayListener {
+class DisplayListener : virtual public IDisplayListener {
 public:
+    DisplayListener();
     virtual ~DisplayListener() = default;
 
     void renderDisplay(const std::string& id, const std::string& type, const std::string& json, const std::string& dialog_id) override;
     bool clearDisplay(const std::string& id, bool unconditionally, bool has_next) override;
     void controlDisplay(const std::string& id, ControlType type, ControlDirection direction) override;
     void updateDisplay(const std::string& id, const std::string& json_payload) override;
+
+protected:
+    std::string capability_name;
 
 private:
     const std::map<ControlType, std::string> CONTROL_TYPE_TEXT {

--- a/include/capability/display_interface.hh
+++ b/include/capability/display_interface.hh
@@ -90,7 +90,7 @@ public:
  * @brief audioplayer's display listener interface
  * @see IDisplayListener
  */
-class IAudioPlayerDisplayListener : public IDisplayListener {
+class IAudioPlayerDisplayListener : virtual public IDisplayListener {
 public:
     virtual ~IAudioPlayerDisplayListener() = default;
 


### PR DESCRIPTION
It change the AudioPlayerListener in standalone example
from implementing APIs about display to inheriting DisplayListener
for removing duplicate code.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>