### PR TITLE
Chips:apply directive blocking policy

### DIFF
--- a/src/capability/chips_agent.cc
+++ b/src/capability/chips_agent.cc
@@ -29,6 +29,20 @@ ChipsAgent::ChipsAgent()
 {
 }
 
+void ChipsAgent::initialize()
+{
+    if (initialized) {
+        nugu_warn("It's already initialized.");
+        return;
+    }
+
+    Capability::initialize();
+
+    addBlockingPolicy("Render", { BlockingMedium::AUDIO, true });
+
+    initialized = true;
+}
+
 void ChipsAgent::setCapabilityListener(ICapabilityListener* clistener)
 {
     if (clistener)

--- a/src/capability/chips_agent.hh
+++ b/src/capability/chips_agent.hh
@@ -28,6 +28,8 @@ public:
     ChipsAgent();
     virtual ~ChipsAgent() = default;
 
+    void initialize() override;
+
     void parsingDirective(const char* dname, const char* message) override;
     void setCapabilityListener(ICapabilityListener* clistener) override;
     void updateInfoForContext(Json::Value& ctx) override;


### PR DESCRIPTION
It apply the directive blocking policy about Chips.
It would block Audio medium for Render directive.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>