### PR TITLE
base: add policy to NuguDirective

### DIFF
--- a/include/base/nugu_directive.h
+++ b/include/base/nugu_directive.h
@@ -45,6 +45,17 @@ extern "C" {
 typedef struct _nugu_directive NuguDirective;
 
 /**
+ * @brief event types
+ */
+enum nugu_directive_medium {
+	NUGU_DIRECTIVE_MEDIUM_AUDIO = 0, /**< BlockingPolicy AUDIO medium */
+	NUGU_DIRECTIVE_MEDIUM_VISUAL = 1, /**< BlockingPolicy VISUAL medium */
+	NUGU_DIRECTIVE_MEDIUM_NONE = 2, /**< BlockingPolicy NONE medium */
+	NUGU_DIRECTIVE_MEDIUM_ANY = 3, /**< BlockingPolicy ANY medium */
+	NUGU_DIRECTIVE_MEDIUM_MAX, /**< maximum value for medium */
+};
+
+/**
  * @brief Callback prototype for receiving an attachment
  */
 typedef void (*NuguDirectiveDataCallback)(NuguDirective *ndir, int seq,
@@ -235,6 +246,52 @@ unsigned char *nugu_directive_get_data(NuguDirective *ndir, size_t *length);
  * @see nugu_directive_get_data()
  */
 size_t nugu_directive_get_data_size(NuguDirective *ndir);
+
+/**
+ * @brief Set the medium of BlockingPolicy for the directive
+ * @param[in] ndir directive object
+ * @param[in] medium medium of BlockingPolicy
+ * @param[in] is_block blocking status (1 = block, 0 = non-block)
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ * @see nugu_directive_get_blocking_medium()
+ * @see nugu_directive_get_blocking_medium_string()
+ * @see nugu_directive_is_blocking()
+ */
+int nugu_directive_set_blocking_policy(NuguDirective *ndir,
+				       enum nugu_directive_medium medium,
+				       int is_block);
+
+/**
+ * @brief Get the medium of BlockingPolicy for the directive
+ * @param[in] ndir directive object
+ * @return medium of BlockingPolicy
+ * @see nugu_directive_set_blocking_policy()
+ * @see nugu_directive_get_blocking_medium_string()
+ */
+enum nugu_directive_medium
+nugu_directive_get_blocking_medium(NuguDirective *ndir);
+
+/**
+ * @brief Get the medium string of BlockingPolicy for the directive
+ * @param[in] ndir directive object
+ * @return medium of BlockingPolicy
+ * @see nugu_directive_set_blocking_policy()
+ * @see nugu_directive_get_blocking_medium()
+ */
+const char *nugu_directive_get_blocking_medium_string(NuguDirective *ndir);
+
+/**
+ * @brief Get the blocking status of BlockingPolicy for the directive
+ * @param[in] ndir directive object
+ * @return blocking status of BlockingPolicy
+ * @retval 0 non-block
+ * @retval 1 block
+ * @retval -1 failure
+ * @see nugu_directive_set_blocking_policy()
+ */
+int nugu_directive_is_blocking(NuguDirective *ndir);
 
 /**
  * @brief Set attachment received event callback

--- a/include/clientkit/directive_sequencer_interface.hh
+++ b/include/clientkit/directive_sequencer_interface.hh
@@ -37,9 +37,10 @@ namespace NuguClientKit {
  * @brief BlockingMedium
  */
 enum class BlockingMedium {
-    AUDIO = 0, /**< Audio related medium */
-    VISUAL = 1, /**< Visual related medium */
-    NONE = 2 /**< None medium */
+    AUDIO = NUGU_DIRECTIVE_MEDIUM_AUDIO, /**< Audio related medium */
+    VISUAL = NUGU_DIRECTIVE_MEDIUM_VISUAL, /**< Visual related medium */
+    NONE = NUGU_DIRECTIVE_MEDIUM_NONE, /**< None medium */
+    ANY = NUGU_DIRECTIVE_MEDIUM_ANY /**< Any medium */
 };
 
 /**

--- a/src/base/nugu_directive.c
+++ b/src/base/nugu_directive.c
@@ -34,6 +34,9 @@ struct _nugu_directive {
 	char *referrer_id;
 	char *groups;
 
+	enum nugu_directive_medium policy_medium;
+	int is_policy_block;
+
 	int seq;
 	int is_active;
 	int is_end;
@@ -71,6 +74,9 @@ nugu_directive_new(const char *name_space, const char *name,
 	ndir->referrer_id = g_strdup(referrer_id);
 	ndir->json = g_strdup(json);
 	ndir->groups = g_strdup(groups);
+
+	ndir->policy_medium = NUGU_DIRECTIVE_MEDIUM_NONE;
+	ndir->is_policy_block = 0;
 
 	ndir->seq = -1;
 	ndir->is_active = 0;
@@ -318,6 +324,53 @@ EXPORT_API size_t nugu_directive_get_data_size(NuguDirective *ndir)
 	size = nugu_buffer_get_size(ndir->buf);
 
 	return size;
+}
+
+EXPORT_API int nugu_directive_set_blocking_policy(
+	NuguDirective *ndir, enum nugu_directive_medium medium, int is_block)
+{
+	g_return_val_if_fail(ndir != NULL, -1);
+
+	ndir->policy_medium = medium;
+	ndir->is_policy_block = is_block;
+
+	return 0;
+}
+
+EXPORT_API enum nugu_directive_medium
+nugu_directive_get_blocking_medium(NuguDirective *ndir)
+{
+	g_return_val_if_fail(ndir != NULL, -1);
+
+	return ndir->policy_medium;
+}
+
+EXPORT_API const char *
+nugu_directive_get_blocking_medium_string(NuguDirective *ndir)
+{
+	g_return_val_if_fail(ndir != NULL, NULL);
+
+	switch (ndir->policy_medium) {
+	case NUGU_DIRECTIVE_MEDIUM_ANY:
+		return "ANY";
+	case NUGU_DIRECTIVE_MEDIUM_AUDIO:
+		return "AUDIO";
+	case NUGU_DIRECTIVE_MEDIUM_VISUAL:
+		return "VISUAL";
+	case NUGU_DIRECTIVE_MEDIUM_NONE:
+		return "NONE";
+	default:
+		break;
+	}
+
+	return "----";
+}
+
+EXPORT_API int nugu_directive_is_blocking(NuguDirective *ndir)
+{
+	g_return_val_if_fail(ndir != NULL, -1);
+
+	return ndir->is_policy_block;
 }
 
 EXPORT_API int nugu_directive_set_data_callback(

--- a/src/core/directive_sequencer.cc
+++ b/src/core/directive_sequencer.cc
@@ -317,6 +317,7 @@ bool DirectiveSequencer::add(NuguDirective* ndir)
     }
 
     BlockingPolicy policy = getPolicy(name_space, name);
+    assignPolicy(ndir);
 
     nugu_dbg("receive '%s.%s' directive (medium: %d, isBlocking: %s)",
         name_space, name, policy.medium,
@@ -444,6 +445,26 @@ BlockingPolicy DirectiveSequencer::getPolicy(const std::string& name_space,
         return default_policy;
 
     return j->second;
+}
+
+void DirectiveSequencer::assignPolicy(NuguDirective* ndir)
+{
+    int is_block = 0;
+    enum nugu_directive_medium medium = NUGU_DIRECTIVE_MEDIUM_NONE;
+    BlockingPolicy policy = getPolicy(nugu_directive_peek_namespace(ndir),
+        nugu_directive_peek_name(ndir));
+
+    if (policy.isBlocking)
+        is_block = 1;
+
+    if (policy.medium == BlockingMedium::AUDIO)
+        medium = NUGU_DIRECTIVE_MEDIUM_AUDIO;
+    else if (policy.medium == BlockingMedium::VISUAL)
+        medium = NUGU_DIRECTIVE_MEDIUM_VISUAL;
+    else if (policy.medium == BlockingMedium::ANY)
+        medium = NUGU_DIRECTIVE_MEDIUM_ANY;
+
+    nugu_directive_set_blocking_policy(ndir, medium, is_block);
 }
 
 bool DirectiveSequencer::cancel(const std::string& dialog_id)

--- a/src/core/directive_sequencer.hh
+++ b/src/core/directive_sequencer.hh
@@ -88,6 +88,8 @@ private:
     std::vector<NuguDirective*> scheduled_list;
     guint idler_src;
 
+    void assignPolicy(NuguDirective* ndir);
+
     bool preHandleDirective(NuguDirective* ndir);
     void handleDirective(NuguDirective* ndir);
     void cancelDirective(NuguDirective* ndir);

--- a/tests/test_nugu_directive.c
+++ b/tests/test_nugu_directive.c
@@ -115,6 +115,23 @@ static void test_nugu_directive_default(void)
 	g_assert(nugu_directive_close_data(ndir) == 0);
 	g_assert(nugu_directive_is_data_end(ndir) == 1);
 
+	g_assert(nugu_directive_set_blocking_policy(
+			 NULL, NUGU_DIRECTIVE_MEDIUM_ANY, 1) == -1);
+
+	/* default policy: NONE / non-block */
+	g_assert(nugu_directive_get_blocking_medium(ndir) ==
+		 NUGU_DIRECTIVE_MEDIUM_NONE);
+	g_assert(nugu_directive_is_blocking(ndir) == 0);
+
+	/* set/get policy */
+	g_assert(nugu_directive_set_blocking_policy(
+			 ndir, NUGU_DIRECTIVE_MEDIUM_ANY, 1) == 0);
+	g_assert(nugu_directive_get_blocking_medium(ndir) ==
+		 NUGU_DIRECTIVE_MEDIUM_ANY);
+	g_assert_cmpstr(nugu_directive_get_blocking_medium_string(ndir), ==,
+			"ANY");
+	g_assert(nugu_directive_is_blocking(ndir) == 1);
+
 	nugu_directive_unref(ndir);
 }
 


### PR DESCRIPTION
The blocking policy for the directive has been modified to be set in
the NuguDirective itself.

When the DirectiveSequencer receives a new directive, it sets a
blocking policy on the directive.

Signed-off-by: Inho Oh <inho.oh@sk.com>