### PR TITLE
Chips:Apply Chips Interface v1.2

### DIFF
--- a/examples/standalone/capability/chips_listener.cc
+++ b/examples/standalone/capability/chips_listener.cc
@@ -18,10 +18,19 @@
 
 #include "chips_listener.hh"
 
+ChipsListener::ChipsListener()
+{
+    target_texts = {
+        { ChipsTarget::DM, "DM" },
+        { ChipsTarget::LISTEN, "LISTEN" },
+        { ChipsTarget::SPEAKING, "SPEAKING" }
+    };
+}
+
 void ChipsListener::onReceiveRender(ChipsInfo&& chips_info)
 {
     if (!chips_info.contents.empty())
-        std::cout << "[Chips] target:" << chips_info.target << std::endl;
+        std::cout << "[Chips] target:" << target_texts[chips_info.target] << std::endl;
 
     for (const auto& content : chips_info.contents)
         std::cout << " - text:" << content.text << std::endl;

--- a/examples/standalone/capability/chips_listener.hh
+++ b/examples/standalone/capability/chips_listener.hh
@@ -23,9 +23,13 @@ using namespace NuguCapability;
 
 class ChipsListener : public IChipsListener {
 public:
+    ChipsListener();
     virtual ~ChipsListener() = default;
 
     void onReceiveRender(ChipsInfo&& chips_info) override;
+
+private:
+    std::map<ChipsTarget, std::string> target_texts;
 };
 
 #endif /* __CHIPS_LISTENER_H__ */

--- a/include/capability/chips_interface.hh
+++ b/include/capability/chips_interface.hh
@@ -35,18 +35,36 @@ using namespace NuguClientKit;
  */
 
 /**
+ * @brief Chips Target
+ */
+enum class ChipsTarget {
+    DM, /**< active with ASR.ExpectSpeech + Session.Set directives */
+    LISTEN, /**< active with ASR.ExpectSpeech directive */
+    SPEAKING /**< active with TTS.Speak directive */
+};
+
+/**
+ * @brief Chips Type
+ */
+enum class ChipsType {
+    NUDGE, /**< Nudge UI type */
+    ACTION, /**< Action Button type */
+    GENERAL /**< Default type */
+};
+
+/**
  * @brief Model for holding chips Info.
  * @see IChipsListener::onReceiveRender
  */
 typedef struct {
     struct Content {
-        std::string type; /**< chips type : ACTION, GENERAL */
+        ChipsType type; /**< chips type */
         std::string text; /**< text for voice command guide */
         std::string token; /**< token which is used to send TextInput event */
     };
 
     std::string play_service_id; /**< playServiceId */
-    std::string target; /**< target for rendering voice command guide */
+    ChipsTarget target; /**< target for rendering voice command guide */
     std::vector<Content> contents; /**< chip content list */
 } ChipsInfo;
 
@@ -54,7 +72,6 @@ typedef struct {
  * @brief chips listener interface
  * @see IChipsHandler
  */
-
 class IChipsListener : public ICapabilityListener {
 public:
     virtual ~IChipsListener() = default;

--- a/src/capability/chips_agent.hh
+++ b/src/capability/chips_agent.hh
@@ -38,6 +38,8 @@ private:
     void parsingRender(const char* message);
 
     IChipsListener* chips_listener = nullptr;
+    std::map<std::string, ChipsTarget> targets;
+    std::map<std::string, ChipsType> chips_types;
 };
 
 } // NuguCapability


### PR DESCRIPTION
It apply the Chips Inteface v1.2.

It define the target and chips.type to enum class.

It update parsing render directive.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>