### PR TITLE
Fix out_of_range without header

### DIFF
--- a/src/core/playstack_manager.cc
+++ b/src/core/playstack_manager.cc
@@ -15,6 +15,7 @@
  */
 
 #include <algorithm>
+#include <stdexcept>
 
 #include "base/nugu_log.h"
 #include "playstack_manager.hh"

--- a/src/core/playsync_manager.cc
+++ b/src/core/playsync_manager.cc
@@ -15,6 +15,7 @@
  */
 
 #include <algorithm>
+#include <stdexcept>
 
 #include "base/nugu_log.h"
 #include "playsync_manager.hh"


### PR DESCRIPTION
It could be occured error depending on build option.

    error: 'out_of_range' in namespace 'std' does not name a type
    |    45 |             } catch (std::out_of_range& exception) {
    |       |                           ^~~~~~~~~~~~

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>