### PR TITLE
Fix gcc-10 format-truncation warning

### DIFF
--- a/plugins/filedump.c
+++ b/plugins/filedump.c
@@ -34,8 +34,8 @@ static NuguPcmDriver *pcm_driver;
 
 static int _dumpfile_open(const char *path, const char *prefix)
 {
-	char ymd[9];
-	char hms[7];
+	char ymd[32];
+	char hms[32];
 	time_t now;
 	struct tm now_tm;
 	char *buf = NULL;
@@ -44,10 +44,10 @@ static int _dumpfile_open(const char *path, const char *prefix)
 	now = time(NULL);
 	localtime_r(&now, &now_tm);
 
-	snprintf(ymd, 9, "%04d%02d%02d", now_tm.tm_year + 1900,
+	snprintf(ymd, sizeof(ymd), "%04d%02d%02d", now_tm.tm_year + 1900,
 		 now_tm.tm_mon + 1, now_tm.tm_mday);
-	snprintf(hms, 7, "%02d%02d%02d", now_tm.tm_hour, now_tm.tm_min,
-		 now_tm.tm_sec);
+	snprintf(hms, sizeof(hms), "%02d%02d%02d", now_tm.tm_hour,
+		 now_tm.tm_min, now_tm.tm_sec);
 
 	if (path)
 		buf = g_strdup_printf("%s/%s_%s_%s.dat", path, prefix, ymd,

--- a/plugins/gstreamer_pcm.c
+++ b/plugins/gstreamer_pcm.c
@@ -92,8 +92,8 @@ static int _pcm_stop(NuguPcmDriver *driver, NuguPcm *pcm);
 #if defined(NUGU_ENV_DUMP_PATH_PCM)
 static int _dumpfile_open(const char *path, const char *prefix)
 {
-	char ymd[9];
-	char hms[7];
+	char ymd[32];
+	char hms[32];
 	time_t now;
 	struct tm now_tm;
 	char *buf = NULL;
@@ -105,10 +105,10 @@ static int _dumpfile_open(const char *path, const char *prefix)
 	now = time(NULL);
 	localtime_r(&now, &now_tm);
 
-	snprintf(ymd, 9, "%04d%02d%02d", now_tm.tm_year + 1900,
+	snprintf(ymd, sizeof(ymd), "%04d%02d%02d", now_tm.tm_year + 1900,
 		 now_tm.tm_mon + 1, now_tm.tm_mday);
-	snprintf(hms, 7, "%02d%02d%02d", now_tm.tm_hour, now_tm.tm_min,
-		 now_tm.tm_sec);
+	snprintf(hms, sizeof(hms), "%02d%02d%02d", now_tm.tm_hour,
+		 now_tm.tm_min, now_tm.tm_sec);
 
 	buf = g_strdup_printf("%s/%s_%s_%s.dat", path, prefix, ymd, hms);
 

--- a/plugins/opus.c
+++ b/plugins/opus.c
@@ -64,8 +64,8 @@ static void dump_opus_error(int error_code)
 
 static int _dumpfile_open(const char *path, const char *prefix)
 {
-	char ymd[9];
-	char hms[7];
+	char ymd[32];
+	char hms[32];
 	time_t now;
 	struct tm now_tm;
 	char *buf = NULL;
@@ -77,10 +77,10 @@ static int _dumpfile_open(const char *path, const char *prefix)
 	now = time(NULL);
 	localtime_r(&now, &now_tm);
 
-	snprintf(ymd, 9, "%04d%02d%02d", now_tm.tm_year + 1900,
+	snprintf(ymd, sizeof(ymd), "%04d%02d%02d", now_tm.tm_year + 1900,
 		 now_tm.tm_mon + 1, now_tm.tm_mday);
-	snprintf(hms, 7, "%02d%02d%02d", now_tm.tm_hour, now_tm.tm_min,
-		 now_tm.tm_sec);
+	snprintf(hms, sizeof(hms), "%02d%02d%02d", now_tm.tm_hour,
+		 now_tm.tm_min, now_tm.tm_sec);
 
 	buf = g_strdup_printf("%s/%s_%s_%s.dat", path, prefix, ymd, hms);
 

--- a/plugins/portaudio_pcm_async.c
+++ b/plugins/portaudio_pcm_async.c
@@ -67,8 +67,8 @@ static NuguPcmDriver *pcm_driver;
 #if defined(NUGU_ENV_DUMP_PATH_PCM)
 static int _dumpfile_open(const char *path, const char *prefix)
 {
-	char ymd[9];
-	char hms[7];
+	char ymd[32];
+	char hms[32];
 	time_t now;
 	struct tm now_tm;
 	char *buf = NULL;
@@ -80,10 +80,10 @@ static int _dumpfile_open(const char *path, const char *prefix)
 	now = time(NULL);
 	localtime_r(&now, &now_tm);
 
-	snprintf(ymd, 9, "%04d%02d%02d", now_tm.tm_year + 1900,
+	snprintf(ymd, sizeof(ymd), "%04d%02d%02d", now_tm.tm_year + 1900,
 		 now_tm.tm_mon + 1, now_tm.tm_mday);
-	snprintf(hms, 7, "%02d%02d%02d", now_tm.tm_hour, now_tm.tm_min,
-		 now_tm.tm_sec);
+	snprintf(hms, sizeof(hms), "%02d%02d%02d", now_tm.tm_hour,
+		 now_tm.tm_min, now_tm.tm_sec);
 
 	buf = g_strdup_printf("%s/%s_%s_%s.dat", path, prefix, ymd, hms);
 

--- a/plugins/portaudio_pcm_sync.c
+++ b/plugins/portaudio_pcm_sync.c
@@ -75,8 +75,8 @@ static NuguPcmDriver *pcm_driver;
 #if defined(NUGU_ENV_DUMP_PATH_PCM)
 static int _dumpfile_open(const char *path, const char *prefix)
 {
-	char ymd[9];
-	char hms[7];
+	char ymd[32];
+	char hms[32];
 	time_t now;
 	struct tm now_tm;
 	char *buf = NULL;
@@ -88,10 +88,10 @@ static int _dumpfile_open(const char *path, const char *prefix)
 	now = time(NULL);
 	localtime_r(&now, &now_tm);
 
-	snprintf(ymd, 9, "%04d%02d%02d", now_tm.tm_year + 1900,
+	snprintf(ymd, sizeof(ymd), "%04d%02d%02d", now_tm.tm_year + 1900,
 		 now_tm.tm_mon + 1, now_tm.tm_mday);
-	snprintf(hms, 7, "%02d%02d%02d", now_tm.tm_hour, now_tm.tm_min,
-		 now_tm.tm_sec);
+	snprintf(hms, sizeof(hms), "%02d%02d%02d", now_tm.tm_hour,
+		 now_tm.tm_min, now_tm.tm_sec);
 
 	buf = g_strdup_printf("%s/%s_%s_%s.dat", path, prefix, ymd, hms);
 

--- a/plugins/portaudio_recorder.c
+++ b/plugins/portaudio_recorder.c
@@ -62,8 +62,8 @@ static NuguRecorderDriver *rec_driver;
 #if defined(NUGU_ENV_DUMP_PATH_RECORDER)
 static int _dumpfile_open(const char *path, const char *prefix)
 {
-	char ymd[9];
-	char hms[7];
+	char ymd[32];
+	char hms[32];
 	time_t now;
 	struct tm now_tm;
 	char *buf = NULL;
@@ -75,10 +75,10 @@ static int _dumpfile_open(const char *path, const char *prefix)
 	now = time(NULL);
 	localtime_r(&now, &now_tm);
 
-	snprintf(ymd, 9, "%04d%02d%02d", now_tm.tm_year + 1900,
+	snprintf(ymd, sizeof(ymd), "%04d%02d%02d", now_tm.tm_year + 1900,
 		 now_tm.tm_mon + 1, now_tm.tm_mday);
-	snprintf(hms, 7, "%02d%02d%02d", now_tm.tm_hour, now_tm.tm_min,
-		 now_tm.tm_sec);
+	snprintf(hms, sizeof(hms), "%02d%02d%02d", now_tm.tm_hour,
+		 now_tm.tm_min, now_tm.tm_sec);
 
 	buf = g_strdup_printf("%s/%s_%s_%s.dat", path, prefix, ymd, hms);
 


### PR DESCRIPTION
It is failed if compiling with `-Werror=format-truncation` with
`gcc v.10.2.0`.

    error: '%04d' directive output may be truncated writing between 4
    and 11 bytes into a region of size 9 [-Werror=format-truncation=]
    |    80 |  snprintf(ymd, 9, "%04d%02d%02d", now_tm.tm_year + 1900,
    |       |                    ^~~~

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>