### PR TITLE
TTS:fix handling TTS.Stop directive

### DIFF
--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -465,6 +465,8 @@ void TTSAgent::parsingStop(const char* message)
         return;
     }
 
+    speak_dir = getNuguDirective();
+
     if (!root["playServiceId"].empty())
         ps_id = root["playServiceId"].asString();
 


### PR DESCRIPTION
When handling TTS.Stop directive, if TTS.Speak directive
is processing, that previous directive is canceled.

Because, the member variable 'speak_dir' has the pointer
of previous directive even if that is canceled,
it cause dangling problem in TTS.Stop.

So, it fix to refresh 'speak_dir' for pointing correct object
when handling TTS.Stop.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>