### PR TITLE
playstack:reset PlayStackManager Timer started flag

### DIFF
--- a/src/core/nugu_timer.hh
+++ b/src/core/nugu_timer.hh
@@ -39,7 +39,7 @@ public:
     void restart(unsigned int sec = 0) override;
 
     void setCallback(timer_callback cb) override;
-    void notifyCallback();
+    virtual void notifyCallback();
 
 private:
     static void timerCallback(void* userdata);

--- a/src/core/playstack_manager.cc
+++ b/src/core/playstack_manager.cc
@@ -74,6 +74,12 @@ void PlayStackManager::StackTimer::stop()
     is_started = false;
 }
 
+void PlayStackManager::StackTimer::notifyCallback()
+{
+    NUGUTimer::notifyCallback();
+    is_started = false;
+}
+
 /*******************************************************************************
  * Define PlayStackManager
  *******************************************************************************/

--- a/src/core/playstack_manager.hh
+++ b/src/core/playstack_manager.hh
@@ -81,6 +81,7 @@ private:
         bool isStarted();
         void start(unsigned int sec = 0) override;
         void stop() override;
+        void notifyCallback() override;
 
     private:
         bool is_started = false;


### PR DESCRIPTION
In StackTimer of PlayStackManager, after the timer is activated,
is_started flag is not reset, it invoke abnormal behavio in some case.

So, It override notifyCallback method from NUGUTimer
and set is_started to false when this method is called.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>