### PR TITLE
core: add ANY medium to DirectiveSequencer

### DIFF
--- a/src/capability/utility_agent.cc
+++ b/src/capability/utility_agent.cc
@@ -38,6 +38,8 @@ void UtilityAgent::initialize()
 
     timer = std::unique_ptr<INuguTimer>(core_container->createNuguTimer(true));
 
+    addBlockingPolicy("Block", { BlockingMedium::ANY, true });
+
     initialized = true;
 }
 

--- a/src/core/directive_sequencer.hh
+++ b/src/core/directive_sequencer.hh
@@ -17,7 +17,6 @@
 #ifndef __NUGU_DIRECTIVE_SEQUENCER_H__
 #define __NUGU_DIRECTIVE_SEQUENCER_H__
 
-#include <deque>
 #include <map>
 #include <vector>
 
@@ -29,6 +28,9 @@ namespace NuguCore {
 
 using namespace NuguClientKit;
 
+class LookupTable;
+class DialogDirectiveList;
+
 class DirectiveSequencer : public IDirectiveSequencer {
 
 public:
@@ -36,6 +38,7 @@ public:
     virtual ~DirectiveSequencer();
 
     void reset();
+
     void addListener(const std::string& name_space, IDirectiveSequencerListener* listener) override;
     void removeListener(const std::string& name_space, IDirectiveSequencerListener* listener) override;
 
@@ -47,8 +50,6 @@ public:
     bool add(NuguDirective* ndir) override;
 
     using BlockingPolicyMap = std::map<std::string, std::map<std::string, BlockingPolicy>>;
-    using DialogQueueMap = std::map<std::string, std::deque<NuguDirective*>>;
-    using MsgidDirectiveMap = std::map<std::string, NuguDirective*>;
 
 private:
     /**
@@ -60,27 +61,20 @@ private:
     BlockingPolicyMap policy_map;
 
     /**
-     * ["namespace"] = IDirectiveSequencerListener*
+     * ["namespace"] = [ IDirectiveSequencerListener*, ... ]
      */
     std::map<std::string, std::vector<IDirectiveSequencerListener*>> listeners_map;
 
     /**
-     * Lookup table for directive searching when receive an attachment
-     * ["message-id"] = NuguDirective*
+     * Message-id lookup table for directive searching when receive an attachment
      */
-    MsgidDirectiveMap msgid_directive_map;
+    LookupTable* msgid_lookup;
 
     /**
-     * Pending directive queue for dialog-id
-     *   audio_map["dialog-id-a"] = [
-     *     directive-1(block), directive-2(non-block)
-     *   ]
-     *   audio_map["dialog-id-b"] = [ directive-4(block) ]
-     *   visual_map["dialog-id-a"] = [ directive-3(block) ]
-     *   visual_map["dialog-id-b"] = []
+     * Pending / Active directive queue for dialog-id
      */
-    DialogQueueMap audio_map;
-    DialogQueueMap visual_map;
+    DialogDirectiveList* pending;
+    DialogDirectiveList* active;
 
     /**
      * Scheduled directive lists to handle in next idle time


### PR DESCRIPTION
The `BlockingMedium::ANY` type was added to the spec document.
This type is blocked by all other types(Audio/Visual/None/Any),
and all other types can be blocked.

e.g. When the sequencer receives a list of directives as below
for the dialog ID:

    [
      1:Audio/block,
      2:Any/block,
      3:None/non-block,
      4:Any/block,
      5:None/non-block
    ]

Directives are processed in the following order.

    Start-1 -> Complete-1
    -> Start-2 -> Complete-2
    *)-> Start-3 -> Complete-3
    -> Start-4 -> Complete-4
    -> Start-5 -> Complete-5

*) Even in the case of a non-block, if there is an ANY behind it,
   the ANY must be processed after the non-block is completed.

Signed-off-by: Inho Oh <inho.oh@sk.com>