### PR TITLE
Chips:extends ChipContent Model to ChipsInfo

### DIFF
--- a/examples/standalone/capability/chips_listener.cc
+++ b/examples/standalone/capability/chips_listener.cc
@@ -18,11 +18,11 @@
 
 #include "chips_listener.hh"
 
-void ChipsListener::onReceiveRender(const std::vector<ChipContent>& contents)
+void ChipsListener::onReceiveRender(ChipsInfo&& chips_info)
 {
-    if (!contents.empty())
-        std::cout << "[Chips]\n";
+    if (!chips_info.contents.empty())
+        std::cout << "[Chips] target:" << chips_info.target << std::endl;
 
-    for (const auto& content : contents)
-        std::cout << "\ttext:" << content.text << std::endl;
+    for (const auto& content : chips_info.contents)
+        std::cout << " - text:" << content.text << std::endl;
 }

--- a/examples/standalone/capability/chips_listener.hh
+++ b/examples/standalone/capability/chips_listener.hh
@@ -25,7 +25,7 @@ class ChipsListener : public IChipsListener {
 public:
     virtual ~ChipsListener() = default;
 
-    void onReceiveRender(const std::vector<ChipContent>& contents) override;
+    void onReceiveRender(ChipsInfo&& chips_info) override;
 };
 
 #endif /* __CHIPS_LISTENER_H__ */

--- a/include/capability/chips_interface.hh
+++ b/include/capability/chips_interface.hh
@@ -35,14 +35,20 @@ using namespace NuguClientKit;
  */
 
 /**
- * @brief Model for holding chips elements.
+ * @brief Model for holding chips Info.
  * @see IChipsListener::onReceiveRender
  */
 typedef struct {
-    std::string type; /**< chips type : ACTION, GENERAL */
-    std::string text; /**< text for voice command guide */
-    std::string token; /**< token which is used to send TextInput event */
-} ChipContent;
+    struct Content {
+        std::string type; /**< chips type : ACTION, GENERAL */
+        std::string text; /**< text for voice command guide */
+        std::string token; /**< token which is used to send TextInput event */
+    };
+
+    std::string play_service_id; /**< playServiceId */
+    std::string target; /**< target for rendering voice command guide */
+    std::vector<Content> contents; /**< chip content list */
+} ChipsInfo;
 
 /**
  * @brief chips listener interface
@@ -55,9 +61,9 @@ public:
 
     /**
      * @brief Notified when receiving Render directive from server.
-     * @param[in] contents received datas for rendering voice command guide
+     * @param[in] chips_info received datas for rendering voice command guide
      */
-    virtual void onReceiveRender(const std::vector<ChipContent>& contents) = 0;
+    virtual void onReceiveRender(ChipsInfo&& chips_info) = 0;
 };
 
 /**


### PR DESCRIPTION
As, all payload of Render directive have to be delivered to app,
it extends the ChipContent model to include playServiceId, target.

And it change the model name to ChipsInfo.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>