### PR TITLE
AudioPlayer:apply AudioPlayer Interface v1.6

### DIFF
--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -23,7 +23,7 @@
 namespace NuguCapability {
 
 static const char* CAPABILITY_NAME = "AudioPlayer";
-static const char* CAPABILITY_VERSION = "1.5";
+static const char* CAPABILITY_VERSION = "1.6";
 
 AudioPlayerAgent::AudioPlayerAgent()
     : Capability(CAPABILITY_NAME, CAPABILITY_VERSION)


### PR DESCRIPTION
It apply the AudioPlayer Interface v1.6.

Because, the updated spec is about display template (not parsing in sdk)
there is no need to handle directly.

So, it just update capability interface version to 1.6.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>