### PR TITLE
AudioPlayer:apply media pause playstack policy

### DIFF
--- a/include/clientkit/playsync_manager_interface.hh
+++ b/include/clientkit/playsync_manager_interface.hh
@@ -176,6 +176,11 @@ public:
     virtual void resetHolding() = 0;
 
     /**
+     * @brief Clear timer for releasing sync.
+     */
+    virtual void clearHolding() = 0;
+
+    /**
      * @brief Check whether the previous dialog has to be handled or not
      * @param[in] prev_ndir preivous directive
      * @param[in] cur_ndir current directive

--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -1343,6 +1343,8 @@ void AudioPlayerAgent::mediaStateChanged(MediaPlayerState state)
         break;
     case MediaPlayerState::PLAYING:
         cur_aplayer_state = AudioPlayerState::PLAYING;
+        playsync_manager->clearHolding();
+
         if (is_paused_by_unfocus) {
             nugu_dbg("force setting previous state for notify to application");
             prev_aplayer_state = AudioPlayerState::PAUSED;
@@ -1356,6 +1358,12 @@ void AudioPlayerAgent::mediaStateChanged(MediaPlayerState state)
         break;
     case MediaPlayerState::PAUSED:
         cur_aplayer_state = AudioPlayerState::PAUSED;
+
+        if (is_paused_by_unfocus) {
+            playsync_manager->continueRelease();
+            playsync_manager->releaseSyncLater(ps_id, getName());
+        }
+
         if (!is_paused && !is_paused_by_unfocus)
             sendEventPlaybackPaused();
         break;

--- a/src/core/playstack_manager.cc
+++ b/src/core/playstack_manager.cc
@@ -187,9 +187,6 @@ void PlayStackManager::remove(const std::string& ps_id, PlayStackRemoveMode mode
         }
     } else if (!is_expect_speech && isStackedCondition(ps_id)) {
         removeFromContainer(ps_id);
-
-        if (has_long_timer)
-            timer->start();
     } else {
         timer->setCallback([&, ps_id]() {
             removeFromContainer(ps_id);
@@ -214,7 +211,7 @@ bool PlayStackManager::hasExpectSpeech(NuguDirective* ndir)
 
 void PlayStackManager::stopHolding()
 {
-    if (timer->isStarted()) {
+    if (timer->isStarted() && !has_long_timer) {
         timer->stop();
         has_holding = true;
     }
@@ -227,6 +224,12 @@ void PlayStackManager::resetHolding()
         is_expect_speech = false;
         has_holding = false;
     }
+}
+
+void PlayStackManager::clearHolding()
+{
+    timer->stop();
+    has_long_timer = false;
 }
 
 bool PlayStackManager::isActiveHolding()

--- a/src/core/playstack_manager.hh
+++ b/src/core/playstack_manager.hh
@@ -71,6 +71,7 @@ public:
     bool hasExpectSpeech(NuguDirective* ndir);
     void stopHolding();
     void resetHolding();
+    void clearHolding();
     bool isActiveHolding();
     bool hasAddingPlayStack();
     void setPlayStackHoldTime(PlayStakcHoldTimes&& hold_times_sec);

--- a/src/core/playsync_manager.cc
+++ b/src/core/playsync_manager.cc
@@ -183,6 +183,11 @@ void PlaySyncManager::resetHolding()
     playstack_manager->resetHolding();
 }
 
+void PlaySyncManager::clearHolding()
+{
+    playstack_manager->clearHolding();
+}
+
 bool PlaySyncManager::hasPostPoneRelease()
 {
     return release_postponed || postponed_release_func;

--- a/src/core/playsync_manager.hh
+++ b/src/core/playsync_manager.hh
@@ -56,6 +56,7 @@ public:
     void continueRelease() override;
     void stopHolding() override;
     void resetHolding() override;
+    void clearHolding() override;
     bool hasPostPoneRelease();
 
     bool isConditionToHandlePrevDialog(NuguDirective* prev_ndir, NuguDirective* cur_ndir) override;

--- a/tests/core/test_core_playstack_manager.cc
+++ b/tests/core/test_core_playstack_manager.cc
@@ -240,6 +240,10 @@ static void test_playstack_manager_control_holding(TestFixture* fixture, gconstp
     // reset holding
     fixture->playstack_manager->resetHolding();
     g_assert(fixture->playstack_manager->isActiveHolding());
+
+    // clear holding
+    fixture->playstack_manager->clearHolding();
+    g_assert(!fixture->playstack_manager->isActiveHolding());
 }
 
 static void test_playstack_manager_check_stack(TestFixture* fixture, gconstpointer ignored)

--- a/tests/core/test_core_playsync_manager.cc
+++ b/tests/core/test_core_playsync_manager.cc
@@ -485,6 +485,26 @@ static void test_playstack_manager_release_sync_later(TestFixture* fixture, gcon
     g_assert(fixture->playsync_manager_listener->getSyncState("ps_id_1") == PlaySyncState::Released);
 }
 
+static void test_playstack_manager_implicit_release_sync_later(TestFixture* fixture, gconstpointer ignored)
+{
+    fixture->playsync_manager->prepareSync("ps_id_1", fixture->ndir_media);
+    fixture->playsync_manager->startSync("ps_id_1", "TTS");
+    fixture->playsync_manager->startSync("ps_id_1", "AudioPlayer");
+    g_assert(fixture->playsync_manager_listener->getSyncState("ps_id_1") == PlaySyncState::Synced);
+
+    fixture->playsync_manager->postPoneRelease();
+    fixture->playsync_manager->continueRelease();
+    fixture->playsync_manager->releaseSyncLater("ps_id_1", "AudioPlayer");
+    fixture->playsync_manager->clearHolding();
+    g_assert(fixture->playsync_manager_listener->getSyncState("ps_id_1") == PlaySyncState::Synced);
+
+    fixture->playsync_manager->postPoneRelease();
+    fixture->playsync_manager->continueRelease();
+    fixture->playsync_manager->releaseSyncLater("ps_id_1", "AudioPlayer");
+    onTimeElapsed(fixture);
+    g_assert(fixture->playsync_manager_listener->getSyncState("ps_id_1") == PlaySyncState::Released);
+}
+
 static void test_playstack_manager_normal_case(TestFixture* fixture, gconstpointer ignored)
 {
     sub_test_playstack_manager_preset_sync(fixture, "ps_id_1");
@@ -734,6 +754,7 @@ int main(int argc, char* argv[])
     G_TEST_ADD_FUNC("/core/PlayStackManager/releaseSyncImmediately", test_playstack_manager_release_sync_immediately);
     G_TEST_ADD_FUNC("/core/PlayStackManager/releaseSync", test_playstack_manager_release_sync);
     G_TEST_ADD_FUNC("/core/PlayStackManager/releaseSyncLater", test_playstack_manager_release_sync_later);
+    G_TEST_ADD_FUNC("/core/PlayStackManager/implicitReleaseSyncLater", test_playstack_manager_implicit_release_sync_later);
     G_TEST_ADD_FUNC("/core/PlayStackManager/normalCase", test_playstack_manager_normal_case);
     G_TEST_ADD_FUNC("/core/PlayStackManager/stopCase", test_playstack_manager_stop_case);
     G_TEST_ADD_FUNC("/core/PlayStackManager/ignoreRenderCase", test_playstack_manager_ignore_render_case);


### PR DESCRIPTION
It apply the changed media pause playstack policy
which is maintained 10m' timer, even if any events are occurred.

That policy is applied to explicit and implicit both cases.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>