### PR TITLE
ASRAgent:Add EPD Attribute setter/getter

### DIFF
--- a/include/capability/asr_interface.hh
+++ b/include/capability/asr_interface.hh
@@ -73,8 +73,6 @@ typedef struct {
     std::string epd_type; /**< Epd type : CLIENT, SERVER */
     std::string asr_encoding; /**< Asr encoding type : PARTIAL, COMPLETE */
     int response_timeout; /**< Server response timeout about speech */
-    int epd_timeout; /**< epd timeout sec */
-    int epd_max_duration; /**< epd max duration sec */
 } ASRAttribute;
 
 /**
@@ -181,10 +179,16 @@ public:
     virtual void setAttribute(ASRAttribute&& attribute) = 0;
 
     /**
-     * @brief Get epd silence interval
-     * @return Interval milliseconds
+     * @brief Set EPD attribute
+     * @param[in] attribute EPD attribute
      */
-    virtual long getEpdSilenceInterval() = 0;
+    virtual void setEpdAttribute(EpdAttribute&& attribute) = 0;
+
+    /**
+     * @brief Get EPD attribute
+     * @return EPD attribute
+     */
+    virtual EpdAttribute getEpdAttribute() = 0;
 };
 
 /**

--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -52,10 +52,6 @@ void ASRAgent::setAttribute(ASRAttribute&& attribute)
 
     if (attribute.response_timeout > 0)
         response_timeout = attribute.response_timeout;
-
-    // It just bypass, because the validation is checked in createSpeechRecognizer().
-    epd_attribute.epd_timeout = attribute.epd_timeout;
-    epd_attribute.epd_max_duration = attribute.epd_max_duration;
 }
 
 void ASRAgent::initialize()
@@ -227,7 +223,7 @@ void ASRAgent::executeOnForegroundAction(bool asr_user)
 
     std::string id = "id#" + std::to_string(uniq++);
     setListeningId(id);
-    speech_recognizer->setEpdAttribute({ epd_attribute.epd_timeout, epd_attribute.epd_max_duration, epd_attribute.epd_pause_length });
+    speech_recognizer->setEpdAttribute(epd_attribute);
     speech_recognizer->startListening(id);
 
     asr_cancel = false;
@@ -484,13 +480,17 @@ void ASRAgent::removeListener(IASRListener* listener)
         asr_listeners.erase(iterator);
 }
 
-long ASRAgent::getEpdSilenceInterval()
+void ASRAgent::setEpdAttribute(EpdAttribute&& attribute)
 {
-    if (speech_recognizer) {
-        EpdAttribute attribute = speech_recognizer->getEpdAttribute();
-        return attribute.epd_pause_length;
-    }
-    return 0;
+    default_epd_attribute = attribute;
+
+    if (!isExpectSpeechState())
+        epd_attribute = attribute;
+}
+
+EpdAttribute ASRAgent::getEpdAttribute()
+{
+    return default_epd_attribute;
 }
 
 std::vector<IASRListener*> ASRAgent::getListener()

--- a/src/capability/asr_agent.hh
+++ b/src/capability/asr_agent.hh
@@ -76,7 +76,8 @@ public:
     void setCapabilityListener(ICapabilityListener* clistener) override;
     void addListener(IASRListener* listener) override;
     void removeListener(IASRListener* listener) override;
-    long getEpdSilenceInterval() override;
+    void setEpdAttribute(EpdAttribute&& attribute) override;
+    EpdAttribute getEpdAttribute() override;
     std::vector<IASRListener*> getListener();
 
     void resetExpectSpeechState();
@@ -106,12 +107,12 @@ private:
     void cancelRecognition();
 
     class FocusListener : public IFocusResourceListener {
-        public:
-            FocusListener(ASRAgent* asr_agent, IFocusManager* focus_manager, bool asr_user);
-            FocusListener() = default;
-            virtual ~FocusListener() = default;
+    public:
+        FocusListener(ASRAgent* asr_agent, IFocusManager* focus_manager, bool asr_user);
+        FocusListener() = default;
+        virtual ~FocusListener() = default;
 
-            void onFocusChanged(FocusState state) override;
+        void onFocusChanged(FocusState state) override;
 
         ASRAgent* asr_agent = nullptr;
         IFocusManager* focus_manager = nullptr;


### PR DESCRIPTION
Because it needs to get or set EPD attribute of SDK in Application,
it add setEpdAttribute and getEpdAttribute methods in IASRHandler.

Also, the getEpdSilenceInterval method is replaced by getEpdAttribute.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>