### PR TITLE
playstack:change playstack layer terms to activity

### DIFF
--- a/include/clientkit/playsync_manager_interface.hh
+++ b/include/clientkit/playsync_manager_interface.hh
@@ -47,14 +47,14 @@ enum class PlaySyncState {
 };
 
 /**
- * @brief PlayStack Layer Type
+ * @brief PlayStack Activity Type
  */
-enum class PlayStackLayer {
-    None, /**< No Layer */
-    Alert, /**< Alert Layer */
-    Call, /**< Call Layer */
-    Info, /**< Info Layer */
-    Media /**< Media Layer */
+enum class PlayStackActivity {
+    None, /**< No Activity */
+    Alert, /**< Alert Activity */
+    Call, /**< Call Activity */
+    TTS, /**< TTS Activity */
+    Media /**< Media Activity */
 };
 
 /**
@@ -189,12 +189,12 @@ public:
     virtual bool isConditionToHandlePrevDialog(NuguDirective* prev_ndir, NuguDirective* cur_ndir) = 0;
 
     /**
-     * @brief Check whether the specific playstack exist.
+     * @brief Check whether the specific playstack activity exist.
      * @param[in] ps_id play service id
-     * @param[in] layer playstack layer
+     * @param[in] activity playstack activity
      * @return true if has to be handled, otherwise false
      */
-    virtual bool hasLayer(const std::string& ps_id, PlayStackLayer layer) = 0;
+    virtual bool hasActivity(const std::string& ps_id, PlayStackActivity activity) = 0;
 
     /**
      * @brief Check whether the next playstack to handle exists.

--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -452,7 +452,7 @@ void AudioPlayerAgent::preprocessDirective(NuguDirective* ndir)
     if (!strcmp(dname, "Play")) {
         std::string playstackctl_ps_id = getPlayServiceIdInStackControl(message);
 
-        playsync_manager->hasLayer(playstackctl_ps_id, PlayStackLayer::Media)
+        playsync_manager->hasActivity(playstackctl_ps_id, PlayStackActivity::Media)
             ? playsync_manager->startSync(playstackctl_ps_id, getName(), composeRenderInfo(ndir, message))
             : playsync_manager->prepareSync(playstackctl_ps_id, ndir);
     }

--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -154,7 +154,7 @@ void TTSAgent::onFocusChanged(FocusState state)
     case FocusState::NONE:
         stopTTS();
 
-        if (!playsync_manager->hasLayer(playstackctl_ps_id, PlayStackLayer::Media)) {
+        if (!playsync_manager->hasActivity(playstackctl_ps_id, PlayStackActivity::Media)) {
             is_stopped_by_explicit ? playsync_manager->releaseSyncImmediately(playstackctl_ps_id, getName())
                                    : playsync_manager->releaseSync(playstackctl_ps_id, getName());
         }

--- a/src/core/playstack_manager.hh
+++ b/src/core/playstack_manager.hh
@@ -49,7 +49,7 @@ public:
 
 class PlayStackManager {
 public:
-    using PlayStack = std::pair<std::map<std::string, PlayStackLayer>, std::vector<std::string>>;
+    using PlayStack = std::pair<std::map<std::string, PlayStackActivity>, std::vector<std::string>>;
     using PlayStakcHoldTimes = struct {
         unsigned int normal_time;
         unsigned int long_time;
@@ -77,7 +77,7 @@ public:
     void setPlayStackHoldTime(PlayStakcHoldTimes&& hold_times_sec);
     PlayStakcHoldTimes getPlayStackHoldTime();
 
-    PlayStackLayer getPlayStackLayer(const std::string& ps_id);
+    PlayStackActivity getPlayStackActivity(const std::string& ps_id);
     std::vector<std::string> getAllPlayStackItems();
     const PlayStack& getPlayStackContainer();
     std::set<bool> getFlagSet();
@@ -95,16 +95,16 @@ private:
     };
 
 private:
-    PlayStackLayer extractPlayStackLayer(NuguDirective* ndir);
+    PlayStackActivity extractPlayStackActivity(NuguDirective* ndir);
     std::string getNoneMediaLayerStack();
     void handlePreviousStack(bool is_stacked);
     bool hasDisplayRenderingInfo(NuguDirective* ndir);
     bool hasKeyword(NuguDirective* ndir, std::vector<std::string>&& keywords);
-    bool addToContainer(const std::string& ps_id, PlayStackLayer layer);
+    bool addToContainer(const std::string& ps_id, PlayStackActivity activity);
     void removeFromContainer(const std::string& ps_id);
     void notifyStackRemoved(const std::string& ps_id);
     void clearContainer();
-    bool isStackedCondition(PlayStackLayer layer);
+    bool isStackedCondition(PlayStackActivity activity);
     bool isStackedCondition(const std::string& ps_id);
 
     template <typename T>

--- a/src/core/playsync_manager.cc
+++ b/src/core/playsync_manager.cc
@@ -199,9 +199,9 @@ bool PlaySyncManager::isConditionToHandlePrevDialog(NuguDirective* prev_ndir, Nu
     return playstack_manager->isStackedCondition(cur_ndir) && !playstack_manager->hasExpectSpeech(prev_ndir);
 }
 
-bool PlaySyncManager::hasLayer(const std::string& ps_id, PlayStackLayer layer)
+bool PlaySyncManager::hasActivity(const std::string& ps_id, PlayStackActivity activity)
 {
-    return playstack_manager->getPlayStackLayer(ps_id) == layer;
+    return playstack_manager->getPlayStackActivity(ps_id) == activity;
 }
 
 bool PlaySyncManager::hasNextPlayStack()

--- a/src/core/playsync_manager.hh
+++ b/src/core/playsync_manager.hh
@@ -60,7 +60,7 @@ public:
     bool hasPostPoneRelease();
 
     bool isConditionToHandlePrevDialog(NuguDirective* prev_ndir, NuguDirective* cur_ndir) override;
-    bool hasLayer(const std::string& ps_id, PlayStackLayer layer) override;
+    bool hasActivity(const std::string& ps_id, PlayStackActivity activity) override;
     bool hasNextPlayStack() override;
     std::vector<std::string> getAllPlayStackItems() override;
     const PlayStacks& getPlayStacks();

--- a/tests/core/test_core_playstack_manager.cc
+++ b/tests/core/test_core_playstack_manager.cc
@@ -134,8 +134,8 @@ static void test_playstack_manager_get_stack(TestFixture* fixture, gconstpointer
 
     fixture->playstack_manager->add("ps_id_1", fixture->ndir_info);
     g_assert(fixture->playstack_manager->getAllPlayStackItems().at(0) == "ps_id_1");
-    g_assert(fixture->playstack_manager->getPlayStackLayer("") == PlayStackLayer::None);
-    g_assert(fixture->playstack_manager->getPlayStackLayer("ps_id_1") == PlayStackLayer::Info);
+    g_assert(fixture->playstack_manager->getPlayStackActivity("") == PlayStackActivity::None);
+    g_assert(fixture->playstack_manager->getPlayStackActivity("ps_id_1") == PlayStackActivity::TTS);
 
     fixture->playstack_manager->remove("ps_id_1", PlayStackRemoveMode::Immediately);
     fixture->playstack_manager->add("ps_id_2", fixture->ndir_media);
@@ -206,13 +206,13 @@ static void test_playstack_manager_layer_policy(TestFixture* fixture, gconstpoin
     fixture->playstack_manager->add("ps_id_2", fixture->ndir_info);
     g_assert(playstack_container.first.size() == 1
         && playstack_container.first.cbegin()->first == "ps_id_2"
-        && playstack_container.first.cbegin()->second == PlayStackLayer::Info);
+        && playstack_container.first.cbegin()->second == PlayStackActivity::TTS);
 
     // Info to Media -> replace
     fixture->playstack_manager->add("ps_id_3", fixture->ndir_media);
     g_assert(playstack_container.first.size() == 1
         && playstack_container.first.cbegin()->first == "ps_id_3"
-        && playstack_container.first.cbegin()->second == PlayStackLayer::Media);
+        && playstack_container.first.cbegin()->second == PlayStackActivity::Media);
 
     // Media to Info -> stacked
     fixture->playstack_manager->add("ps_id_4", fixture->ndir_info);
@@ -223,7 +223,7 @@ static void test_playstack_manager_layer_policy(TestFixture* fixture, gconstpoin
     fixture->playstack_manager->add("ps_id_5", fixture->ndir_media);
     g_assert(playstack_container.first.size() == 1
         && playstack_container.first.cbegin()->first == "ps_id_5"
-        && playstack_container.first.cbegin()->second == PlayStackLayer::Media);
+        && playstack_container.first.cbegin()->second == PlayStackActivity::Media);
 }
 
 static void test_playstack_manager_control_holding(TestFixture* fixture, gconstpointer ignored)

--- a/tests/core/test_core_playsync_manager.cc
+++ b/tests/core/test_core_playsync_manager.cc
@@ -589,9 +589,9 @@ static void test_playstack_manager_check_playstack_layer(TestFixture* fixture, g
 {
     fixture->playsync_manager->prepareSync("ps_id_1", fixture->ndir_media);
     fixture->playsync_manager->startSync("ps_id_1", "TTS");
-    g_assert(!fixture->playsync_manager->hasLayer("", PlayStackLayer::Media));
-    g_assert(fixture->playsync_manager->hasLayer("ps_id_1", PlayStackLayer::Media));
-    g_assert(!fixture->playsync_manager->hasLayer("ps_id_1", PlayStackLayer::Info));
+    g_assert(!fixture->playsync_manager->hasActivity("", PlayStackActivity::Media));
+    g_assert(fixture->playsync_manager->hasActivity("ps_id_1", PlayStackActivity::Media));
+    g_assert(!fixture->playsync_manager->hasActivity("ps_id_1", PlayStackActivity::TTS));
 }
 
 static void test_playstack_manager_recv_callback_only_participants(TestFixture* fixture, gconstpointer ignored)
@@ -623,7 +623,7 @@ static void test_playstack_manager_media_stacked_case(TestFixture* fixture, gcon
 {
     sub_test_playstack_manager_preset_media_stacked(fixture);
 
-    // It released info layer immediately if the media is stacked
+    // It released TTS activity immediately if the media is stacked
     fixture->playsync_manager->releaseSync("ps_id_2", "TTS");
     g_assert(fixture->playsync_manager_listener->getSyncState("ps_id_1") == PlaySyncState::Synced);
     g_assert(fixture->playsync_manager_listener->getSyncState("ps_id_2") == PlaySyncState::Released);
@@ -760,7 +760,7 @@ int main(int argc, char* argv[])
     G_TEST_ADD_FUNC("/core/PlayStackManager/ignoreRenderCase", test_playstack_manager_ignore_render_case);
     G_TEST_ADD_FUNC("/core/PlayStackManager/handleInfoLayer", test_playstack_manager_handle_info_layer);
     G_TEST_ADD_FUNC("/core/PlayStackManager/playstackHolding", test_playstack_manager_playstack_holding);
-    G_TEST_ADD_FUNC("/core/PlayStackManager/checkPlayStackLayer", test_playstack_manager_check_playstack_layer);
+    G_TEST_ADD_FUNC("/core/PlayStackManager/checkPlayStackActivity", test_playstack_manager_check_playstack_layer);
     G_TEST_ADD_FUNC("/core/PlayStackManager/recvCallbackOnlyParticipants", test_playstack_manager_recv_callback_only_participants);
     G_TEST_ADD_FUNC("/core/PlayStackManager/mediaStackedCase", test_playstack_manager_media_stacked_case);
     G_TEST_ADD_FUNC("/core/PlayStackManager/postPoneRelease", test_playstack_manager_postpone_release);


### PR DESCRIPTION
As the term about layer is updated to activity in playstack policy,
it change all related code for matching with the policy.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>