### PR TITLE
AudioPlayerAgent: Rollback about context clear

### DIFF
--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -1524,7 +1524,6 @@ void AudioPlayerAgent::onSyncState(const std::string& ps_id, PlaySyncState state
         is_next_play = false;
         focus_manager->releaseFocus(MEDIA_FOCUS_TYPE, CAPABILITY_NAME);
 
-        clearContext();
         clearDisplay(extra_data);
     }
 }


### PR DESCRIPTION
The context is still meaningful to PlayRouter even if the playsync
is released.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>