### PR TITLE
PlaySync:Add clear API for removing playstack info

### DIFF
--- a/include/clientkit/playsync_manager_interface.hh
+++ b/include/clientkit/playsync_manager_interface.hh
@@ -181,6 +181,11 @@ public:
     virtual void clearHolding() = 0;
 
     /**
+     * @brief Clear all playstack info.
+     */
+    virtual void clear() = 0;
+
+    /**
      * @brief Check whether the previous dialog has to be handled or not
      * @param[in] prev_ndir preivous directive
      * @param[in] cur_ndir current directive

--- a/src/core/playsync_manager.cc
+++ b/src/core/playsync_manager.cc
@@ -189,6 +189,11 @@ void PlaySyncManager::clearHolding()
     playstack_manager->clearHolding();
 }
 
+void PlaySyncManager::clear()
+{
+    reset();
+}
+
 bool PlaySyncManager::hasPostPoneRelease()
 {
     return release_postponed || postponed_release_func;

--- a/src/core/playsync_manager.hh
+++ b/src/core/playsync_manager.hh
@@ -57,6 +57,7 @@ public:
     void stopHolding() override;
     void resetHolding() override;
     void clearHolding() override;
+    void clear() override;
     bool hasPostPoneRelease();
 
     bool isConditionToHandlePrevDialog(NuguDirective* prev_ndir, NuguDirective* cur_ndir) override;

--- a/tests/core/test_core_playsync_manager.cc
+++ b/tests/core/test_core_playsync_manager.cc
@@ -738,6 +738,26 @@ static void test_playstack_manager_check_next_playstack(TestFixture* fixture, gc
     g_assert(!fixture->playsync_manager->hasNextPlayStack());
 }
 
+static void test_playstack_manager_clear(TestFixture* fixture, gconstpointer ignored)
+{
+    sub_test_playstack_manager_preset_media_stacked(fixture);
+
+    const auto& playstacks = fixture->playsync_manager->getPlayStacks();
+
+    g_assert(!playstacks.empty());
+    g_assert(!fixture->playsync_manager->getAllPlayStackItems().empty());
+    g_assert(!fixture->playsync_manager->hasPostPoneRelease());
+
+    fixture->playsync_manager->postPoneRelease();
+    g_assert(fixture->playsync_manager->hasPostPoneRelease());
+
+    fixture->playsync_manager->clear();
+
+    g_assert(playstacks.empty());
+    g_assert(fixture->playsync_manager->getAllPlayStackItems().empty());
+    g_assert(!fixture->playsync_manager->hasPostPoneRelease());
+}
+
 int main(int argc, char* argv[])
 {
 #if !GLIB_CHECK_VERSION(2, 36, 0)
@@ -770,6 +790,7 @@ int main(int argc, char* argv[])
     G_TEST_ADD_FUNC("/core/PlayStackManager/reset", test_playstack_manager_reset);
     G_TEST_ADD_FUNC("/core/PlayStackManager/registerCapabilityForSync", test_playstack_manager_register_capability_for_sync);
     G_TEST_ADD_FUNC("/core/PlayStackManager/checkNextPlayStack", test_playstack_manager_check_next_playstack);
+    G_TEST_ADD_FUNC("/core/PlayStackManager/clear", test_playstack_manager_clear);
 
     return g_test_run();
 }


### PR DESCRIPTION
It add the clear API in PlaySyncManager for removing all playstack info.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>