### PR TITLE
nugu_sample:Fix bug about constructing capability

### DIFF
--- a/examples/standalone/capability_collection.hh
+++ b/examples/standalone/capability_collection.hh
@@ -45,10 +45,14 @@ public:
     CapabilityCollection();
     virtual ~CapabilityCollection() = default;
 
-    template <typename T>
+    template <typename T = ICapabilityInterface>
     T* getCapability(const std::string& capability_name)
     {
-        return dynamic_cast<T*>(factories[capability_name]());
+        try {
+            return dynamic_cast<T*>(factories.at(capability_name)());
+        } catch (std::out_of_range& exception) {
+            return nullptr;
+        }
     }
 
     SpeechOperator* getSpeechOperator();


### PR DESCRIPTION
If the factory of specific capability is not exist in construction,
it occur std::bad_function_call error and the app is terminated.

So, it add the exception handling in factory usage.			

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>