### PR TITLE
capability:add setCancelPolicy API

### DIFF
--- a/include/clientkit/capability.hh
+++ b/include/clientkit/capability.hh
@@ -334,6 +334,12 @@ public:
     void setCapabilityListener(ICapabilityListener* clistener) override;
 
     /**
+     * @brief Set directive cancel policy
+     * @param[in] cancel_policy policy object
+     */
+    void setCancelPolicy(DirectiveCancelPolicy&& cancel_policy) override;
+
+    /**
      * @brief Process command from other objects.
      * @param[in] from capability who send the command
      * @param[in] command command

--- a/include/clientkit/capability_interface.hh
+++ b/include/clientkit/capability_interface.hh
@@ -20,6 +20,7 @@
 #include <functional>
 #include <json/json.h>
 #include <list>
+#include <set>
 #include <string>
 
 #include <base/nugu_directive.h>
@@ -37,6 +38,14 @@ namespace NuguClientKit {
  *
  * @{
  */
+
+/**
+ * @brief Policy about canceling directives which are belong to the specific dialog id.
+ */
+typedef struct {
+    bool cancel_all; /**< cancel all directives or selections */
+    std::set<std::string> dir_groups; /**< directive groups for canceling */
+} DirectiveCancelPolicy;
 
 /**
  * @brief capability listener interface
@@ -213,6 +222,12 @@ public:
      * @param[in] clistener listener
      */
     virtual void setCapabilityListener(ICapabilityListener* clistener) = 0;
+
+    /**
+     * @brief Set directive cancel policy
+     * @param[in] cancel_policy policy object
+     */
+    virtual void setCancelPolicy(DirectiveCancelPolicy&& cancel_policy) = 0;
 };
 
 /**

--- a/src/clientkit/capability.cc
+++ b/src/clientkit/capability.cc
@@ -29,6 +29,7 @@ struct Capability::Impl {
     std::string ref_dialog_id;
     NuguDirective* cur_ndir = nullptr;
     NuguDirective* prev_ndir = nullptr;
+    DirectiveCancelPolicy cancel_policy = { true };
     std::map<std::string, std::string> referrer_events;
     std::map<std::string, std::string> referrer_dirs;
 
@@ -452,6 +453,11 @@ bool Capability::Impl::parseEventResultDesc(const std::string& desc, std::string
 
 void Capability::setCapabilityListener(ICapabilityListener* clistener)
 {
+}
+
+void Capability::setCancelPolicy(DirectiveCancelPolicy&& cancel_policy)
+{
+    pimpl->cancel_policy = cancel_policy;
 }
 
 bool Capability::receiveCommand(const std::string& from, const std::string& command, const std::string& param)


### PR DESCRIPTION
It add the setCancelPolicy API in ICapabilityInterface
for setting directive cancel policy.

```
// example
ITTSHandler->setCancelPolicy({true});  // set cancel all (default)
ITTSHandler->setCancelPolicy({false, {"PhonCall.makeCall", "PhoneCall.endCall});  // set cancel about specific groups
```

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>