### PR TITLE
core: add cancel by group to directive sequencer

### DIFF
--- a/include/clientkit/directive_sequencer_interface.hh
+++ b/include/clientkit/directive_sequencer_interface.hh
@@ -19,6 +19,8 @@
 
 #include <base/nugu_directive.h>
 
+#include <set>
+
 namespace NuguClientKit {
 
 /**
@@ -134,6 +136,17 @@ public:
      * @retval false failure
      */
     virtual bool cancel(const std::string& dialog_id) = 0;
+
+    /**
+     * @brief Cancels specific pending directives related to the dialog_id.
+     * The canceled directives are freed.
+     * @param[in] dialog_id dialog-request-id
+     * @param[in] groups list of directives('{Namespace}.{Name}')
+     * @return result
+     * @retval true success
+     * @retval false failure
+     */
+    virtual bool cancel(const std::string& dialog_id, std::set<std::string> groups) = 0;
 
     /**
      * @brief Complete the blocking directive. The NuguDirective object will be destroyed.

--- a/src/core/directive_sequencer.hh
+++ b/src/core/directive_sequencer.hh
@@ -46,6 +46,7 @@ public:
     BlockingPolicy getPolicy(const std::string& name_space, const std::string& name) override;
 
     bool cancel(const std::string& dialog_id) override;
+    bool cancel(const std::string& dialog_id, std::set<std::string> groups) override;
     bool complete(NuguDirective* ndir) override;
     bool add(NuguDirective* ndir) override;
 
@@ -87,6 +88,7 @@ private:
     bool preHandleDirective(NuguDirective* ndir);
     void handleDirective(NuguDirective* ndir);
     void cancelDirective(NuguDirective* ndir);
+    void nextDirective(const std::string& dialog_id);
 
     /* Network manager callback */
     static void onDirective(NuguDirective* ndir, void* userdata);


### PR DESCRIPTION
Currently, the cancellation API provided by DirectiveSequcner cancels
the entire directive corresponding to the dialog ID, but an API that
cancels only specific directives is also required.

So, add the following API.

    bool cancel(const std::string& dialog_id,
                std::set<std::string> groups)

For groups, you can use a list of strings in the form of
`"{Namespace}.{Name}"` such as `"PhoneCall.MakeCall"`.

    cancel("dlg-1", { "PhoneCall.MakeCall", "PhoneCall.EndCall" });

Signed-off-by: Inho Oh <inho.oh@sk.com>