### PR TITLE
examples: remove oob systemd file from install

### DIFF
--- a/examples/oob_setup/CMakeLists.txt
+++ b/examples/oob_setup/CMakeLists.txt
@@ -1,2 +1,5 @@
 INSTALL(PROGRAMS nugu_oob_server.py DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME nugu_oob_server)
-INSTALL(FILES nugu_oob.service DESTINATION /lib/systemd/system)
+
+# Optional installation
+# - systemd service file for nugu_oob
+#INSTALL(FILES nugu_oob.service DESTINATION /lib/systemd/system)

--- a/packaging/bionic/libnugu-examples.install
+++ b/packaging/bionic/libnugu-examples.install
@@ -1,3 +1,2 @@
 debian/tmp/usr/bin/*
-debian/tmp/lib/*
 debian/tmp/usr/share/*

--- a/packaging/xenial/libnugu-examples.install
+++ b/packaging/xenial/libnugu-examples.install
@@ -1,3 +1,2 @@
 debian/tmp/usr/bin/*
-debian/tmp/lib/*
 debian/tmp/usr/share/*


### PR DESCRIPTION
Remove the systemd service file for nugu_oob from default installation
list. Because this file is just an example and not mandatory.

Signed-off-by: Inho Oh <inho.oh@sk.com>