### PR TITLE
MediaPlayer:supplement media player mute

### DIFF
--- a/src/core/media_player.cc
+++ b/src/core/media_player.cc
@@ -399,10 +399,13 @@ bool MediaPlayer::setMute(bool mute)
     for (auto l : d->listeners)
         l->muteChanged(d->mute);
 
-    if (d->mute)
+    if (d->mute) {
         nugu_player_set_volume(d->player, MEDIA_MUTE_SETTING);
-    else
+        // for flushing previous frame, because it's played as previous volume level in a short time.
+        seek(position());
+    } else {
         nugu_player_set_volume(d->player, d->volume);
+    }
 
     return true;
 }


### PR DESCRIPTION
When the media player is muted, in some case,
the media is played by previous volume level in short time.

For supplementation this,
it apply the seek with the purpose of avoiding malfunctional frame.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>