### PR TITLE
nugu_sample:show mic status on UI

### DIFF
--- a/examples/standalone/nugu_sample_manager.cc
+++ b/examples/standalone/nugu_sample_manager.cc
@@ -129,9 +129,14 @@ void NuguSampleManager::setTextCommander(TextCommander&& text_commander)
     commander.text_commander = text_commander;
 }
 
-void NuguSampleManager::setPlayStackRetriever(PlayStackRetriever&& playstack_retriever)
+void NuguSampleManager::setPlayStackRetriever(StatusRetriever&& playstack_retriever)
 {
     commander.playstack_retriever = playstack_retriever;
+}
+
+void NuguSampleManager::setMicStatusRetriever(StatusRetriever&& mic_status_retriever)
+{
+    commander.mic_status_retriever = mic_status_retriever;
 }
 
 const std::string& NuguSampleManager::getModelPath()
@@ -223,8 +228,9 @@ void NuguSampleManager::showPrompt(void)
 
         // show current PlayStack info
         if (commander.is_connected) {
-            std::cout << C_GREEN << "[PlayStack] "
-                      << (commander.playstack_retriever ? commander.playstack_retriever() : "")
+            std::cout << C_GREEN
+                      << "[MIC] " << (commander.mic_status_retriever ? commander.mic_status_retriever() : "") << " / "
+                      << "[PlayStack] " << (commander.playstack_retriever ? commander.playstack_retriever() : "")
                       << std::endl;
         }
 

--- a/examples/standalone/nugu_sample_manager.hh
+++ b/examples/standalone/nugu_sample_manager.hh
@@ -28,14 +28,15 @@
 class NuguSampleManager {
 public:
     using TextCommander = std::function<void(const std::string&, bool)>;
-    using PlayStackRetriever = std::function<std::string()>;
+    using StatusRetriever = std::function<std::string()>;
     using Command = std::pair<std::string, std::function<void(int& flag)>>;
     using Commands = std::pair<std::vector<std::string>, std::map<std::string, Command>>;
     using Commander = struct {
         bool is_connected;
         int text_input;
         TextCommander text_commander;
-        PlayStackRetriever playstack_retriever;
+        StatusRetriever playstack_retriever;
+        StatusRetriever mic_status_retriever;
     };
 
     class CommandBuilder {
@@ -62,7 +63,8 @@ public:
     bool handleArguments(const int& argc, char** argv);
     void handleNetworkResult(bool is_connected, bool is_show_cmd = true);
     void setTextCommander(TextCommander&& text_commander);
-    void setPlayStackRetriever(PlayStackRetriever&& playstack_retriever);
+    void setPlayStackRetriever(StatusRetriever&& playstack_retriever);
+    void setMicStatusRetriever(StatusRetriever&& mic_status_retriever);
 
     const std::string& getModelPath();
     CommandBuilder* getCommandBuilder();

--- a/examples/standalone/nugu_sdk_manager.cc
+++ b/examples/standalone/nugu_sdk_manager.cc
@@ -84,9 +84,8 @@ void NuguSDKManager::composeSDKCommands()
                          flag = TEXT_INPUT_TYPE_2;
                      } })
         ->add("m", { "set mic mute", [&](int& flag) {
-                        static bool mute = false;
-                        mute = !mute;
-                        !mute ? mic_handler->enable() : mic_handler->disable();
+                        mic_mute = !mic_mute;
+                        !mic_mute ? mic_handler->enable() : mic_handler->disable();
                     } })
         ->add("sa", { "suspend all", [&](int& flag) {
                          nugu_core_container->getCapabilityHelper()->suspendAll();
@@ -159,27 +158,29 @@ void NuguSDKManager::setDefaultSoundLayerPolicy()
     auto capability_helper(nugu_core_container->getCapabilityHelper());
     auto focus_manager = capability_helper->getFocusManager();
 
-    std::vector<FocusConfiguration> request_configuration;
-    request_configuration.push_back({ CALL_FOCUS_TYPE, CALL_FOCUS_REQUEST_PRIORITY });
-    request_configuration.push_back({ ASR_USER_FOCUS_TYPE, ASR_USER_FOCUS_REQUEST_PRIORITY });
-    request_configuration.push_back({ INFO_FOCUS_TYPE, INFO_FOCUS_REQUEST_PRIORITY });
-    request_configuration.push_back({ ASR_DM_FOCUS_TYPE, ASR_DM_FOCUS_REQUEST_PRIORITY });
-    request_configuration.push_back({ ALERTS_FOCUS_TYPE, ALERTS_FOCUS_REQUEST_PRIORITY });
-    request_configuration.push_back({ ASR_BEEP_FOCUS_TYPE, ASR_BEEP_FOCUS_REQUEST_PRIORITY });
-    request_configuration.push_back({ MEDIA_FOCUS_TYPE, MEDIA_FOCUS_REQUEST_PRIORITY });
-    request_configuration.push_back({ SOUND_FOCUS_TYPE, SOUND_FOCUS_REQUEST_PRIORITY });
-    request_configuration.push_back({ DUMMY_FOCUS_TYPE, DUMMY_FOCUS_REQUEST_PRIORITY });
+    std::vector<FocusConfiguration> request_configuration {
+        { CALL_FOCUS_TYPE, CALL_FOCUS_REQUEST_PRIORITY },
+        { ASR_USER_FOCUS_TYPE, ASR_USER_FOCUS_REQUEST_PRIORITY },
+        { INFO_FOCUS_TYPE, INFO_FOCUS_REQUEST_PRIORITY },
+        { ASR_DM_FOCUS_TYPE, ASR_DM_FOCUS_REQUEST_PRIORITY },
+        { ALERTS_FOCUS_TYPE, ALERTS_FOCUS_REQUEST_PRIORITY },
+        { ASR_BEEP_FOCUS_TYPE, ASR_BEEP_FOCUS_REQUEST_PRIORITY },
+        { MEDIA_FOCUS_TYPE, MEDIA_FOCUS_REQUEST_PRIORITY },
+        { SOUND_FOCUS_TYPE, SOUND_FOCUS_REQUEST_PRIORITY },
+        { DUMMY_FOCUS_TYPE, DUMMY_FOCUS_REQUEST_PRIORITY }
+    };
 
-    std::vector<FocusConfiguration> release_configuration;
-    release_configuration.push_back({ CALL_FOCUS_TYPE, CALL_FOCUS_RELEASE_PRIORITY });
-    release_configuration.push_back({ ASR_USER_FOCUS_TYPE, ASR_USER_FOCUS_RELEASE_PRIORITY });
-    release_configuration.push_back({ ASR_DM_FOCUS_TYPE, ASR_DM_FOCUS_RELEASE_PRIORITY });
-    release_configuration.push_back({ INFO_FOCUS_TYPE, INFO_FOCUS_RELEASE_PRIORITY });
-    release_configuration.push_back({ ALERTS_FOCUS_TYPE, ALERTS_FOCUS_RELEASE_PRIORITY });
-    release_configuration.push_back({ ASR_BEEP_FOCUS_TYPE, ASR_BEEP_FOCUS_RELEASE_PRIORITY });
-    release_configuration.push_back({ MEDIA_FOCUS_TYPE, MEDIA_FOCUS_RELEASE_PRIORITY });
-    release_configuration.push_back({ SOUND_FOCUS_TYPE, SOUND_FOCUS_RELEASE_PRIORITY });
-    release_configuration.push_back({ DUMMY_FOCUS_TYPE, DUMMY_FOCUS_RELEASE_PRIORITY });
+    std::vector<FocusConfiguration> release_configuration {
+        { CALL_FOCUS_TYPE, CALL_FOCUS_RELEASE_PRIORITY },
+        { ASR_USER_FOCUS_TYPE, ASR_USER_FOCUS_RELEASE_PRIORITY },
+        { ASR_DM_FOCUS_TYPE, ASR_DM_FOCUS_RELEASE_PRIORITY },
+        { INFO_FOCUS_TYPE, INFO_FOCUS_RELEASE_PRIORITY },
+        { ALERTS_FOCUS_TYPE, ALERTS_FOCUS_RELEASE_PRIORITY },
+        { ASR_BEEP_FOCUS_TYPE, ASR_BEEP_FOCUS_RELEASE_PRIORITY },
+        { MEDIA_FOCUS_TYPE, MEDIA_FOCUS_RELEASE_PRIORITY },
+        { SOUND_FOCUS_TYPE, SOUND_FOCUS_RELEASE_PRIORITY },
+        { DUMMY_FOCUS_TYPE, DUMMY_FOCUS_RELEASE_PRIORITY }
+    };
 
     focus_manager->setConfigurations(request_configuration, release_configuration);
 }
@@ -201,6 +202,9 @@ void NuguSDKManager::setAdditionalExecutor()
             playstack_text.pop_back();
 
         return playstack_text;
+    });
+    nugu_sample_manager->setMicStatusRetriever([&]() {
+        return mic_mute ? "OFF" : "ON";
     });
 }
 

--- a/examples/standalone/nugu_sdk_manager.hh
+++ b/examples/standalone/nugu_sdk_manager.hh
@@ -78,6 +78,7 @@ private:
 
     bool sdk_initialized = false;
     bool is_network_error = false;
+    bool mic_mute = false;
 };
 
 #endif /* __NUGU_SDK_MANAGER_H__ */


### PR DESCRIPTION
It add to show the current mic status (ON/OFF).

```
=======================================================
NUGU SDK Command (Connected)
=======================================================
[ w] : start listening with wakeup
[ l] : start listening
[ s] : stop listening/wakeup
[ t] : text input
[t2] : text input (ignore dialog attribute)
[ m] : set mic mute
[sa] : suspend all
[ra] : restore all
-------------------------------------------------------
[ i] : initialize
[ d] : deinitialize
[ q] : quit
-------------------------------------------------------
[MIC] ON / [PlayStack] 
Select Command >
```

Also, it clean the code about composing focus configuration.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>