### PR TITLE
session:compose recent sessionId in same playServiceId

### DIFF
--- a/src/core/session_manager.cc
+++ b/src/core/session_manager.cc
@@ -131,18 +131,22 @@ void SessionManager::deactivate(const std::string& dialog_id)
 Json::Value SessionManager::getActiveSessionInfo()
 {
     Json::Value session_info_list;
+    std::map<std::string, std::string> rearranged_sessions;
 
     for (const auto& item : active_list) {
         try {
             auto session = session_map.at(item.first);
-
-            Json::Value session_info;
-            session_info["sessionId"] = session.session_id;
-            session_info["playServiceId"] = session.ps_id;
-            session_info_list.append(session_info);
+            rearranged_sessions[session.ps_id] = session.session_id;
         } catch (std::out_of_range& exception) {
             nugu_warn("The such session is not exist.");
         }
+    }
+
+    for (const auto& session : rearranged_sessions) {
+        Json::Value session_info;
+        session_info["sessionId"] = session.second;
+        session_info["playServiceId"] = session.first;
+        session_info_list.append(session_info);
     }
 
     return session_info_list;


### PR DESCRIPTION
If the several sessionIds which are matched with same playServiceId
exist, as the context policy, it has to select a recent received one.

So, it update to extract the latest sessionId in same playServiceId.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>