### PR TITLE
ASR:Apply ASR interface v1.6

### DIFF
--- a/examples/profiling/main_prof.cc
+++ b/examples/profiling/main_prof.cc
@@ -180,7 +180,7 @@ public:
     {
     }
 
-    void onError(ASRError error, const std::string& dialog_id)
+    void onError(ASRError error, const std::string& dialog_id, bool listen_timeout_fail_beep)
     {
         switch (error) {
         case ASRError::RESPONSE_TIMEOUT:

--- a/examples/response_filter/main.cc
+++ b/examples/response_filter/main.cc
@@ -88,7 +88,7 @@ public:
         std::cout << "ASR complete result: " << text << ", request dialog id: " << dialog_id << std::endl;
     }
 
-    void onError(ASRError error, const std::string& dialog_id)
+    void onError(ASRError error, const std::string& dialog_id, bool listen_timeout_fail_beep)
     {
         switch (error) {
         case ASRError::RESPONSE_TIMEOUT:

--- a/examples/simple_asr/main_asr.cc
+++ b/examples/simple_asr/main_asr.cc
@@ -74,7 +74,7 @@ public:
         std::cout << "ASR complete result: " << text << ", request dialog id: " << dialog_id << std::endl;
     }
 
-    void onError(ASRError error, const std::string& dialog_id)
+    void onError(ASRError error, const std::string& dialog_id, bool listen_timeout_fail_beep)
     {
         switch (error) {
         case ASRError::RESPONSE_TIMEOUT:

--- a/examples/standalone/capability/speech_operator.cc
+++ b/examples/standalone/capability/speech_operator.cc
@@ -213,7 +213,7 @@ void SpeechOperator::onComplete(const std::string& text, const std::string& dial
     msg::asr::callback(__FUNCTION__, dialog_id, text);
 }
 
-void SpeechOperator::onError(ASRError error, const std::string& dialog_id)
+void SpeechOperator::onError(ASRError error, const std::string& dialog_id, bool listen_timeout_fail_beep)
 {
     switch (error) {
     case ASRError::RESPONSE_TIMEOUT: {

--- a/examples/standalone/capability/speech_operator.hh
+++ b/examples/standalone/capability/speech_operator.hh
@@ -33,7 +33,7 @@ public:
     void onNone(const std::string& dialog_id) override;
     void onPartial(const std::string& text, const std::string& dialog_id) override;
     void onComplete(const std::string& text, const std::string& dialog_id) override;
-    void onError(ASRError error, const std::string& dialog_id) override;
+    void onError(ASRError error, const std::string& dialog_id, bool listen_timeout_fail_beep) override;
     void onCancel(const std::string& dialog_id) override;
 
     IASRListener* getASRListener();

--- a/include/capability/asr_interface.hh
+++ b/include/capability/asr_interface.hh
@@ -128,8 +128,9 @@ public:
      * @brief Report an error occurred during speech recognition to the user.
      * @param[in] error ASR error
      * @param[in] dialog_id dialog request id
+     * @param[in] listen_timeout_fail_beep whether to play fail beep or not when listen-timeout occurred
      */
-    virtual void onError(ASRError error, const std::string& dialog_id) = 0;
+    virtual void onError(ASRError error, const std::string& dialog_id, bool listen_timeout_fail_beep = true) = 0;
 
     /**
      * @brief Speech recognition is canceled.

--- a/src/capability/asr_agent.hh
+++ b/src/capability/asr_agent.hh
@@ -138,6 +138,7 @@ private:
     std::map<ASRState, std::string> asr_state_texts;
     std::string request_listening_id;
     bool asr_cancel;
+    bool listen_timeout_fail_beep;
 
     FocusListener* asr_user_listener;
     FocusListener* asr_dm_listener;


### PR DESCRIPTION
It apply the ASR interface v1.6 Spec.

It update onError method in IASRListener as adding argument
listen_timeout_fail_beep for check to play fail beep or not
when the listen timeout error's occurred.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>