### PR TITLE
Text:Refactor requestTextInput methods

### DIFF
--- a/src/capability/text_agent.hh
+++ b/src/capability/text_agent.hh
@@ -38,7 +38,6 @@ public:
     void setCapabilityListener(ICapabilityListener* clistener) override;
 
     std::string requestTextInput(const std::string& text, const std::string& token = "", bool include_dialog_attribute = true) override;
-    std::string requestTextInput(const std::string& text, const std::string& token, const std::string& ps_id);
 
     void notifyResponseTimeout();
 
@@ -49,6 +48,7 @@ private:
         std::string ps_id;
     };
 
+    std::string requestTextInput(TextInputParam&& text_input_param, bool routine_play, bool include_dialog_attribute = true);
     void sendEventTextInput(const TextInputParam& text_input_param, bool include_dialog_attribute = true, EventResultCallback cb = nullptr);
     void sendEventTextSourceFailed(const TextInputParam& text_input_param, EventResultCallback cb = nullptr);
     void sendEventTextRedirectFailed(const TextInputParam& text_input_param, EventResultCallback cb = nullptr);


### PR DESCRIPTION
The codes of overloading requestTextInput methods are almost same,
so, it refactor to remove duplication.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>