### PR TITLE
playstack:adjust checking next display info

### DIFF
--- a/src/core/playstack_manager.cc
+++ b/src/core/playstack_manager.cc
@@ -163,7 +163,7 @@ bool PlayStackManager::add(const std::string& ps_id, NuguDirective* ndir)
         return false;
     }
 
-    has_adding_playstack = true;
+    has_adding_playstack = hasDisplayRenderingInfo(ndir);
 
     handlePreviousStack(is_stacked);
     return addToContainer(ps_id, layer);
@@ -209,15 +209,7 @@ bool PlayStackManager::isStackedCondition(NuguDirective* ndir)
 
 bool PlayStackManager::hasExpectSpeech(NuguDirective* ndir)
 {
-    if (!ndir) {
-        nugu_warn("The directive is empty.");
-        return false;
-    }
-
-    const char* tmp_ndir_groups = nugu_directive_peek_groups(ndir);
-    std::string ndir_groups = tmp_ndir_groups ? tmp_ndir_groups : "";
-
-    return ndir_groups.find("ASR.ExpectSpeech") != std::string::npos;
+    return hasKeyword(ndir, { "ASR.ExpectSpeech" });
 }
 
 void PlayStackManager::stopHolding()
@@ -308,6 +300,28 @@ void PlayStackManager::handlePreviousStack(bool is_stacked)
 
         clearContainer();
     }
+}
+
+bool PlayStackManager::hasDisplayRenderingInfo(NuguDirective* ndir)
+{
+    return hasKeyword(ndir, { "Display", "AudioPlayer" });
+}
+
+bool PlayStackManager::hasKeyword(NuguDirective* ndir, std::vector<std::string>&& keywords)
+{
+    if (!ndir) {
+        nugu_warn("The directive is empty.");
+        return false;
+    }
+
+    const char* tmp_ndir_groups = nugu_directive_peek_groups(ndir);
+    std::string ndir_groups = tmp_ndir_groups ? tmp_ndir_groups : "";
+
+    for (const auto& keyword : keywords)
+        if (ndir_groups.find(keyword) != std::string::npos)
+            return true;
+
+    return false;
 }
 
 bool PlayStackManager::addToContainer(const std::string& ps_id, PlayStackLayer layer)

--- a/src/core/playstack_manager.hh
+++ b/src/core/playstack_manager.hh
@@ -91,6 +91,8 @@ private:
     PlayStackLayer extractPlayStackLayer(NuguDirective* ndir);
     std::string getNoneMediaLayerStack();
     void handlePreviousStack(bool is_stacked);
+    bool hasDisplayRenderingInfo(NuguDirective* ndir);
+    bool hasKeyword(NuguDirective* ndir, std::vector<std::string>&& keywords);
     bool addToContainer(const std::string& ps_id, PlayStackLayer layer);
     void removeFromContainer(const std::string& ps_id);
     void notifyStackRemoved(const std::string& ps_id);


### PR DESCRIPTION
It some case, even if it has no display rendering info,
it decide to has that info.

So, it adjust to check whether the directive has Display
or AudioPlayer when new playstack is added for correct judgement.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>