### PR TITLE
CapabilityManager:refactor composing context info

### DIFF
--- a/include/clientkit/capability.hh
+++ b/include/clientkit/capability.hh
@@ -368,6 +368,12 @@ public:
     virtual std::string getContextInfo();
 
     /**
+     * @brief Update the compact context information of the capability agent.
+     * @param[in] ctx capability agent's context
+     */
+    virtual void updateCompactContext(Json::Value& ctx);
+
+    /**
      * @brief Get ICapabilityHelper instance for using NuguCore functions.
      * @return ICapabilityHelper instance
      */

--- a/include/clientkit/capability_interface.hh
+++ b/include/clientkit/capability_interface.hh
@@ -180,6 +180,12 @@ public:
     virtual void updateInfoForContext(Json::Value& ctx) = 0;
 
     /**
+     * @brief Update the compact context information of the capability agent.
+     * @param[in] ctx capability agent's context
+     */
+    virtual void updateCompactContext(Json::Value& ctx) = 0;
+
+    /**
      * @brief Process command from other objects.
      * @param[in] from capability who send the command
      * @param[in] command command

--- a/src/clientkit/capability.cc
+++ b/src/clientkit/capability.cc
@@ -490,6 +490,11 @@ std::string Capability::getContextInfo()
     return capa_helper->makeContextInfo(getName(), ctx);
 }
 
+void Capability::updateCompactContext(Json::Value& ctx)
+{
+    ctx[getName()]["version"] = getVersion();
+}
+
 ICapabilityHelper* Capability::getCapabilityHelper()
 {
     return capa_helper;

--- a/src/core/capability_manager.hh
+++ b/src/core/capability_manager.hh
@@ -62,7 +62,7 @@ public:
     void setWakeupWord(const std::string& word);
     std::string getWakeupWord();
 
-    std::string makeContextInfo(const std::string& cname, Json::Value& ctx);
+    std::string makeContextInfo(const std::string& cname, Json::Value& cap_ctx);
     std::string makeAllContextInfo();
 
     bool isSupportDirectiveVersion(const std::string& version, ICapabilityInterface* cap);
@@ -81,6 +81,7 @@ public:
 
 private:
     ICapabilityInterface* findCapability(const std::string& cname);
+    Json::Value getBaseContextInfo(Json::Value& supported_interfaces, Json::Value&& playstack);
 
     static CapabilityManager* instance;
     std::map<std::string, ICapabilityInterface*> caps;


### PR DESCRIPTION
It add the updateCompactContext API in ICapabilityInterface for retrieving
the simple context information (like version) from each capability agent.

It update to use updateCompactContext API in makeContextInfo()
for removing implementation details about capability.
(It has to implement the check logic about Delegation in DelegationAgent.)

It extract getBaseContextInfo() from makeContextInfo() and
makeAllContextInfo() for removing duplicated codes.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>