### PR TITLE
playstack:Add method for changing playstack hold time

### DIFF
--- a/src/core/playstack_manager.cc
+++ b/src/core/playstack_manager.cc
@@ -197,7 +197,7 @@ void PlayStackManager::remove(const std::string& ps_id, PlayStackRemoveMode mode
         });
 
         has_long_timer = (mode == PlayStackRemoveMode::Later);
-        timer->setInterval(has_long_timer ? LONG_HOLD_TIME : DEFAULT_HOLD_TIME);
+        timer->setInterval((has_long_timer ? hold_times_sec.long_time : hold_times_sec.normal_time) * NUGU_TIMER_UNIT_SEC);
         timer->start();
     }
 }
@@ -237,6 +237,16 @@ bool PlayStackManager::isActiveHolding()
 bool PlayStackManager::hasAddingPlayStack()
 {
     return has_adding_playstack;
+}
+
+void PlayStackManager::setPlayStackHoldTime(PlayStakcHoldTimes&& hold_times_sec)
+{
+    this->hold_times_sec = hold_times_sec;
+}
+
+PlayStackManager::PlayStakcHoldTimes PlayStackManager::getPlayStackHoldTime()
+{
+    return hold_times_sec;
 }
 
 PlayStackLayer PlayStackManager::getPlayStackLayer(const std::string& ps_id)

--- a/src/core/playstack_manager.hh
+++ b/src/core/playstack_manager.hh
@@ -50,6 +50,10 @@ public:
 class PlayStackManager {
 public:
     using PlayStack = std::pair<std::map<std::string, PlayStackLayer>, std::vector<std::string>>;
+    using PlayStakcHoldTimes = struct {
+        unsigned int normal_time;
+        unsigned int long_time;
+    };
 
 public:
     PlayStackManager();
@@ -69,6 +73,8 @@ public:
     void resetHolding();
     bool isActiveHolding();
     bool hasAddingPlayStack();
+    void setPlayStackHoldTime(PlayStakcHoldTimes&& hold_times_sec);
+    PlayStakcHoldTimes getPlayStackHoldTime();
 
     PlayStackLayer getPlayStackLayer(const std::string& ps_id);
     std::vector<std::string> getAllPlayStackItems();
@@ -103,12 +109,13 @@ private:
     template <typename T>
     void removeItemInList(std::vector<T>& list, const T& item);
 
-    const unsigned int DEFAULT_HOLD_TIME = 7 * NUGU_TIMER_UNIT_SEC;
-    const unsigned int LONG_HOLD_TIME = 600 * NUGU_TIMER_UNIT_SEC;
+    const unsigned int DEFAULT_NORMAL_HOLD_TIME_SEC = 7;
+    const unsigned int DEFAULT_LONG_HOLD_TIME_SEC = 600;
 
     PlayStack playstack_container;
     std::vector<IPlayStackManagerListener*> listeners;
     std::unique_ptr<IStackTimer> timer = nullptr;
+    PlayStakcHoldTimes hold_times_sec { DEFAULT_NORMAL_HOLD_TIME_SEC, DEFAULT_LONG_HOLD_TIME_SEC };
 
     bool has_long_timer = false;
     bool has_holding = false;

--- a/tests/core/test_core_playstack_manager.cc
+++ b/tests/core/test_core_playstack_manager.cc
@@ -75,7 +75,6 @@ typedef struct {
     NuguDirective* ndir_media;
     NuguDirective* ndir_disp;
     NuguDirective* ndir_expect_speech;
-
 } TestFixture;
 
 static void setup(TestFixture* fixture, gconstpointer user_data)
@@ -291,6 +290,20 @@ static void test_playstack_manager_check_adding_playstack(TestFixture* fixture, 
     g_assert(!fixture->playstack_manager->hasAddingPlayStack());
 }
 
+static void test_playstack_manager_adjust_playstack_hold_time(TestFixture* fixture, gconstpointer ignored)
+{
+    // check default hold times
+    auto hold_times = fixture->playstack_manager->getPlayStackHoldTime();
+    g_assert(hold_times.normal_time == 7);
+    g_assert(hold_times.long_time == 600);
+
+    // check custom hold times
+    fixture->playstack_manager->setPlayStackHoldTime({ 5, 10 });
+    hold_times = fixture->playstack_manager->getPlayStackHoldTime();
+    g_assert(hold_times.normal_time == 5);
+    g_assert(hold_times.long_time == 10);
+}
+
 static void test_playstack_manager_reset(TestFixture* fixture, gconstpointer ignored)
 {
     const auto& playstack_container = fixture->playstack_manager->getPlayStackContainer();
@@ -330,6 +343,7 @@ int main(int argc, char* argv[])
     G_TEST_ADD_FUNC("/core/PlayStackManager/checkStack", test_playstack_manager_check_stack);
     G_TEST_ADD_FUNC("/core/PlayStackManager/checkExpectSpeech", test_playstack_manager_check_expect_speech);
     G_TEST_ADD_FUNC("/core/PlayStackManager/checkAddingPlayStack", test_playstack_manager_check_adding_playstack);
+    G_TEST_ADD_FUNC("/core/PlayStackManager/adjustPlayStackHoldTime", test_playstack_manager_adjust_playstack_hold_time);
     G_TEST_ADD_FUNC("/core/PlayStackManager/reset", test_playstack_manager_reset);
 
     return g_test_run();

--- a/tests/core/test_core_playsync_manager.cc
+++ b/tests/core/test_core_playsync_manager.cc
@@ -208,6 +208,7 @@ static void setup(TestFixture* fixture, gconstpointer user_data)
 
     PlayStackManager* playstack_manager = new PlayStackManager();
     playstack_manager->setTimer(fixture->fake_timer);
+    playstack_manager->setPlayStackHoldTime({ 7, 60 });
     fixture->ic_manager->addListener(fixture->ic_manager_listener.get());
 
     fixture->playsync_manager->setPlayStackManager(playstack_manager);


### PR DESCRIPTION
It add the setPlayStackHoldTime in PlayStackManager
for changing playstack hold time. (Default normal:7s, long:600s)

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>