### PR TITLE
TextAgent:change handling TextRedirect directive

### DIFF
--- a/src/capability/text_agent.cc
+++ b/src/capability/text_agent.cc
@@ -311,8 +311,7 @@ void TextAgent::parsingTextRedirect(const char* message)
 
         text_input_param.text = root["text"].asString();
         text_input_param.token = root["token"].asString();
-        target_ps_id = root["targetPlayServiceId"].asString();
-        text_input_param.ps_id = !target_ps_id.empty() ? target_ps_id : root["playServiceId"].asString();
+        text_input_param.ps_id = root["targetPlayServiceId"].asString();
 
         startInteractionControl(getInteractionMode(root["interactionControl"]));
 


### PR DESCRIPTION
If the targetPlayServiceId in TextRedirect directive is empty,
it shouldn't send the playServiceId when sending TextInput event.

So. it update not to change to playServiceId,
if the targetPlayServiceId is empty.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>