### PR TITLE
capability:change has_attachment variable name

### DIFF
--- a/include/clientkit/capability.hh
+++ b/include/clientkit/capability.hh
@@ -374,8 +374,8 @@ protected:
     /** @brief whether capability initialized */
     bool initialized = false;
 
-    /** @brief whether has attachment */
-    bool has_attachment = false;
+    /** @brief whether destroy received directive by agent */
+    bool destroy_directive_by_agent = false;
 
     /** @brief whether capability suspend */
     bool suspended = false;

--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -866,7 +866,7 @@ void AudioPlayerAgent::parsingPlay(const char* message)
     }
 
     if (source_type == "ATTACHMENT") {
-        has_attachment = true;
+        destroy_directive_by_agent = true;
 
         nugu_dbg("    token => %s", token.c_str());
         nugu_dbg("cur_token => %s", cur_token.c_str());
@@ -942,7 +942,7 @@ void AudioPlayerAgent::parsingPlay(const char* message)
     cur_token = token;
     ps_id = play_service_id;
 
-    if (has_attachment) {
+    if (destroy_directive_by_agent) {
         cur_player = dynamic_cast<IMediaPlayer*>(tts_player);
         is_tts_activate = true;
         speak_dir = getNuguDirective();

--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -415,7 +415,7 @@ void TTSAgent::parsingSpeak(const char* message)
         return;
     }
 
-    has_attachment = true;
+    destroy_directive_by_agent = true;
     speak_dir = nullptr;
 
     // set referrer id previous dialog_id

--- a/src/clientkit/capability.cc
+++ b/src/clientkit/capability.cc
@@ -157,7 +157,7 @@ void Capability::setNuguCoreContainer(INuguCoreContainer* core_container)
 
 void Capability::initialize()
 {
-    has_attachment = false;
+    destroy_directive_by_agent = false;
     suspended = false;
     suspend_policy = SuspendPolicy::STOP;
 
@@ -341,11 +341,11 @@ void Capability::processDirective(NuguDirective* ndir)
 
         setReferrerDialogRequestId(nugu_directive_peek_name(ndir), nugu_directive_peek_dialog_id(ndir));
 
-        has_attachment = false;
+        destroy_directive_by_agent = false;
         parsingDirective(dname, message);
 
-        // the directive with attachment should destroy by agent
-        if (!has_attachment)
+        // if 'destroy_directive_by_agent' is set to true, the related agent should destroy it by self.
+        if (!destroy_directive_by_agent)
             destroyDirective(ndir);
     }
 }


### PR DESCRIPTION
It some case, it has to destroy directive by agent,
and the "has_attachment" variable is used for this purpose
in TTSAgent and AudioPlayerAgent.

But, in another case, even if it doesn't have attachment,
as it need to destroy directive byself,
the "has_attachment" variable name is not appropriate in this case.

So it change that variable name to destroy_directive_by_agent.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>