### PR TITLE
TTS:update handling TTS.Stop

### DIFF
--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -475,7 +475,9 @@ void TTSAgent::parsingStop(const char* message)
     if (!root["playServiceId"].empty())
         ps_id = root["playServiceId"].asString();
 
-    focus_manager->releaseFocus(INFO_FOCUS_TYPE, CAPABILITY_NAME);
+    (cur_state == MediaPlayerState::PLAYING)
+        ? (void)focus_manager->releaseFocus(INFO_FOCUS_TYPE, CAPABILITY_NAME)
+        : playsync_manager->releaseSyncImmediately(playstackctl_ps_id, getName());
 }
 
 void TTSAgent::postProcessDirective(bool is_cancel)


### PR DESCRIPTION
It update handling TTS.Stop directive to release playsync
immediatley if the current TTS state is not playing.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>