### PR TITLE
examples: fix url issue in nugu_oob_server.py

### DIFF
--- a/examples/oob_setup/nugu_oob_server.py
+++ b/examples/oob_setup/nugu_oob_server.py
@@ -44,9 +44,9 @@ DEFAULT_JSON_OAUTH = """{
 }
 """
 
-authorization_base_url = OAUTH2_URL + '/v1/auth/oauth/authorize'
-token_url = OAUTH2_URL + '/v1/auth/oauth/token'
-revoke_url = OAUTH2_URL + '/v1/auth/oauth/revoke'
+authorization_base_url = OAUTH2_URL + 'v1/auth/oauth/authorize'
+token_url = OAUTH2_URL + 'v1/auth/oauth/token'
+revoke_url = OAUTH2_URL + 'v1/auth/oauth/revoke'
 redirect_uri = 'http://localhost:8080/callback'
 
 app = Flask(__name__)


### PR DESCRIPTION
Remove the duplicated '/' to fix oauth error.

as-is) URL//v1/auth/oauth/token
to-be) URL/v1/auth/oauth/token

Signed-off-by: Inho Oh <inho.oh@sk.com>