### PR TITLE
AudioPlayer:update parsing stop directive

### DIFF
--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -1024,6 +1024,8 @@ void AudioPlayerAgent::parsingStop(const char* message)
 
         capa_helper->sendCommand("AudioPlayer", "ASR", "releaseFocus", "");
     }
+
+    cur_url.clear();
 }
 
 void AudioPlayerAgent::parsingUpdateMetadata(const char* message)


### PR DESCRIPTION
It update parsing stop directive in AudioPlayerAgent to clear
cur_url variable which is used to save current media url.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>