### PR TITLE
Mic:adjust send SetMicSucceeded event

### DIFF
--- a/src/capability/mic_agent.cc
+++ b/src/capability/mic_agent.cc
@@ -135,16 +135,15 @@ void MicAgent::control(bool enable, bool send_event)
     MicStatus pre_status = cur_status;
     cur_status = enable ? MicStatus::ON : MicStatus::OFF;
 
-    if (cur_status == pre_status)
-        return;
+    if (cur_status != pre_status) {
+        capa_helper->setMute(cur_status == MicStatus::OFF);
 
-    capa_helper->setMute(cur_status == MicStatus::OFF);
+        if (mic_listener)
+            mic_listener->micStatusChanged(cur_status);
+    }
 
     if (send_event)
         sendEventSetMicSucceeded();
-
-    if (mic_listener)
-        mic_listener->micStatusChanged(cur_status);
 }
 
 std::string MicAgent::getCurrentMicStatusText()


### PR DESCRIPTION
Even if the mic status is not changed,
it change to send SetMicSucceeded event.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>