### PR TITLE
AudioInputProcessor:Apply move semantics in method arguments

### DIFF
--- a/src/core/audio_input_processor.cc
+++ b/src/core/audio_input_processor.cc
@@ -46,7 +46,7 @@ AudioInputProcessor::~AudioInputProcessor()
     }
 }
 
-void AudioInputProcessor::init(std::string name, std::string& sample, std::string& format, std::string& channel)
+void AudioInputProcessor::init(std::string&& name, std::string& sample, std::string& format, std::string& channel)
 {
     if (is_initialized) {
         nugu_dbg("It's already initialized.");

--- a/src/core/audio_input_processor.hh
+++ b/src/core/audio_input_processor.hh
@@ -36,7 +36,7 @@ public:
     virtual ~AudioInputProcessor();
 
 protected:
-    void init(std::string name, std::string& sample, std::string& format, std::string& channel);
+    void init(std::string&& name, std::string& sample, std::string& format, std::string& channel);
     bool start(const std::function<void()>& extra_func = nullptr);
     void stop();
     void sendEvent(const std::function<void()>& action = nullptr);


### PR DESCRIPTION
Because the first argument of init method is sent by r-value
in WakeupDetector and SpeechRecognizer(derived of AudioInputProcessor),
it change to handle by universal reference for moving object(not copy).

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>