### PR TITLE
base: change strdup to g_strdup

### DIFF
--- a/src/base/network/http2/directives_parser.cc
+++ b/src/base/network/http2/directives_parser.cc
@@ -135,7 +135,7 @@ static void on_parsing_header(MultipartParser* parser, const char* data,
         } else if (key.compare("Parent-Message-Id") == 0) {
             if (dp->parent_msg_id)
                 free(dp->parent_msg_id);
-            dp->parent_msg_id = strdup(value.c_str());
+            dp->parent_msg_id = g_strdup(value.c_str());
         } else if (key.compare("Filename") == 0) {
             dp->seq = std::stoi(value);
             if (value.find("end") != std::string::npos)
@@ -257,8 +257,8 @@ static void _body_opus(DirParser* dp, const char* parent_msg_id, int seq,
         return;
     }
 
-    item->parent_msg_id = strdup(parent_msg_id);
-    item->media_type = strdup("audio/opus");
+    item->parent_msg_id = g_strdup(parent_msg_id);
+    item->media_type = g_strdup("audio/opus");
     item->seq = seq;
     item->is_end = is_end;
     item->length = length;
@@ -395,7 +395,7 @@ int dir_parser_set_debug_message(DirParser* dp, const char* msg)
     }
 
     if (msg)
-        dp->debug_msg = strdup(msg);
+        dp->debug_msg = g_strdup(msg);
 
     return 0;
 }

--- a/src/base/network/http2/http2_request.c
+++ b/src/base/network/http2/http2_request.c
@@ -767,7 +767,7 @@ int http2_request_set_msgid(HTTP2Request *req, const char *msgid)
 		free(req->msg_id);
 
 	if (msgid)
-		req->msg_id = strdup(msgid);
+		req->msg_id = g_strdup(msgid);
 	else
 		req->msg_id = NULL;
 
@@ -789,7 +789,7 @@ int http2_request_set_dialogid(HTTP2Request *req, const char *dialogid)
 		free(req->dialog_id);
 
 	if (dialogid)
-		req->dialog_id = strdup(dialogid);
+		req->dialog_id = g_strdup(dialogid);
 	else
 		req->dialog_id = NULL;
 
@@ -812,7 +812,7 @@ int http2_request_set_profiling_contents(HTTP2Request *req,
 		free(req->profiling_contents);
 
 	if (contents)
-		req->profiling_contents = strdup(contents);
+		req->profiling_contents = g_strdup(contents);
 	else
 		req->profiling_contents = NULL;
 

--- a/src/base/network/http2/v1_event.c
+++ b/src/base/network/http2/v1_event.c
@@ -108,10 +108,10 @@ static void _emit_send_result(int code, HTTP2Request *req)
 	event->code = code;
 
 	if (http2_request_peek_msgid(req))
-		event->msg_id = strdup(http2_request_peek_msgid(req));
+		event->msg_id = g_strdup(http2_request_peek_msgid(req));
 
 	if (http2_request_peek_dialogid(req))
-		event->dialog_id = strdup(http2_request_peek_dialogid(req));
+		event->dialog_id = g_strdup(http2_request_peek_dialogid(req));
 
 	if (code == HTTP2_RESPONSE_OK) {
 		event->success = 1;

--- a/src/base/network/http2/v1_event_attachment.c
+++ b/src/base/network/http2/v1_event_attachment.c
@@ -61,7 +61,7 @@ V1EventAttachment *v1_event_attachment_new(const char *host)
 	/* Set maximum timeout to 5 seconds */
 	http2_request_set_timeout(attach->req, 5);
 
-	attach->host = strdup(host);
+	attach->host = g_strdup(host);
 
 	return attach;
 }
@@ -97,7 +97,7 @@ void v1_event_attachment_set_query(V1EventAttachment *attach,
 		endstr = "true";
 
 	attach->seq = seq;
-	attach->msgid = strdup(msg_id);
+	attach->msgid = g_strdup(msg_id);
 
 	tmp = g_strdup_printf("%s/v1/event-attachment" QUERY, attach->host,
 			      name_space, name, dialog_id, msg_id, version,

--- a/src/base/network/http2/v2_events.c
+++ b/src/base/network/http2/v2_events.c
@@ -70,10 +70,10 @@ static void _emit_send_result(int code, HTTP2Request *req)
 	event->code = code;
 
 	if (http2_request_peek_msgid(req))
-		event->msg_id = strdup(http2_request_peek_msgid(req));
+		event->msg_id = g_strdup(http2_request_peek_msgid(req));
 
 	if (http2_request_peek_dialogid(req))
-		event->dialog_id = strdup(http2_request_peek_dialogid(req));
+		event->dialog_id = g_strdup(http2_request_peek_dialogid(req));
 
 	if (code == HTTP2_RESPONSE_OK) {
 		event->success = 1;
@@ -110,14 +110,14 @@ static void _emit_directive_response(HTTP2Request *req, const char *json)
 		event->success = 0;
 
 	if (http2_request_peek_msgid(req))
-		event->event_msg_id = strdup(http2_request_peek_msgid(req));
+		event->event_msg_id = g_strdup(http2_request_peek_msgid(req));
 
 	if (http2_request_peek_dialogid(req))
 		event->event_dialog_id =
-			strdup(http2_request_peek_dialogid(req));
+			g_strdup(http2_request_peek_dialogid(req));
 
 	if (json)
-		event->json = strdup(json);
+		event->json = g_strdup(json);
 
 	if (nugu_equeue_push(NUGU_EQUEUE_TYPE_EVENT_RESPONSE, event) < 0) {
 		nugu_error("nugu_equeue_push failed");

--- a/src/base/nugu_directive.c
+++ b/src/base/nugu_directive.c
@@ -63,14 +63,14 @@ nugu_directive_new(const char *name_space, const char *name,
 	g_return_val_if_fail(groups != NULL, NULL);
 
 	ndir = calloc(1, sizeof(NuguDirective));
-	ndir->name_space = strdup(name_space);
-	ndir->name = strdup(name);
-	ndir->version = strdup(version);
-	ndir->msg_id = strdup(msg_id);
-	ndir->dialog_id = strdup(dialog_id);
-	ndir->referrer_id = strdup(referrer_id);
-	ndir->json = strdup(json);
-	ndir->groups = strdup(groups);
+	ndir->name_space = g_strdup(name_space);
+	ndir->name = g_strdup(name);
+	ndir->version = g_strdup(version);
+	ndir->msg_id = g_strdup(msg_id);
+	ndir->dialog_id = g_strdup(dialog_id);
+	ndir->referrer_id = g_strdup(referrer_id);
+	ndir->json = g_strdup(json);
+	ndir->groups = g_strdup(groups);
 
 	ndir->seq = -1;
 	ndir->is_active = 0;
@@ -226,7 +226,7 @@ EXPORT_API int nugu_directive_set_media_type(NuguDirective *ndir,
 	if (type == NULL)
 		return 0;
 
-	ndir->media_type = strdup(type);
+	ndir->media_type = g_strdup(type);
 
 	return 0;
 }

--- a/src/base/nugu_event.c
+++ b/src/base/nugu_event.c
@@ -85,13 +85,13 @@ EXPORT_API NuguEvent *nugu_event_new(const char *name_space, const char *name,
 		return NULL;
 	}
 
-	nev->name_space = strdup(name_space);
-	nev->name = strdup(name);
+	nev->name_space = g_strdup(name_space);
+	nev->name = g_strdup(name);
 	nev->dialog_id = nugu_uuid_generate_time();
 	nev->msg_id = nugu_uuid_generate_time();
 	nev->referrer_id = NULL;
 	nev->seq = 0;
-	nev->version = strdup(version);
+	nev->version = g_strdup(version);
 	nev->type = NUGU_EVENT_TYPE_DEFAULT;
 
 	return nev;
@@ -149,7 +149,7 @@ EXPORT_API int nugu_event_set_context(NuguEvent *nev, const char *context)
 	if (nev->context)
 		free(nev->context);
 
-	nev->context = strdup(context);
+	nev->context = g_strdup(context);
 
 	return 0;
 }
@@ -169,7 +169,7 @@ EXPORT_API int nugu_event_set_json(NuguEvent *nev, const char *json)
 		free(nev->json);
 
 	if (json)
-		nev->json = strdup(json);
+		nev->json = g_strdup(json);
 	else
 		nev->json = NULL;
 
@@ -196,7 +196,7 @@ EXPORT_API int nugu_event_set_dialog_id(NuguEvent *nev, const char *dialog_id)
 	if (nev->dialog_id)
 		free(nev->dialog_id);
 
-	nev->dialog_id = strdup(dialog_id);
+	nev->dialog_id = g_strdup(dialog_id);
 
 	return 0;
 }
@@ -217,7 +217,7 @@ EXPORT_API int nugu_event_set_referrer_id(NuguEvent *nev,
 		free(nev->referrer_id);
 
 	if (referrer_id)
-		nev->referrer_id = strdup(referrer_id);
+		nev->referrer_id = g_strdup(referrer_id);
 	else
 		nev->referrer_id = NULL;
 

--- a/src/base/nugu_network_manager.c
+++ b/src/base/nugu_network_manager.c
@@ -1092,7 +1092,7 @@ EXPORT_API int nugu_network_manager_set_token(const char *token)
 	if (_network->token)
 		free(_network->token);
 
-	_network->token = strdup(token);
+	_network->token = g_strdup(token);
 
 	/* Reset the Last-Asr-Event-Time header */
 	if (_network->last_asr) {
@@ -1135,11 +1135,11 @@ EXPORT_API int nugu_network_manager_set_registry_url(const char *urlname)
 #ifdef NUGU_ENV_NETWORK_REGISTRY_SERVER
 	override_value = getenv(NUGU_ENV_NETWORK_REGISTRY_SERVER);
 	if (override_value)
-		_network->registry_url = strdup(override_value);
+		_network->registry_url = g_strdup(override_value);
 	else
-		_network->registry_url = strdup(urlname);
+		_network->registry_url = g_strdup(urlname);
 #else
-	_network->registry_url = strdup(urlname);
+	_network->registry_url = g_strdup(urlname);
 #endif
 
 	return 0;
@@ -1182,7 +1182,7 @@ EXPORT_API int nugu_network_manager_set_useragent(const char *app_version,
 #ifdef NUGU_ENV_NETWORK_USERAGENT
 	override_value = getenv(NUGU_ENV_NETWORK_USERAGENT);
 	if (override_value)
-		_network->useragent = strdup(override_value);
+		_network->useragent = g_strdup(override_value);
 	else
 		_network->useragent = g_strdup_printf(NUGU_USERAGENT_FORMAT,
 						      app_version, more_info);

--- a/src/base/nugu_prof.c
+++ b/src/base/nugu_prof.c
@@ -235,7 +235,7 @@ static void _emit_callback(enum nugu_prof_type type, const char *contents)
 	memcpy(data, &_prof_data[type], sizeof(struct nugu_prof_data));
 
 	if (contents)
-		data->contents = strdup(contents);
+		data->contents = g_strdup(contents);
 	else
 		data->contents = NULL;
 

--- a/src/base/nugu_uuid.c
+++ b/src/base/nugu_uuid.c
@@ -175,7 +175,7 @@ EXPORT_API char *nugu_uuid_generate_time(void)
 
 	nugu_uuid_convert_base16(buf, sizeof(buf), base16, sizeof(base16));
 
-	return strdup(base16);
+	return g_strdup(base16);
 }
 
 EXPORT_API int nugu_uuid_fill(const struct timespec *time,


### PR DESCRIPTION
Replace all `strdup` with safe(NULL checked) `g_strdup` function.

Signed-off-by: Inho Oh <inho.oh@sk.com>