### PR TITLE
Utility:Add Utility Interface and Agent.

### DIFF
--- a/examples/standalone/capability_collection.cc
+++ b/examples/standalone/capability_collection.cc
@@ -153,6 +153,12 @@ void CapabilityCollection::composeCapabilityFactory()
 
         return display_handler.get();
     });
+    factories.emplace("Utility", [&]() {
+        if (!utility_handler)
+            utility_handler = makeCapability<UtilityAgent, IUtilityHandler>(nullptr);
+
+        return utility_handler.get();
+    });
 }
 
 SpeakerInfo CapabilityCollection::makeSpeakerInfo(SpeakerType type, int muted, bool can_control)

--- a/examples/standalone/capability_collection.hh
+++ b/examples/standalone/capability_collection.hh
@@ -21,7 +21,7 @@
 #include <map>
 #include <memory>
 
-#include <capability/session_interface.hh>
+#include <capability/utility_interface.hh>
 
 #include "audio_player_listener.hh"
 #include "display_listener.hh"
@@ -65,6 +65,7 @@ private:
     std::shared_ptr<ISoundHandler> sound_handler = nullptr;
     std::shared_ptr<ISessionHandler> session_handler = nullptr;
     std::shared_ptr<IDisplayHandler> display_handler = nullptr;
+    std::shared_ptr<IUtilityHandler> utility_handler = nullptr;
 
     // Capability listener
     std::shared_ptr<SpeechOperator> speech_operator = nullptr;

--- a/include/capability/capability_factory.hh
+++ b/include/capability/capability_factory.hh
@@ -86,6 +86,11 @@ class SessionAgent;
 class DisplayAgent;
 
 /**
+ * @brief UtilityAgent
+ */
+class UtilityAgent;
+
+/**
  * @brief CapabilityFactory
  */
 class CapabilityFactory {

--- a/include/capability/utility_interface.hh
+++ b/include/capability/utility_interface.hh
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NUGU_UTILITY_INTERFACE_H__
+#define __NUGU_UTILITY_INTERFACE_H__
+
+#include <clientkit/capability_interface.hh>
+
+namespace NuguCapability {
+
+using namespace NuguClientKit;
+
+/**
+ * @file utility_interface.hh
+ * @defgroup UtilityInterface UtilityInterface
+ * @ingroup SDKNuguCapability
+ * @brief Utility capability interface
+ *
+ * It's for blocking directive set which is located in the rear.
+ *
+ * @{
+ */
+
+/**
+ * @brief utility listener interface
+ * @see IUtilityHandler
+ */
+class IUtilityListener : public ICapabilityListener {
+    virtual ~IUtilityListener() = default;
+};
+
+/**
+ * @brief utility handler interface
+ * @see IUtilityListener
+ */
+class IUtilityHandler : virtual public ICapabilityInterface {
+public:
+    virtual ~IUtilityHandler() = default;
+};
+
+/**
+ * @}
+ */
+
+} // NuguCapability
+
+#endif /* __NUGU_UTILITY_INTERFACE_H__ */

--- a/src/capability/capability_factory.cc
+++ b/src/capability/capability_factory.cc
@@ -24,6 +24,7 @@
 #include "system_agent.hh"
 #include "text_agent.hh"
 #include "tts_agent.hh"
+#include "utility_agent.hh"
 
 #include "capability/capability_factory.hh"
 
@@ -50,5 +51,6 @@ template IMicHandler* CapabilityFactory::makeCapability<MicAgent, IMicHandler>(I
 template ISoundHandler* CapabilityFactory::makeCapability<SoundAgent, ISoundHandler>(ICapabilityListener* listener);
 template ISessionHandler* CapabilityFactory::makeCapability<SessionAgent, ISessionHandler>(ICapabilityListener* listener);
 template IDisplayHandler* CapabilityFactory::makeCapability<DisplayAgent, IDisplayHandler>(ICapabilityListener* listener);
+template IUtilityHandler* CapabilityFactory::makeCapability<UtilityAgent, IUtilityHandler>(ICapabilityListener* listener);
 
 } // NuguCapability

--- a/src/capability/utility_agent.cc
+++ b/src/capability/utility_agent.cc
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstring>
+
+#include "base/nugu_log.h"
+#include "utility_agent.hh"
+
+namespace NuguCapability {
+
+static const char* CAPABILITY_NAME = "Utility";
+static const char* CAPABILITY_VERSION = "1.0";
+
+UtilityAgent::UtilityAgent()
+    : Capability(CAPABILITY_NAME, CAPABILITY_VERSION)
+{
+}
+
+void UtilityAgent::initialize()
+{
+    if (initialized) {
+        nugu_info("It's already initialized.");
+        return;
+    }
+
+    timer = std::unique_ptr<INuguTimer>(core_container->createNuguTimer(true));
+
+    initialized = true;
+}
+
+void UtilityAgent::deInitialize()
+{
+    if (timer) {
+        timer->stop();
+        timer.reset();
+    }
+
+    ps_id.clear();
+
+    initialized = false;
+}
+
+void UtilityAgent::setCapabilityListener(ICapabilityListener* clistener)
+{
+    if (clistener)
+        utility_listener = dynamic_cast<IUtilityListener*>(clistener);
+}
+
+void UtilityAgent::updateInfoForContext(Json::Value& ctx)
+{
+    Json::Value utility;
+
+    utility["version"] = getVersion();
+    ctx[getName()] = utility;
+}
+
+void UtilityAgent::parsingDirective(const char* dname, const char* message)
+{
+    nugu_dbg("message: %s", message);
+
+    if (!strcmp(dname, "Block"))
+        parsingBlock(message);
+    else
+        nugu_warn("%s[%s] is not support %s directive", getName().c_str(), getVersion().c_str(), dname);
+}
+
+void UtilityAgent::parsingBlock(const char* message)
+{
+    Json::Value root;
+    Json::Reader reader;
+
+    if (!reader.parse(message, root)) {
+        nugu_error("parsing error");
+        return;
+    }
+
+    if (root["playServiceId"].empty()) {
+        nugu_error("There is no mandatory data in directive message");
+        return;
+    }
+
+    ps_id = root["playServiceId"].asString();
+
+    if (!root["sleepInMillisecond"].empty())
+        delayReleasingBlocking(root["sleepInMillisecond"].asLargestInt());
+}
+
+void UtilityAgent::delayReleasingBlocking(long sleep_time_msec)
+{
+    if (sleep_time_msec <= 0 || !timer)
+        return;
+
+    destroy_directive_by_agent = true;
+
+    timer->setCallback([&]() {
+        destroyDirective(getNuguDirective());
+    });
+    timer->setInterval(sleep_time_msec);
+    timer->start();
+}
+
+} // NuguCapability

--- a/src/capability/utility_agent.hh
+++ b/src/capability/utility_agent.hh
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NUGU_UTILITY_AGENT_H__
+#define __NUGU_UTILITY_AGENT_H__
+
+#include "capability/utility_interface.hh"
+#include "clientkit/capability.hh"
+
+namespace NuguCapability {
+
+class UtilityAgent final : public Capability,
+                           public IUtilityHandler {
+
+public:
+    UtilityAgent();
+    virtual ~UtilityAgent() = default;
+
+    void initialize() override;
+    void deInitialize() override;
+    void setCapabilityListener(ICapabilityListener* clistener) override;
+    void updateInfoForContext(Json::Value& ctx) override;
+    void parsingDirective(const char* dname, const char* message) override;
+
+private:
+    void parsingBlock(const char* message);
+    void delayReleasingBlocking(long sleep_time_msec);
+
+    IUtilityListener* utility_listener = nullptr;
+    std::unique_ptr<INuguTimer> timer = nullptr;
+    std::string ps_id;
+};
+
+} // NuguCapability
+
+#endif /* __NUGU_UTILITY_AGENT_H__ */


### PR DESCRIPTION
It add utility interface(It's composed by IUtilityHandler and
IUtilityListener) and UtilityAgent.
It apply Utility Interface v1.0 spec.

For correct activation, it has to update DirectiveSequencer.
So, in this commit, it skip constructing agent by NuguClient.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>