### PR TITLE
ASR:adjust handling ExpectSpeech

### DIFF
--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -561,8 +561,6 @@ void ASRAgent::parsingExpectSpeech(std::string&& dialog_id, const char* message)
 
     session_manager->activate(es_attr.dialog_id);
     interaction_control_manager->start(InteractionMode::MULTI_TURN, getName());
-
-    focus_manager->requestFocus(ASR_DM_FOCUS_TYPE, CAPABILITY_NAME, asr_dm_listener);
 }
 
 void ASRAgent::parsingNotifyResult(const char* message)
@@ -630,6 +628,7 @@ void ASRAgent::parsingCancelRecognize(const char* message)
 
 void ASRAgent::handleExpectSpeech()
 {
+    focus_manager->requestFocus(ASR_DM_FOCUS_TYPE, CAPABILITY_NAME, asr_dm_listener);
 }
 
 void ASRAgent::onListeningState(ListeningState state, const std::string& id)

--- a/src/clientkit/capability.cc
+++ b/src/clientkit/capability.cc
@@ -353,6 +353,11 @@ void Capability::processDirective(NuguDirective* ndir)
 
 void Capability::destroyDirective(NuguDirective* ndir, bool is_cancel)
 {
+    if (pimpl->prev_ndir) {
+        directive_sequencer->complete(pimpl->prev_ndir);
+        pimpl->prev_ndir = nullptr;
+    }
+
     if (pimpl->cur_ndir && ndir == pimpl->cur_ndir) {
         nugu_directive_remove_data_callback(pimpl->cur_ndir);
 
@@ -371,11 +376,6 @@ void Capability::destroyDirective(NuguDirective* ndir, bool is_cancel)
         }
 
         pimpl->cur_ndir = nullptr;
-    }
-
-    if (pimpl->prev_ndir) {
-        directive_sequencer->complete(pimpl->prev_ndir);
-        pimpl->prev_ndir = nullptr;
     }
 }
 


### PR DESCRIPTION
It change the time to request focus about ExpectSpeech
from preHandleDirective to HandleDirective.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>