### PR TITLE
Focus: fixed the recursive call bug

### DIFF
--- a/src/core/focus_manager.cc
+++ b/src/core/focus_manager.cc
@@ -206,9 +206,10 @@ bool FocusManager::releaseFocus(const std::string& type, const std::string& name
 
     const std::string release_focus_type = release_focus->type;
 
+    focus_resource_ordered_list.remove(release_focus);
+
     nugu_info("[%s - %s] - NONE (priority - req:%d, rel:%d)", release_focus->type.c_str(), release_focus->name.c_str(), release_focus->request_priority, release_focus->release_priority);
     release_focus->setState(FocusState::NONE);
-    focus_resource_ordered_list.remove(release_focus);
 
     // focus resource is not exist anymore
     if (focus_resource_ordered_list.size() == 0)


### PR DESCRIPTION
There was an issue where the focus was mixed when the focus was
controlled in the listener, and this has been fixed.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>