### PR TITLE
network: add on-demand network type

### DIFF
--- a/examples/standalone/nugu_sdk_manager.cc
+++ b/examples/standalone/nugu_sdk_manager.cc
@@ -414,6 +414,15 @@ void NuguSDKManager::onStatusChanged(NetworkStatus status)
             on_fail_func();
 
         break;
+    case NetworkStatus::READY:
+        msg_info("Network ready.");
+        is_network_error = false;
+        nugu_sample_manager->handleNetworkResult(true);
+
+        if (on_init_func)
+            on_init_func();
+
+        break;
     case NetworkStatus::CONNECTED:
         msg_info("Network connected.");
         is_network_error = false;

--- a/include/base/nugu_network_manager.h
+++ b/include/base/nugu_network_manager.h
@@ -39,12 +39,17 @@ extern "C" {
 /**
  * @brief network status
  *
- * Basic connection status flow
+ * Basic connection status flow for connection-oriented
  *   - Normal connection: DISCONNECTED -> CONNECTING -> CONNECTED
  *   - Connection failed: DISCONNECTED -> CONNECTING -> DISCONNECTED
  *   - Token error: DISCONNECTED -> CONNECTING -> TOKEN_ERROR -> DISCONNECTED
  *
- * Connection recovery flow
+ * Basic connection status flow for connection-ondemand
+ *   - Normal connection: DISCONNECTED -> CONNECTING -> READY
+ *   - Connection failed: DISCONNECTED -> CONNECTING -> DISCONNECTED
+ *   - Token error: DISCONNECTED -> CONNECTING -> TOKEN_ERROR -> DISCONNECTED
+ *
+ * Connection recovery flow for connection-oriented
  *   - Connection recovered: CONNECTED -> CONNECTING -> CONNECTED
  *   - Recovery failed: CONNECTED -> CONNECTING -> DISCONNECTED
  *   - Token error: CONNECTED -> CONNECTING -> TOKEN_ERROR -> DISCONNECTED
@@ -56,6 +61,7 @@ extern "C" {
 typedef enum nugu_network_status {
 	NUGU_NETWORK_DISCONNECTED, /**< Network disconnected */
 	NUGU_NETWORK_CONNECTING, /**< Connection in progress */
+	NUGU_NETWORK_READY, /**< Network ready for ondemand connection type */
 	NUGU_NETWORK_CONNECTED, /**< Network connected */
 	NUGU_NETWORK_TOKEN_ERROR /**< Token error */
 } NuguNetworkStatus;

--- a/include/clientkit/network_manager_interface.hh
+++ b/include/clientkit/network_manager_interface.hh
@@ -36,8 +36,9 @@ namespace NuguClientKit {
 
 enum class NetworkStatus {
     DISCONNECTED, /**< Network disconnected */
-    CONNECTED, /**< Network connected */
-    CONNECTING /**< Connection in progress */
+    CONNECTING, /**< Connection in progress */
+    READY, /**< Network ready for ondemand connection type */
+    CONNECTED /**< Network connected */
 };
 
 enum class NetworkError {

--- a/src/core/network_manager.cc
+++ b/src/core/network_manager.cc
@@ -40,17 +40,23 @@ static void _status(NuguNetworkStatus status, void* userdata)
         for (auto listener : listeners) {
             listener->onStatusChanged(NetworkStatus::DISCONNECTED);
         }
-    } else if (status == NUGU_NETWORK_CONNECTED) {
-        nugu_info("Network connected");
-
-        for (auto listener : listeners) {
-            listener->onStatusChanged(NetworkStatus::CONNECTED);
-        }
     } else if (status == NUGU_NETWORK_CONNECTING) {
         nugu_info("Network connecting");
 
         for (auto listener : listeners) {
             listener->onStatusChanged(NetworkStatus::CONNECTING);
+        }
+    } else if (status == NUGU_NETWORK_READY) {
+        nugu_info("Network ready");
+
+        for (auto listener : listeners) {
+            listener->onStatusChanged(NetworkStatus::READY);
+        }
+    } else if (status == NUGU_NETWORK_CONNECTED) {
+        nugu_info("Network connected");
+
+        for (auto listener : listeners) {
+            listener->onStatusChanged(NetworkStatus::CONNECTED);
         }
     } else if (status == NUGU_NETWORK_TOKEN_ERROR) {
         nugu_error("Network token error");


### PR DESCRIPTION
Currently, only the method of maintaining the connection was
supported, but due to a new requirement, a method of requesting
a connection only when necessary was added. Aka connectionless
or on-demand connection.

When a network connection request is received from a user, the
gateway list is received from the registry server and the network
status is changed to `READY`.

After receiving an event transmission request, the SDK connects to
the gateway server, transmits the event, and terminates the
connection after receiving all responses.

Signed-off-by: Inho Oh <inho.oh@sk.com>