### PR TITLE
AudioPlayer:apply AudioPlayer Interface 1.5

### DIFF
--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -23,7 +23,7 @@
 namespace NuguCapability {
 
 static const char* CAPABILITY_NAME = "AudioPlayer";
-static const char* CAPABILITY_VERSION = "1.4";
+static const char* CAPABILITY_VERSION = "1.5";
 
 AudioPlayerAgent::AudioPlayerAgent()
     : Capability(CAPABILITY_NAME, CAPABILITY_VERSION)


### PR DESCRIPTION
Because, AudioPlayer Interface 1.5 spec is already applied using by
PlaySync flow, it just update capability version number from 1.4 to 1.5.

* PlaybackStopped event reason according by PlayServiceId
1. same : PLAY_ANOTHER
2. differenct :STOP (It's handled by PlaySyncManager.)

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>