### PR TITLE
TextAgent:Apply focus in sending TextInput event

### DIFF
--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -369,6 +369,10 @@ bool ASRAgent::getProperty(const std::string& property, std::string& value)
             Json::FastWriter writer;
             value = writer.write(es_attr.asr_context);
         }
+    } else if (property == "focusState") {
+        if (asr_dm_listener->focus_state == FocusState::FOREGROUND
+            || asr_user_listener->focus_state == FocusState::FOREGROUND)
+            value = focus_manager->getStateString(FocusState::FOREGROUND);
     } else {
         nugu_error("invalid property: %s", property.c_str());
         return false;

--- a/src/capability/text_agent.hh
+++ b/src/capability/text_agent.hh
@@ -23,7 +23,8 @@
 namespace NuguCapability {
 
 class TextAgent final : public Capability,
-                        public ITextHandler {
+                        public ITextHandler,
+                        public IFocusResourceListener {
 public:
     TextAgent();
     virtual ~TextAgent() = default;
@@ -40,6 +41,9 @@ public:
     std::string requestTextInput(const std::string& text, const std::string& token = "", bool include_dialog_attribute = true) override;
 
     void notifyResponseTimeout();
+
+    // implements IFocusResourceListener
+    void onFocusChanged(FocusState state) override;
 
 private:
     using TextInputParam = struct {
@@ -59,6 +63,8 @@ private:
     void notifyEventResponse(const std::string& msg_id, const std::string& data, bool success) override;
     void startInteractionControl(InteractionMode&& mode);
     void finishInteractionControl();
+    void requestFocus();
+    void releaseFocus();
 
     const std::string FAIL_EVENT_ERROR_CODE = "NOT_SUPPORTED_STATE";
 
@@ -70,6 +76,7 @@ private:
     std::string dir_groups;
     InteractionMode interaction_mode;
     bool handle_interaction_control;
+    FocusState focus_state;
 
     // attribute
     int response_timeout;


### PR DESCRIPTION
When the ASR has foreground focus, if it try to send TextInput event,
the ASR is canceled and the focus is released.

In this situation, if background media exist, it has acquire foreground
focus even if not receiving response of TextInput event, so,
it cause abnormal behavior.

So, it update to relay focus in TextInput event, if the ASR has foreground
focus for maintaining focus until receiving response.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>