### PR TITLE
network: remove event send with sync

### DIFF
--- a/include/base/nugu_network_manager.h
+++ b/include/base/nugu_network_manager.h
@@ -274,7 +274,6 @@ NuguNetworkStatus nugu_network_manager_get_status(void);
 /**
  * @brief Send the event to server
  * @param[in] nev event object
- * @param[in] is_sync synchronized blocking event(is_sync=1) or not(is_sync=0)
  * @return result
  * @retval 0 success
  * @retval -1 failure
@@ -282,7 +281,7 @@ NuguNetworkStatus nugu_network_manager_get_status(void);
  * @see nugu_network_manager_send_event_data()
  * @see nugu_network_manager_force_close_event()
  */
-int nugu_network_manager_send_event(NuguEvent *nev, int is_sync);
+int nugu_network_manager_send_event(NuguEvent *nev);
 
 /**
  * @brief Send the attachment data of event to server

--- a/include/clientkit/capability.hh
+++ b/include/clientkit/capability.hh
@@ -92,9 +92,8 @@ public:
      * @brief Send event to server.
      * @param[in] context context info
      * @param[in] payload payload info
-     * @param[in] is_sync whether synchronized blocking event
      */
-    void sendEvent(const std::string& context, const std::string& payload, bool is_sync = false);
+    void sendEvent(const std::string& context, const std::string& payload);
 
     /**
      * @brief Send attachment event to server.
@@ -284,19 +283,17 @@ public:
      * @param[in] name event name
      * @param[in] context context info
      * @param[in] payload payload info
-     * @param[in] is_sync whether synchronized blocking event
      * @return event's request dialog id
      */
-    std::string sendEvent(const std::string& name, const std::string& context, const std::string& payload, EventResultCallback cb = nullptr, bool is_sync = false);
+    std::string sendEvent(const std::string& name, const std::string& context, const std::string& payload, EventResultCallback cb = nullptr);
 
     /**
      * @brief Send event to server.
      * @param[in] event CapabilityEvent instance
      * @param[in] context context info
      * @param[in] payload payload info
-     * @param[in] is_sync whether synchronized blocking event
      */
-    void sendEvent(CapabilityEvent* event, const std::string& context, const std::string& payload, EventResultCallback cb = nullptr, bool is_sync = false);
+    void sendEvent(CapabilityEvent* event, const std::string& context, const std::string& payload, EventResultCallback cb = nullptr);
 
     /**
      * @brief Send attachment event to server.

--- a/src/base/network/dg_server.c
+++ b/src/base/network/dg_server.c
@@ -55,18 +55,17 @@ struct _dg_server {
 	int use_events;
 	GHashTable *pending_events;
 
-	int (*send_event)(DGServer *server, NuguEvent *nev, const char *payload,
-			  int is_sync);
+	int (*send_event)(DGServer *server, NuguEvent *nev,
+			  const char *payload);
 	int (*send_attachment)(DGServer *server, NuguEvent *nev, int is_end,
 			       size_t length, unsigned char *data);
 };
 
-static int _send_v1_event(DGServer *server, NuguEvent *nev, const char *payload,
-			  int is_sync)
+static int _send_v1_event(DGServer *server, NuguEvent *nev, const char *payload)
 {
 	V1Event *e;
 
-	e = v1_event_new(server->host, is_sync);
+	e = v1_event_new(server->host);
 	if (!e)
 		return -1;
 
@@ -79,12 +78,11 @@ static int _send_v1_event(DGServer *server, NuguEvent *nev, const char *payload,
 }
 
 static int _send_v2_events(DGServer *server, NuguEvent *nev,
-			   const char *payload, int is_sync)
+			   const char *payload)
 {
 	V2Events *e;
 
-	e = v2_events_new(server->host, server->net, is_sync,
-			  nugu_event_get_type(nev));
+	e = v2_events_new(server->host, server->net, nugu_event_get_type(nev));
 	if (!e)
 		return -1;
 
@@ -378,7 +376,7 @@ void dg_server_reset_retry_count(DGServer *server)
 	server->retry_count = 0;
 }
 
-int dg_server_send_event(DGServer *server, NuguEvent *nev, int is_sync)
+int dg_server_send_event(DGServer *server, NuguEvent *nev)
 {
 	char *payload;
 	int ret;
@@ -398,7 +396,7 @@ int dg_server_send_event(DGServer *server, NuguEvent *nev, int is_sync)
 			    nugu_event_peek_dialog_id(nev),
 			    nugu_event_peek_msg_id(nev), payload);
 
-	ret = server->send_event(server, nev, payload, is_sync);
+	ret = server->send_event(server, nev, payload);
 	g_free(payload);
 
 	if (ret < 0) {

--- a/src/base/network/dg_server.h
+++ b/src/base/network/dg_server.h
@@ -50,7 +50,7 @@ int dg_server_is_retry_over(DGServer *server);
 void dg_server_increse_retry_count(DGServer *server);
 void dg_server_reset_retry_count(DGServer *server);
 
-int dg_server_send_event(DGServer *server, NuguEvent *nev, int is_sync);
+int dg_server_send_event(DGServer *server, NuguEvent *nev);
 int dg_server_send_attachment(DGServer *server, NuguEvent *nev, int is_end,
 			      size_t length, unsigned char *data);
 int dg_server_force_close_event(DGServer *server, NuguEvent *nev);

--- a/src/base/network/http2/v1_event.h
+++ b/src/base/network/http2/v1_event.h
@@ -25,7 +25,7 @@ extern "C" {
 
 typedef struct _v1_event V1Event;
 
-V1Event *v1_event_new(const char *host, int is_sync);
+V1Event *v1_event_new(const char *host);
 void v1_event_free(V1Event *event);
 
 int v1_event_set_json(V1Event *event, const char *data, size_t length);

--- a/src/base/network/http2/v2_events.h
+++ b/src/base/network/http2/v2_events.h
@@ -25,7 +25,7 @@ extern "C" {
 
 typedef struct _v2_events V2Events;
 
-V2Events *v2_events_new(const char *host, HTTP2Network *net, int is_sync,
+V2Events *v2_events_new(const char *host, HTTP2Network *net,
 			enum nugu_event_type type);
 void v2_events_free(V2Events *event);
 

--- a/src/base/nugu_network_manager.c
+++ b/src/base/nugu_network_manager.c
@@ -936,7 +936,7 @@ EXPORT_API NuguNetworkStatus nugu_network_manager_get_status(void)
 	return _network->cur_status;
 }
 
-EXPORT_API int nugu_network_manager_send_event(NuguEvent *nev, int is_sync)
+EXPORT_API int nugu_network_manager_send_event(NuguEvent *nev)
 {
 	int ret;
 
@@ -957,16 +957,11 @@ EXPORT_API int nugu_network_manager_send_event(NuguEvent *nev, int is_sync)
 		return -1;
 	}
 
-	if (is_sync && nugu_event_get_type(nev) != NUGU_EVENT_TYPE_DEFAULT) {
-		nugu_error("sync option supports only default type event");
-		return -1;
-	}
-
 	if (_network->event_send_callback)
 		_network->event_send_callback(
 			nev, _network->event_send_callback_userdata);
 
-	ret = dg_server_send_event(_network->server, nev, is_sync);
+	ret = dg_server_send_event(_network->server, nev);
 	if (ret < 0) {
 		nugu_error("event send failed: %d", ret);
 		return -1;

--- a/src/clientkit/capability.cc
+++ b/src/clientkit/capability.cc
@@ -92,7 +92,7 @@ void CapabilityEvent::forceClose()
     nugu_network_manager_force_close_event(pimpl->event);
 }
 
-void CapabilityEvent::sendEvent(const std::string& context, const std::string& payload, bool is_sync)
+void CapabilityEvent::sendEvent(const std::string& context, const std::string& payload)
 {
     if (pimpl->event == NULL) {
         nugu_error("event is NULL");
@@ -111,12 +111,8 @@ void CapabilityEvent::sendEvent(const std::string& context, const std::string& p
 
     pimpl->capability->getCapabilityHelper()->sendCommand(pimpl->capability->getName(), "System", "activity", "");
 
-    if (is_sync) {
-        nugu_network_manager_send_event(pimpl->event, 1);
-    } else {
-        pimpl->capability->getCapabilityHelper()->requestEventResult(pimpl->event);
-        nugu_network_manager_send_event(pimpl->event, 0);
-    }
+    pimpl->capability->getCapabilityHelper()->requestEventResult(pimpl->event);
+    nugu_network_manager_send_event(pimpl->event);
 }
 
 void CapabilityEvent::sendAttachmentEvent(bool is_end, size_t size, unsigned char* data)
@@ -403,16 +399,16 @@ bool Capability::getProperties(const std::string& property, std::list<std::strin
     return true;
 }
 
-std::string Capability::sendEvent(const std::string& name, const std::string& context, const std::string& payload, EventResultCallback cb, bool is_sync)
+std::string Capability::sendEvent(const std::string& name, const std::string& context, const std::string& payload, EventResultCallback cb)
 {
     CapabilityEvent event(name, this);
 
-    sendEvent(&event, context, payload, std::move(cb), is_sync);
+    sendEvent(&event, context, payload, std::move(cb));
 
     return event.getDialogRequestId();
 }
 
-void Capability::sendEvent(CapabilityEvent* event, const std::string& context, const std::string& payload, EventResultCallback cb, bool is_sync)
+void Capability::sendEvent(CapabilityEvent* event, const std::string& context, const std::string& payload, EventResultCallback cb)
 {
     if (!event)
         return;
@@ -426,7 +422,7 @@ void Capability::sendEvent(CapabilityEvent* event, const std::string& context, c
     else
         addEventResultCallback(ename, std::move(cb));
 
-    event->sendEvent(context, payload, is_sync);
+    event->sendEvent(context, payload);
 }
 
 void Capability::sendAttachmentEvent(CapabilityEvent* event, bool is_end, size_t size, unsigned char* data)


### PR DESCRIPTION
The sync type event send method is no longer used, so remove it.

Signed-off-by: Inho Oh <inho.oh@sk.com>