### PR TITLE
session:apply multi-session maintenance flow

### DIFF
--- a/src/capability/display_agent.hh
+++ b/src/capability/display_agent.hh
@@ -17,6 +17,8 @@
 #ifndef __NUGU_DISPLAY_AGENT_H__
 #define __NUGU_DISPLAY_AGENT_H__
 
+#include <set>
+
 #include "capability/display_interface.hh"
 #include "clientkit/capability.hh"
 #include "display_render_helper.hh"
@@ -67,10 +69,14 @@ private:
     void parsingUpdate(const char* message);
     void parsingTemplates(const char* message);
 
+    void activateSession(NuguDirective* ndir);
+    void deactiveSession();
+
     DisplayRenderInfo* composeRenderInfo(NuguDirective* ndir, const std::string& ps_id, const std::string& token);
     std::string getTemplateId(const std::string& ps_id);
     std::string getDirectionString(ControlDirection direction);
 
+    std::set<std::string> session_dialog_ids;
     std::shared_ptr<DisplayRenderHelper> render_helper;
     IDisplayListener* display_listener;
     std::string disp_cur_ps_id;


### PR DESCRIPTION
In DisplayAgent, there are some case which needs to
maintain multi-session until display is closed.

So, it apply mutli-session maintenance flow in DisplayAgent.

Because, it's hard to do an acceptance test in current situation,
it replace to do similar test in test_core_session_manager.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>