### PR TITLE
DisplayRender:Add DisplayRenderHelper

### DIFF
--- a/src/capability/audio_player_agent.hh
+++ b/src/capability/audio_player_agent.hh
@@ -22,6 +22,7 @@
 #include "capability/audio_player_interface.hh"
 #include "capability/display_interface.hh"
 #include "clientkit/capability.hh"
+#include "display_render_helper.hh"
 
 namespace NuguCapability {
 
@@ -135,15 +136,12 @@ private:
     void parsingControlLyricsPage(const char* message);
     void parsingRequestPlayCommand(const char* dname, const char* message);
     void parsingRequestOthersCommand(const char* dname, const char* message);
-    std::string parsingRenderInfo(NuguDirective* ndir, const char* message);
+    DisplayRenderInfo* composeRenderInfo(NuguDirective* ndir, const char* message);
 
     void clearContext();
     void checkAndUpdateVolume();
     std::string playbackError(PlaybackError error);
     std::string playerActivity(AudioPlayerState state);
-
-    void renderDisplay(void* data);
-    void clearDisplay(void* data, bool has_next_render = false);
 
     const unsigned int PAUSE_CONTEXT_HOLD_TIME = 60 * 10;
 
@@ -170,11 +168,9 @@ private:
     bool volume_update;
     int volume;
     std::string template_id;
-    std::string template_view;
-    std::string template_type;
+    std::shared_ptr<DisplayRenderHelper> render_helper;
     std::vector<IAudioPlayerListener*> aplayer_listeners;
     IAudioPlayerDisplayListener* display_listener;
-    std::map<std::string, RenderInfo> render_infos;
 };
 
 } // NuguCapability

--- a/src/capability/display_agent.hh
+++ b/src/capability/display_agent.hh
@@ -19,18 +19,9 @@
 
 #include "capability/display_interface.hh"
 #include "clientkit/capability.hh"
+#include "display_render_helper.hh"
 
 namespace NuguCapability {
-
-struct DisplayRenderInfo {
-    std::string id;
-    std::string type;
-    std::string payload;
-    std::string dialog_id;
-    std::string ps_id;
-    std::string token;
-    bool close = false;
-};
 
 class DisplayAgent : public Capability,
                      public IDisplayHandler,
@@ -76,13 +67,11 @@ private:
     void parsingUpdate(const char* message);
     void parsingTemplates(const char* message);
 
+    DisplayRenderInfo* composeRenderInfo(NuguDirective* ndir, const std::string& ps_id, const std::string& token);
     std::string getTemplateId(const std::string& ps_id);
     std::string getDirectionString(ControlDirection direction);
 
-    void renderDisplay(void* data);
-    void clearDisplay(void* data, bool has_next_render = false);
-
-    std::map<std::string, DisplayRenderInfo*> render_info;
+    std::shared_ptr<DisplayRenderHelper> render_helper;
     IDisplayListener* display_listener;
     std::string disp_cur_ps_id;
     std::string disp_cur_token;

--- a/src/capability/display_render_helper.cc
+++ b/src/capability/display_render_helper.cc
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <sys/time.h>
+
+#include "base/nugu_log.h"
+#include "display_render_helper.hh"
+
+namespace NuguCapability {
+
+DisplayRenderHelper::Builder::Builder(DisplayRenderHelper* parent)
+    : _parent(parent)
+{
+}
+
+DisplayRenderHelper::Builder* DisplayRenderHelper::Builder::setId(const std::string& id)
+{
+    render_info.id = id;
+
+    return this;
+}
+
+DisplayRenderHelper::Builder* DisplayRenderHelper::Builder::setType(const std::string& type)
+{
+    render_info.type = type;
+
+    return this;
+}
+
+DisplayRenderHelper::Builder* DisplayRenderHelper::Builder::setView(const std::string& view)
+{
+    render_info.view = view;
+
+    return this;
+}
+
+DisplayRenderHelper::Builder* DisplayRenderHelper::Builder::setDialogId(const std::string& dialog_id)
+{
+    render_info.dialog_id = dialog_id;
+
+    return this;
+}
+
+DisplayRenderHelper::Builder* DisplayRenderHelper::Builder::setPlayServiceId(const std::string& ps_id)
+{
+    render_info.ps_id = ps_id;
+
+    return this;
+}
+
+DisplayRenderHelper::Builder* DisplayRenderHelper::Builder::setToken(const std::string& token)
+{
+    render_info.token = token;
+
+    return this;
+}
+
+DisplayRenderHelper::Builder* DisplayRenderHelper::Builder::setPostPoneRemove(bool postpone_remove)
+{
+    render_info.postpone_remove = postpone_remove;
+
+    return this;
+}
+
+DisplayRenderInfo* DisplayRenderHelper::Builder::build()
+{
+    if (render_info.type.empty() || render_info.view.empty() || render_info.dialog_id.empty()) {
+        nugu_error("Some required datas are not set.");
+        return nullptr;
+    }
+
+    DisplayRenderInfo* info = new DisplayRenderInfo;
+    info->id = !render_info.id.empty() ? render_info.id : makeId();
+    info->type = render_info.type;
+    info->view = render_info.view;
+    info->dialog_id = render_info.dialog_id;
+    info->postpone_remove = render_info.postpone_remove;
+    info->ps_id = render_info.ps_id;
+    info->token = render_info.token;
+
+    _parent->setRenderInfo(info);
+    render_info = {};
+
+    return info;
+}
+
+std::string DisplayRenderHelper::Builder::makeId()
+{
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+
+    return std::to_string(tv.tv_sec) + std::to_string(tv.tv_usec);
+}
+
+DisplayRenderHelper::DisplayRenderHelper()
+    : builder(std::unique_ptr<Builder>(new DisplayRenderHelper::Builder(this)))
+{
+}
+
+DisplayRenderHelper::~DisplayRenderHelper()
+{
+    clear();
+}
+
+void DisplayRenderHelper::setDisplayListener(IDisplayListener* listener)
+{
+    if (listener)
+        display_listener = listener;
+}
+
+DisplayRenderHelper::Builder* DisplayRenderHelper::getRenderInfoBuilder()
+{
+    return builder.get();
+}
+
+void DisplayRenderHelper::setRenderInfo(DisplayRenderInfo* render_info)
+{
+    if (!render_info || render_info->id.empty()) {
+        nugu_error("The Render Info is not exist.");
+        return;
+    }
+
+    render_infos.emplace(render_info->id, render_info);
+}
+
+DisplayRenderInfo* DisplayRenderHelper::getRenderInfo(const std::string& id)
+{
+    try {
+        return render_infos.at(id);
+    } catch (std::out_of_range& exception) {
+        return nullptr;
+    }
+}
+
+std::string DisplayRenderHelper::getTemplateId(const std::string& ps_id)
+{
+    for (const auto& info : render_infos)
+        if (info.second->ps_id == ps_id)
+            return info.second->id;
+
+    return "";
+}
+
+std::string DisplayRenderHelper::renderDisplay(void* data)
+{
+    if (!display_listener || !data) {
+        nugu_warn("The DisplayListener or render data is not exist.");
+        return "";
+    }
+
+    auto render_info = reinterpret_cast<DisplayRenderInfo*>(data);
+    display_listener->renderDisplay(render_info->id, render_info->type, render_info->view, render_info->dialog_id);
+
+    return render_info->id;
+}
+
+std::string DisplayRenderHelper::updateDisplay(std::pair<void*, void*> datas, bool has_next_render)
+{
+    clearDisplay(datas.first, (datas.second || has_next_render));
+    return renderDisplay(datas.second);
+}
+
+void DisplayRenderHelper::clearDisplay(void* data, bool has_next_render)
+{
+    if (!display_listener || !data) {
+        nugu_warn("The DisplayListener or render data is not exist.");
+        return;
+    }
+
+    auto render_info = reinterpret_cast<DisplayRenderInfo*>(data);
+    std::string id = render_info->id;
+
+    display_listener->clearDisplay(id, true, has_next_render);
+    render_info->postpone_remove ? setRenderClose(id) : removedRenderInfo(id);
+}
+
+void DisplayRenderHelper::setRenderClose(const std::string& id)
+{
+    try {
+        render_infos.at(id)->close = true;
+    } catch (std::out_of_range& exception) {
+        nugu_warn("No render info exist.");
+    }
+}
+
+void DisplayRenderHelper::removedRenderInfo(const std::string& id)
+{
+    try {
+        delete render_infos.at(id);
+        render_infos.erase(id);
+    } catch (std::out_of_range& exception) {
+        nugu_warn("No render info exist.");
+    }
+}
+
+void DisplayRenderHelper::clear()
+{
+    for (auto info : render_infos)
+        delete info.second;
+
+    render_infos.clear();
+}
+
+} // NuguCapability

--- a/src/capability/display_render_helper.hh
+++ b/src/capability/display_render_helper.hh
@@ -1,0 +1,86 @@
+
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NUGU_DISPLAY_RENDER_HELPER_H__
+#define __NUGU_DISPLAY_RENDER_HELPER_H__
+
+#include <map>
+#include <memory>
+
+#include "capability/display_interface.hh"
+
+namespace NuguCapability {
+
+typedef struct {
+    std::string id;
+    std::string type;
+    std::string view;
+    std::string dialog_id;
+    std::string ps_id;
+    std::string token;
+    bool close = false;
+    bool postpone_remove = false;
+} DisplayRenderInfo;
+
+class DisplayRenderHelper {
+public:
+    class Builder {
+    public:
+        Builder* setId(const std::string& id);
+        Builder* setType(const std::string& type);
+        Builder* setView(const std::string& view);
+        Builder* setDialogId(const std::string& dialog_id);
+        Builder* setPlayServiceId(const std::string& ps_id);
+        Builder* setToken(const std::string& token);
+        Builder* setPostPoneRemove(bool postpone_remove);
+        DisplayRenderInfo* build();
+
+    private:
+        friend class DisplayRenderHelper;
+        explicit Builder(DisplayRenderHelper* parent);
+        std::string makeId();
+
+        DisplayRenderHelper* _parent;
+        DisplayRenderInfo render_info {};
+    };
+
+public:
+    DisplayRenderHelper();
+    virtual ~DisplayRenderHelper();
+
+    void setDisplayListener(IDisplayListener* display_listener);
+    Builder* getRenderInfoBuilder();
+    DisplayRenderInfo* getRenderInfo(const std::string& id);
+    std::string getTemplateId(const std::string& ps_id);
+    std::string renderDisplay(void* data);
+    std::string updateDisplay(std::pair<void*, void*> datas, bool has_next_render);
+    void clearDisplay(void* data, bool has_next_render);
+    void setRenderClose(const std::string& id);
+    void removedRenderInfo(const std::string& id);
+    void clear();
+
+private:
+    void setRenderInfo(DisplayRenderInfo* render_info);
+
+    std::map<std::string, DisplayRenderInfo*> render_infos;
+    std::unique_ptr<Builder> builder = nullptr;
+    IDisplayListener* display_listener = nullptr;
+};
+
+} // NuguCapability
+
+#endif


### PR DESCRIPTION
In DisplayAgent and AudioPlayerAgent, the code about rendering
exist duplicately and also it's not commonized.

So, it add DisplayRenderHelper for handling rendering singly.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>