### PR TITLE
System:adjust access specifier

### DIFF
--- a/src/capability/system_agent.hh
+++ b/src/capability/system_agent.hh
@@ -40,12 +40,13 @@ public:
     void synchronizeState() override;
     void updateUserActivity() override;
 
+private:
+    // send event
     void sendEventSynchronizeState(EventResultCallback cb = nullptr);
     void sendEventUserInactivityReport(int seconds, EventResultCallback cb = nullptr);
     void sendEventEcho(EventResultCallback cb = nullptr);
     void sendEventDisconnect(EventResultCallback cb = nullptr);
 
-private:
     // parsing directive
     void parsingResetUserInactivity(const char* message);
     void parsingHandoffConnection(const char* message);


### PR DESCRIPTION
It adjust the access specifier of some methods which are not used
by outside from public to private in SystemAgent.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>