### PR TITLE
playsync:add clear holding when preparing sync

### DIFF
--- a/src/core/playsync_manager.cc
+++ b/src/core/playsync_manager.cc
@@ -93,6 +93,7 @@ int PlaySyncManager::getListenerCount()
 void PlaySyncManager::prepareSync(const std::string& ps_id, NuguDirective* ndir)
 {
     clearPostPonedRelease();
+    clearHolding();
 
     if (!playstack_manager->add(ps_id, ndir)) {
         nugu_warn("The condition is not satisfied to prepare sync.");


### PR DESCRIPTION
It add to clear previous release timer when preparing sync.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>