### PR TITLE
extension:match extension interface API

### DIFF
--- a/examples/standalone/capability/extension_listener.cc
+++ b/examples/standalone/capability/extension_listener.cc
@@ -24,10 +24,13 @@ void ExtensionListener::setExtensionHandler(IExtensionHandler* extension_handler
         this->extension_handler = extension_handler;
 }
 
-void ExtensionListener::receiveAction(const std::string& data)
+void ExtensionListener::receiveAction(const std::string& data, const std::string& ps_id, const std::string& dialog_id)
 {
-    std::cout << "[Extension] " << data << std::endl;
+    std::cout << "[Extension] receive action\n"
+              << "- playServiceId:" << ps_id << std::endl
+              << "- dialogId:" << dialog_id << std::endl
+              << "- data:" << data << std::endl;
 
     if (extension_handler)
-        extension_handler->ActionSucceeded();
+        extension_handler->actionSucceeded();
 }

--- a/examples/standalone/capability/extension_listener.hh
+++ b/examples/standalone/capability/extension_listener.hh
@@ -26,7 +26,7 @@ public:
     virtual ~ExtensionListener() = default;
 
     void setExtensionHandler(IExtensionHandler* extension_handler);
-    void receiveAction(const std::string& data) override;
+    void receiveAction(const std::string& data, const std::string& ps_id, const std::string& dialog_id) override;
 
 private:
     IExtensionHandler* extension_handler = nullptr;

--- a/include/capability/extension_interface.hh
+++ b/include/capability/extension_interface.hh
@@ -45,8 +45,10 @@ public:
     /**
      * @brief Notified when receiving Action directive from server.
      * @param[in] data received raw data
+     * @param[in] ps_id received playServiceId
+     * @param[in] dialog_id dialogId of received action
      */
-    virtual void receiveAction(const std::string& data) = 0;
+    virtual void receiveAction(const std::string& data, const std::string& ps_id, const std::string& dialog_id) = 0;
 };
 
 /**
@@ -66,18 +68,19 @@ public:
     /**
      * @brief Call if handling action succeed
      */
-    virtual void ActionSucceeded() = 0;
+    virtual void actionSucceeded() = 0;
 
     /**
      * @brief Call if handling action fail
      */
-    virtual void ActionFailed() = 0;
+    virtual void actionFailed() = 0;
 
     /**
      * @brief Request the specific command to Play
+     * @param[in] ps_id playServiceId for handling request
      * @param[in] data raw data to request
      */
-    virtual void CommandIssued(const std::string& data) = 0;
+    virtual void commandIssued(const std::string& ps_id, const std::string& data) = 0;
 };
 
 /**

--- a/src/capability/extension_agent.cc
+++ b/src/capability/extension_agent.cc
@@ -93,21 +93,21 @@ void ExtensionAgent::parsingDirective(const char* dname, const char* message)
         nugu_warn("%s[%s] is not support %s directive", getName().c_str(), getVersion().c_str(), dname);
 }
 
-void ExtensionAgent::ActionSucceeded()
+void ExtensionAgent::actionSucceeded()
 {
     postProcessDirective();
     sendEventCommon("ActionSucceeded");
 }
 
-void ExtensionAgent::ActionFailed()
+void ExtensionAgent::actionFailed()
 {
     postProcessDirective();
     sendEventCommon("ActionFailed");
 }
 
-void ExtensionAgent::CommandIssued(const std::string& data)
+void ExtensionAgent::commandIssued(const std::string& ps_id, const std::string& data)
 {
-    sendEventCommandIssued(data);
+    sendEventCommandIssued(ps_id, data);
 }
 
 void ExtensionAgent::postProcessDirective()
@@ -118,7 +118,7 @@ void ExtensionAgent::postProcessDirective()
     }
 }
 
-void ExtensionAgent::sendEventCommandIssued(const std::string& data, EventResultCallback cb)
+void ExtensionAgent::sendEventCommandIssued(const std::string& ps_id, const std::string& data, EventResultCallback cb)
 {
     Json::StyledWriter writer;
     Json::Value root;
@@ -164,9 +164,9 @@ void ExtensionAgent::parsingAction(const char* message)
         destroy_directive_by_agent = true;
         action_dir = getNuguDirective();
 
-        extension_listener->receiveAction(action);
+        extension_listener->receiveAction(action, ps_id, nugu_directive_peek_dialog_id(action_dir));
     } else {
-        ActionFailed();
+        actionFailed();
     }
 }
 

--- a/src/capability/extension_agent.hh
+++ b/src/capability/extension_agent.hh
@@ -35,13 +35,13 @@ public:
     void setContextInformation(const std::string& ctx) override;
     void updateInfoForContext(Json::Value& ctx) override;
     void parsingDirective(const char* dname, const char* message) override;
-    void ActionSucceeded() override;
-    void ActionFailed() override;
-    void CommandIssued(const std::string& data) override;
+    void actionSucceeded() override;
+    void actionFailed() override;
+    void commandIssued(const std::string& ps_id, const std::string& data) override;
 
 private:
     void postProcessDirective();
-    void sendEventCommandIssued(const std::string& data, EventResultCallback cb = nullptr);
+    void sendEventCommandIssued(const std::string& ps_id, const std::string& data, EventResultCallback cb = nullptr);
     void sendEventCommon(std::string&& ename, EventResultCallback cb = nullptr);
     void parsingAction(const char* message);
 


### PR DESCRIPTION
It update the extension interface API to match with
another platform (Android, iOS).

Because, the coding convention of some methods are incorrect,
it fix to obey rule.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>