### PR TITLE
AudioPlayerAgent: Fixed the version 1.5 spec

### DIFF
--- a/src/capability/audio_player_agent.hh
+++ b/src/capability/audio_player_agent.hh
@@ -152,7 +152,7 @@ private:
     NuguDirective* speak_dir;
     FocusState focus_state;
     bool is_tts_activate;
-    bool is_next_play;
+    bool stop_reason_by_play_another;
     bool has_play_directive;
     std::string play_directive_dialog_id;
     bool receive_new_play_directive;


### PR DESCRIPTION
The `reason` field in the `PlaybackStopped` is filled `PLAY_ANOTHER`
when the audioplayer is stopped caused by next content in same play
service.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>