### PR TITLE
AudioPlayer:adjust log level about render info

### DIFF
--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -1247,7 +1247,7 @@ DisplayRenderInfo* AudioPlayerAgent::composeRenderInfo(NuguDirective* ndir, cons
 
     if (!reader.parse(message, root)
         || ((meta = root["audioItem"]["metadata"]).empty() || meta["template"].empty())) {
-        nugu_error("parsing error");
+        nugu_warn("no rendering info");
         return nullptr;
     }
 


### PR DESCRIPTION
Even if there are no existing render info in AudioPlayerAgent,
it's not reasonable to log error.

So, it adjust log level and description.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>