### PR TITLE
TextAgent:remove validation check for text and token

### DIFF
--- a/src/capability/text_agent.cc
+++ b/src/capability/text_agent.cc
@@ -155,11 +155,6 @@ std::string TextAgent::requestTextInput(const std::string& text, const std::stri
         return "";
     }
 
-    if (text.size() == 0) {
-        nugu_error("The mandatory data is not exist.");
-        return "";
-    }
-
     if (timer)
         timer->start();
 
@@ -302,7 +297,7 @@ void TextAgent::parsingTextRedirect(const char* message)
 
 bool TextAgent::handleTextCommonProcess(const TextInputParam& text_input_param)
 {
-    if (text_input_param.text.empty() || text_input_param.token.empty()) {
+    if (text_input_param.token.empty()) {
         nugu_error("There is no mandatory data in directive message");
         return false;
     }


### PR DESCRIPTION
As the request for handling blank text,
it remove validation check for text field size.

Also, the token field is not mandatory, there are no reason

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>