### PR TITLE
DirectiveSequencer:change to notify cancelDirective about pending list

### DIFF
--- a/src/core/directive_sequencer.cc
+++ b/src/core/directive_sequencer.cc
@@ -611,11 +611,13 @@ bool DirectiveSequencer::cancel(const std::string& dialog_id)
         });
     scheduled_list.erase(new_end, scheduled_list.end());
 
-    /* Remove from pending list without cancel notify */
+    /* Remove from pending list with cancel notify */
     std::vector<NuguDirective*>* list = pending->getList(dialog_id.c_str());
     if (list != NULL) {
         for (auto& ndir : *list) {
             msgid_lookup->remove(nugu_directive_peek_msg_id(ndir));
+
+            cancelDirective(ndir);
 
             nugu_directive_unref(ndir);
         };


### PR DESCRIPTION
Even if the some directive is not handled, because
it's possible to execute the specific flow in preHandling time,
it needs to receive cancelDirective callback about pending list
when the related dialog is canceled.

So, it change to notify cancelDirective when removing pending list.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>