### PR TITLE
TextAgent:handle TextRedirect by InteractionControl

### DIFF
--- a/include/clientkit/interaction_control_manager_interface.hh
+++ b/include/clientkit/interaction_control_manager_interface.hh
@@ -100,6 +100,11 @@ public:
     virtual void notifyHasMultiTurn() = 0;
 
     /**
+     * @brief Check whether multi-turn is active
+     */
+    virtual bool isMultiTurnActive() = 0;
+
+    /**
      * @brief Clear all about interaction mode
      */
     virtual void clear() = 0;

--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -205,6 +205,11 @@ void AudioPlayerAgent::onFocusChanged(FocusState state)
 
     switch (state) {
     case FocusState::FOREGROUND:
+        if (interaction_control_manager->isMultiTurnActive()) {
+            nugu_info("The multi-turn is active. So, it ignore intermediate foreground focus. ");
+            return;
+        }
+
         executeOnForegroundAction();
         break;
     case FocusState::BACKGROUND:

--- a/src/capability/text_agent.hh
+++ b/src/capability/text_agent.hh
@@ -54,6 +54,9 @@ private:
     void parsingTextSource(const char* message);
     void parsingTextRedirect(const char* message);
     bool handleTextCommonProcess(const TextInputParam& text_input_param);
+    void notifyEventResponse(const std::string& msg_id, const std::string& data, bool success) override;
+    void startInteractionControl(InteractionMode&& mode);
+    void finishInteractionControl();
 
     const std::string FAIL_EVENT_ERROR_CODE = "NOT_SUPPORTED_STATE";
 
@@ -63,6 +66,8 @@ private:
     TextState cur_state;
     std::string cur_dialog_id;
     std::string dir_groups;
+    InteractionMode interaction_mode;
+    bool handle_interaction_control;
 
     // attribute
     int response_timeout;

--- a/src/core/interaction_control_manager.cc
+++ b/src/core/interaction_control_manager.cc
@@ -69,6 +69,11 @@ void InteractionControlManager::notifyHasMultiTurn()
         listener->onHasMultiTurn();
 }
 
+bool InteractionControlManager::isMultiTurnActive()
+{
+    return !requester_set.empty();
+}
+
 void InteractionControlManager::start(InteractionMode mode, const std::string& requester)
 {
     if (mode != InteractionMode::MULTI_TURN) {

--- a/src/core/interaction_control_manager.hh
+++ b/src/core/interaction_control_manager.hh
@@ -40,6 +40,7 @@ public:
     int getListenerCount();
 
     void notifyHasMultiTurn() override;
+    bool isMultiTurnActive() override;
     void start(InteractionMode mode, const std::string& requester) override;
     void finish(InteractionMode mode, const std::string& requester) override;
     void clear() override;


### PR DESCRIPTION
When handling Text.TextRedirect directive,
because it needs to maintain processing state (multi-turn),
it update to be controlled by InteractionControlManager.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>