### PR TITLE
Text: multi-turn

### DIFF
--- a/src/capability/text_agent.cc
+++ b/src/capability/text_agent.cc
@@ -269,6 +269,9 @@ void TextAgent::parsingTextSource(const char* message)
         text_input_param.token = root["token"].asString();
         text_input_param.ps_id = root["playServiceId"].asString();
 
+        if (!handle_interaction_control && interaction_control_manager->isMultiTurnActive())
+            startInteractionControl(InteractionMode::MULTI_TURN);
+
         if (!handleTextCommonProcess(text_input_param))
             throw "The processing TextSource is incomplete.";
     } catch (const char* message) {


### PR DESCRIPTION
When receiving a Text command instead of a user's speech in a DM
situation, it should be confirmed that it is multi-turn. Otherwise, the
media could be played before the response to the Text command comes.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>