### PR TITLE
context:remove unnecessary context info about Routine

### DIFF
--- a/src/core/capability_manager.cc
+++ b/src/core/capability_manager.cc
@@ -253,13 +253,6 @@ std::string CapabilityManager::makeContextInfo(const std::string& cname, Json::V
             continue;
 
         ctx[icap->getName()]["version"] = icap->getVersion();
-
-        // TODO : It need to generalize not to handle each capability directly.
-        if (icap->getName() == "Routine") {
-            std::string routine_activity;
-            icap->getProperty("routineActivity", routine_activity);
-            ctx["Routine"]["routineActivity"] = routine_activity;
-        }
     }
 
     client["wakeupWord"] = wword;


### PR DESCRIPTION
Because, the routineActivity context info is only required when sent
events about Routine, it remove from makeContextInfo in CapabilityManager.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>