### PR TITLE
capabiliy:reinforce destroyDirective

### DIFF
--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -214,7 +214,6 @@ void AudioPlayerAgent::onFocusChanged(FocusState state)
         break;
     case FocusState::NONE:
         if (speak_dir) {
-            nugu_directive_remove_data_callback(speak_dir);
             destroyDirective(speak_dir);
             speak_dir = nullptr;
         }

--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -476,7 +476,6 @@ void TTSAgent::parsingStop(const char* message)
 void TTSAgent::postProcessDirective(bool is_cancel)
 {
     if (speak_dir) {
-        nugu_directive_remove_data_callback(speak_dir);
         destroyDirective(speak_dir, is_cancel);
         speak_dir = nullptr;
     }

--- a/src/clientkit/capability.cc
+++ b/src/clientkit/capability.cc
@@ -352,12 +352,15 @@ void Capability::processDirective(NuguDirective* ndir)
 
 void Capability::destroyDirective(NuguDirective* ndir, bool is_cancel)
 {
-    if (ndir == pimpl->cur_ndir)
-        pimpl->cur_ndir = NULL;
+    if (pimpl->cur_ndir && ndir == pimpl->cur_ndir) {
+        nugu_directive_remove_data_callback(pimpl->cur_ndir);
 
-    is_cancel
-        ? directive_sequencer->cancel(nugu_directive_peek_dialog_id(ndir))
-        : directive_sequencer->complete(ndir);
+        is_cancel
+            ? directive_sequencer->cancel(nugu_directive_peek_dialog_id(pimpl->cur_ndir))
+            : directive_sequencer->complete(pimpl->cur_ndir);
+
+        pimpl->cur_ndir = nullptr;
+    }
 
     if (pimpl->prev_ndir) {
         directive_sequencer->complete(pimpl->prev_ndir);


### PR DESCRIPTION
If destroyDirective method is called more than once,
it could be operated abnormally.

So, it add the validation check and make a group the related flow.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>