### PR TITLE
core: add missing header includes

### DIFF
--- a/src/core/directive_sequencer.cc
+++ b/src/core/directive_sequencer.cc
@@ -15,6 +15,7 @@
  */
 
 #include <algorithm>
+#include <string>
 
 #include "base/nugu_log.h"
 #include "base/nugu_network_manager.h"

--- a/src/core/tts_player.cc
+++ b/src/core/tts_player.cc
@@ -15,9 +15,11 @@
  */
 
 #include <algorithm>
-#include <glib.h>
 #include <list>
 #include <map>
+
+#include <stdlib.h>
+#include <glib.h>
 
 #include "base/nugu_decoder.h"
 #include "base/nugu_log.h"

--- a/tests/core/test_core_directive_sequencer.cc
+++ b/tests/core/test_core_directive_sequencer.cc
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <string>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Add the missing `#include` for some header files.

Signed-off-by: Inho Oh <inho.oh@sk.com>