### PR TITLE
ASRAgent: Fixed the server response error

### DIFF
--- a/src/capability/asr_agent.hh
+++ b/src/capability/asr_agent.hh
@@ -81,6 +81,7 @@ public:
     void resetExpectSpeechState();
     bool isExpectSpeechState();
     ListeningState getListeningState();
+    std::string getListeningStateStr(ListeningState state);
 
     void setASRState(ASRState state);
     ASRState getASRState();


### PR DESCRIPTION
The server is sent the directive `System.Exception` when the event
`ASR.StopRecognize` is sent after the directive stream is closed.
To prevent this, ASRAgent notify to the server by sending attachment
with end instead of closing the directive stream forcely.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>