### PR TITLE
ASR:apply ASR interface v1.5

### DIFF
--- a/examples/response_filter/main.cc
+++ b/examples/response_filter/main.cc
@@ -138,7 +138,7 @@ public:
                 text_handler->requestTextInput(text_value);
             } else {
                 std::cout << "Start ASR Recognition !" << std::endl;
-                asr_handler->startRecognition([&](const std::string& dialog_id) {
+                asr_handler->startRecognition(ASRInitiator::TAP, [&](const std::string& dialog_id) {
                     std::cout << "ASR request dialog id: " << dialog_id << std::endl;
                 });
             }

--- a/examples/simple_asr/main_asr.cc
+++ b/examples/simple_asr/main_asr.cc
@@ -117,7 +117,7 @@ public:
         case NetworkStatus::CONNECTED:
             std::cout << "Network connected !" << std::endl;
             std::cout << "Start ASR Recognition !" << std::endl;
-            asr_handler->startRecognition([&](const std::string& dialog_id) {
+            asr_handler->startRecognition(ASRInitiator::TAP, [&](const std::string& dialog_id) {
                 std::cout << "ASR request dialog id: " << dialog_id << std::endl;
             });
             break;

--- a/examples/standalone/capability/speech_operator.cc
+++ b/examples/standalone/capability/speech_operator.cc
@@ -85,7 +85,7 @@ void SpeechOperator::onWakeupState(WakeupDetectState state, float power_noise, f
         msg::wakeup::state("wakeup detected (power: " + std::to_string(power_noise) + ", " + std::to_string(power_speech) + ")");
 
         stopWakeup();
-        startListening(power_noise, power_speech);
+        startListening(power_noise, power_speech, ASRInitiator::WAKE_UP_WORD);
 
         break;
     case WakeupDetectState::WAKEUP_FAIL:
@@ -118,7 +118,7 @@ void SpeechOperator::startListeningWithWakeup()
     startWakeup();
 }
 
-void SpeechOperator::startListening(float noise, float speech)
+void SpeechOperator::startListening(float noise, float speech, ASRInitiator initiator)
 {
     stopListening();
 
@@ -128,9 +128,9 @@ void SpeechOperator::startListening(float noise, float speech)
     }
 
     if (noise && speech)
-        asr_handler->startRecognition(noise, speech, [&](const std::string& dialog_id) {});
+        asr_handler->startRecognition(noise, speech, initiator);
     else
-        asr_handler->startRecognition([&](const std::string& dialog_id) {});
+        asr_handler->startRecognition(initiator);
 }
 
 void SpeechOperator::stopListeningAndWakeup()

--- a/examples/standalone/capability/speech_operator.hh
+++ b/examples/standalone/capability/speech_operator.hh
@@ -40,7 +40,7 @@ public:
     void setWakeupHandler(IWakeupHandler* wakeup_handler);
     void setASRHandler(IASRHandler* asr_handler);
     void startListeningWithWakeup();
-    void startListening(float noise = 0, float speech = 0);
+    void startListening(float noise = 0, float speech = 0, ASRInitiator initiator = ASRInitiator::TAP);
     void stopListeningAndWakeup();
 
 private:

--- a/include/capability/asr_interface.hh
+++ b/include/capability/asr_interface.hh
@@ -53,6 +53,18 @@ enum class ASRState {
 };
 
 /**
+ * @brief ASR initiator list
+ * @see IASRHandler::startRecognition
+ */
+enum class ASRInitiator {
+    WAKE_UP_WORD, /**< initiated by wakeup */
+    PRESS_AND_HOLD, /**< initiated by button press and hold */
+    TAP, /**< initiated by button tap */
+    EXPECT_SPEECH, /**< initiated by ASR.EXPECT_SPEECH directive */
+    EARSET /**< initiated by earset voice command */
+};
+
+/**
  * @brief ASR error list
  * @see IASRListener::onError
  */
@@ -145,15 +157,17 @@ public:
      * @brief Turn on the microphone and start speech recognition (support multi-wakeup)
      * @param[in] power_noise min wakeup power value
      * @param[in] power_speech max wakeup power value
+     * @param[in] initiator asr initiator
      * @param[in] callback asr recognize callback
      */
-    virtual void startRecognition(float power_noise, float power_speech, AsrRecognizeCallback callback = nullptr) = 0;
+    virtual void startRecognition(float power_noise, float power_speech, ASRInitiator initiator = ASRInitiator::TAP, AsrRecognizeCallback callback = nullptr) = 0;
 
     /**
      * @brief Turn on the microphone and start speech recognition
+     * @param[in] initiator asr initiator
      * @param[in] callback asr recognize callback
      */
-    virtual void startRecognition(AsrRecognizeCallback callback = nullptr) = 0;
+    virtual void startRecognition(ASRInitiator initiator = ASRInitiator::TAP, AsrRecognizeCallback callback = nullptr) = 0;
 
     /**
      * @brief Turn off the microphone and stop speech recognition

--- a/src/capability/asr_agent.hh
+++ b/src/capability/asr_agent.hh
@@ -45,8 +45,8 @@ public:
     void deInitialize() override;
     void suspend() override;
 
-    void startRecognition(float power_noise, float power_speech, AsrRecognizeCallback callback = nullptr) override;
-    void startRecognition(AsrRecognizeCallback callback = nullptr) override;
+    void startRecognition(float power_noise, float power_speech, ASRInitiator initiator = ASRInitiator::TAP, AsrRecognizeCallback callback = nullptr) override;
+    void startRecognition(ASRInitiator initiator = ASRInitiator::TAP, AsrRecognizeCallback callback = nullptr) override;
     void stopRecognition() override;
 
     void preprocessDirective(NuguDirective* ndir) override;
@@ -120,6 +120,8 @@ private:
         bool asr_user = false;
     };
 
+    const ASRInitiator NONE_INITIATOR = static_cast<ASRInitiator>(-1);
+
     ExpectSpeechAttr es_attr;
     CapabilityEvent* rec_event;
     INuguTimer* timer;
@@ -130,7 +132,10 @@ private:
     std::vector<IASRListener*> asr_listeners;
     ListeningState prev_listening_state;
     AsrRecognizeCallback rec_callback;
+    ASRInitiator asr_initiator;
     ASRState cur_state;
+    std::map<ASRInitiator, std::string> asr_initiator_texts;
+    std::map<ASRState, std::string> asr_state_texts;
     std::string request_listening_id;
     bool asr_cancel;
 


### PR DESCRIPTION
It apply the ASR interface v1.5 NDI spec.
(state, initiator fields are added in context.)

* state : state of asr like IDLE, LISTENING,...
* initiator : initiator of ASR whether wakeup of button tap.

It addition, it add the engine field in context which is already
defined in v1.0 by option, for managing the spec fully.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>