### PR TITLE
NetworkManager:Apply const reference in method arguments

### DIFF
--- a/include/clientkit/network_manager_interface.hh
+++ b/include/clientkit/network_manager_interface.hh
@@ -138,7 +138,7 @@ public:
      * @retval 0 success
      * @retval -1 failure
      */
-    virtual bool setToken(std::string token) = 0;
+    virtual bool setToken(const std::string& token) = 0;
 
     /**
      * @brief Set the device gateway registry url.
@@ -147,7 +147,7 @@ public:
      * @retval 0 success
      * @retval -1 failure
      */
-    virtual bool setRegistryUrl(std::string url) = 0;
+    virtual bool setRegistryUrl(const std::string& url) = 0;
 
     /**
      * @brief Set the HTTP header UserAgent information.
@@ -157,7 +157,7 @@ public:
      * @retval 0 success
      * @retval -1 failure
      */
-    virtual bool setUserAgent(std::string app_version, std::string additional_info = "") = 0;
+    virtual bool setUserAgent(const std::string& app_version, const std::string& additional_info = "") = 0;
 };
 
 /**

--- a/src/core/network_manager.cc
+++ b/src/core/network_manager.cc
@@ -172,7 +172,7 @@ std::vector<INetworkManagerListener*> NetworkManager::getListener()
     return listeners;
 }
 
-bool NetworkManager::setToken(std::string token)
+bool NetworkManager::setToken(const std::string& token)
 {
     /* JWT format consist of 3 parts (header, payload, signature) */
     gchar **jwt = g_strsplit(token.c_str(), ".", -1);
@@ -251,7 +251,7 @@ bool NetworkManager::setToken(std::string token)
     return true;
 }
 
-bool NetworkManager::setRegistryUrl(std::string url)
+bool NetworkManager::setRegistryUrl(const std::string& url)
 {
     if (nugu_network_manager_set_registry_url(url.c_str()) < 0) {
         nugu_error("network set registry url failed");
@@ -261,7 +261,7 @@ bool NetworkManager::setRegistryUrl(std::string url)
     return true;
 }
 
-bool NetworkManager::setUserAgent(std::string app_version, std::string additional_info)
+bool NetworkManager::setUserAgent(const std::string& app_version, const std::string& additional_info)
 {
     if (nugu_network_manager_set_useragent(app_version.c_str(), additional_info.c_str()) < 0) {
         nugu_error("network set useragent failed");

--- a/src/core/network_manager.hh
+++ b/src/core/network_manager.hh
@@ -35,9 +35,9 @@ public:
     std::vector<INetworkManagerListener*> getListener();
     bool connect() override;
     bool disconnect() override;
-    bool setToken(std::string token) override;
-    bool setRegistryUrl(std::string url) override;
-    bool setUserAgent(std::string app_version, std::string additional_info) override;
+    bool setToken(const std::string& token) override;
+    bool setRegistryUrl(const std::string& url) override;
+    bool setUserAgent(const std::string& app_version, const std::string& additional_info) override;
 
 private:
     std::vector<INetworkManagerListener*> listeners;


### PR DESCRIPTION
For preventing unnecessary copy of string argument,
it change to const reference in some methods of NetworkManager.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>