### PR TITLE
nugu_sample:Change shared_ptr to unique_ptr

### DIFF
--- a/examples/standalone/nugu_sdk_manager.cc
+++ b/examples/standalone/nugu_sdk_manager.cc
@@ -28,6 +28,12 @@ void msg_info(std::string&& message)
 {
     NuguSampleManager::info(std::move(message));
 }
+
+template <typename T, typename... Ts>
+std::unique_ptr<T> make_unique(Ts&&... params)
+{
+    return std::unique_ptr<T>(new T(std::forward<Ts>(params)...));
+}
 }
 
 /*******************************************************************************
@@ -119,7 +125,7 @@ NuguSDKManager::NuguSDKManager(NuguSampleManager* nugu_sample_manager)
 {
     this->nugu_sample_manager = nugu_sample_manager;
     speaker_status = SpeakerStatus::getInstance();
-    speaker_controller = std::make_shared<SpeakerController>();
+    speaker_controller = make_unique<SpeakerController>();
 }
 
 void NuguSDKManager::setup()
@@ -193,8 +199,8 @@ void NuguSDKManager::composeSDKCommands()
 
 void NuguSDKManager::createInstance()
 {
-    nugu_client = std::make_shared<NuguClient>();
-    capa_collection = std::make_shared<CapabilityCollection>();
+    nugu_client = make_unique<NuguClient>();
+    capa_collection = make_unique<CapabilityCollection>();
     nugu_core_container = nugu_client->getNuguCoreContainer();
     speech_operator = capa_collection->getSpeechOperator();
     network_manager = nugu_client->getNetworkManager();
@@ -213,7 +219,7 @@ void NuguSDKManager::createInstance()
     network_manager->setUserAgent("0.2.0");
 
     on_init_func = [&]() {
-        wakeup_handler = std::shared_ptr<IWakeupHandler>(nugu_core_container->createWakeupHandler(nugu_sample_manager->getModelPath()));
+        wakeup_handler = std::unique_ptr<IWakeupHandler>(nugu_core_container->createWakeupHandler(nugu_sample_manager->getModelPath()));
         speech_operator->setWakeupHandler(wakeup_handler.get());
     };
 }

--- a/examples/standalone/nugu_sdk_manager.hh
+++ b/examples/standalone/nugu_sdk_manager.hh
@@ -90,10 +90,10 @@ private:
     const int TEXT_INPUT_TYPE_1 = 1;
     const int TEXT_INPUT_TYPE_2 = 2;
 
-    std::shared_ptr<SpeakerController> speaker_controller = nullptr;
-    std::shared_ptr<NuguClient> nugu_client = nullptr;
-    std::shared_ptr<CapabilityCollection> capa_collection = nullptr;
-    std::shared_ptr<IWakeupHandler> wakeup_handler = nullptr;
+    std::unique_ptr<SpeakerController> speaker_controller = nullptr;
+    std::unique_ptr<NuguClient> nugu_client = nullptr;
+    std::unique_ptr<CapabilityCollection> capa_collection = nullptr;
+    std::unique_ptr<IWakeupHandler> wakeup_handler = nullptr;
     NuguSampleManager* nugu_sample_manager = nullptr;
     INuguCoreContainer* nugu_core_container = nullptr;
     IPlaySyncManager* playsync_manager = nullptr;


### PR DESCRIPTION
It change the shared_ptr to unique_ptr in NuguSDKManager
for improving memeory usage.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>