### PR TITLE
TTS:fix handling TTS.Stop directive

### DIFF
--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -487,9 +487,17 @@ void TTSAgent::parsingStop(const char* message)
     if (!root["playServiceId"].empty())
         ps_id = root["playServiceId"].asString();
 
-    (cur_state == MediaPlayerState::PLAYING)
-        ? (void)focus_manager->releaseFocus(INFO_FOCUS_TYPE, CAPABILITY_NAME)
-        : playsync_manager->releaseSyncImmediately(playstackctl_ps_id, getName());
+    if (cur_state == MediaPlayerState::PLAYING) {
+        focus_manager->releaseFocus(INFO_FOCUS_TYPE, CAPABILITY_NAME);
+    } else {
+        std::string asr_focus_state;
+        capa_helper->getCapabilityProperty("ASR", "focusState", asr_focus_state);
+
+        if (asr_focus_state == "FOREGROUND")
+            capa_helper->sendCommand("TTS", "ASR", "releaseFocus", "");
+
+        playsync_manager->releaseSyncImmediately(playstackctl_ps_id, getName());
+    }
 }
 
 void TTSAgent::postProcessDirective(bool is_cancel)


### PR DESCRIPTION
When receiving TTS.Stop directive by ASR result, because there are
no handling about focus, the ASR has no chance to release focus,
so, the state is remained BUSY.

So, it update to check the focus state of ASR and
release the ASR focus, if the state is foreground.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>