### PR TITLE
AudioPlayer: doesn't play the expired media

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ nbproject
 .project
 .cproject
 
-build/
+build*/
 
 # Binary
 *.o

--- a/src/capability/audio_player_agent.hh
+++ b/src/capability/audio_player_agent.hh
@@ -56,6 +56,7 @@ public:
     void parsingDirective(const char* dname, const char* message) override;
     void updateInfoForContext(Json::Value& ctx) override;
     bool receiveCommand(const std::string& from, const std::string& command, const std::string& param) override;
+    void receiveCommandAll(const std::string& command, const std::string& param) override;
     void setCapabilityListener(ICapabilityListener* clistener) override;
 
     static void directiveDataCallback(NuguDirective* ndir, int seq, void* userdata);
@@ -152,6 +153,9 @@ private:
     FocusState focus_state;
     bool is_tts_activate;
     bool is_next_play;
+    bool has_play_directive;
+    std::string play_directive_dialog_id;
+    bool receive_new_play_directive;
 
     AudioPlayerState cur_aplayer_state;
     AudioPlayerState prev_aplayer_state;


### PR DESCRIPTION
If user requests music service during playing media, the media should be
expired. But the media is resumed when the AudioPlayer's focus state is
changed from `Background` to `Foreground` by release the TTS before it
receives the new `AudioPlayer.Play` directive.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>