### PR TITLE
Display:Apply Display Interface v1.7

### DIFF
--- a/src/capability/display_agent.cc
+++ b/src/capability/display_agent.cc
@@ -23,7 +23,7 @@
 namespace NuguCapability {
 
 static const char* CAPABILITY_NAME = "Display";
-static const char* CAPABILITY_VERSION = "1.6";
+static const char* CAPABILITY_VERSION = "1.7";
 
 DisplayAgent::DisplayAgent()
     : Capability(CAPABILITY_NAME, CAPABILITY_VERSION)


### PR DESCRIPTION
It apply the Display Interface v1.7.

Because, the updated spec is about template inner datas,
there are no need to handle that changes in SDK.

So, it just increase the Agent version to 1.7.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>