### PR TITLE
AudioPlayer:set AudioPlayer/Display listener at once

### DIFF
--- a/examples/standalone/capability_collection.cc
+++ b/examples/standalone/capability_collection.cc
@@ -67,7 +67,6 @@ void CapabilityCollection::composeCapabilityFactory()
         if (!audio_player_handler) {
             aplayer_listener = std::make_shared<AudioPlayerListener>();
             audio_player_handler = makeCapability<AudioPlayerAgent, IAudioPlayerHandler>(aplayer_listener.get());
-            audio_player_handler->setListener(aplayer_listener.get());
         }
 
         return audio_player_handler.get();

--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -541,6 +541,7 @@ void AudioPlayerAgent::setCapabilityListener(ICapabilityListener* listener)
 {
     if (listener) {
         addListener(dynamic_cast<IAudioPlayerListener*>(listener));
+        setListener(dynamic_cast<IAudioPlayerDisplayListener*>(listener));
     }
 }
 


### PR DESCRIPTION
It update to add the AudioPlayer/Display listener at once
in setCapabilityListener because it's same object generally.

If two listeners are different, it could add by
addListener(AudioPlayer), setListener(Display) separately.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>