### PR TITLE
Text:adjust access specifier and method order

### DIFF
--- a/src/capability/text_agent.cc
+++ b/src/capability/text_agent.cc
@@ -160,6 +160,12 @@ std::string TextAgent::requestTextInput(const std::string& text, const std::stri
     return requestTextInput({ text, token, "" }, false, include_dialog_attribute);
 }
 
+void TextAgent::onFocusChanged(FocusState state)
+{
+    nugu_info("Focus Changed(%s -> %s)", focus_manager->getStateString(state).c_str(), focus_manager->getStateString(state).c_str());
+    focus_state = state;
+}
+
 std::string TextAgent::requestTextInput(TextInputParam&& text_input_param, bool routine_play, bool include_dialog_attribute)
 {
     nugu_dbg("receive text interface : %s from user app", text_input_param.text.c_str());
@@ -198,16 +204,6 @@ std::string TextAgent::requestTextInput(TextInputParam&& text_input_param, bool 
     capa_helper->sendCommand("Text", "ASR", "cancel", "");
 
     return cur_dialog_id;
-}
-
-void TextAgent::notifyResponseTimeout()
-{
-    if (text_listener)
-        text_listener->onError(TextError::RESPONSE_TIMEOUT, cur_dialog_id);
-
-    cur_state = TextState::IDLE;
-    if (text_listener)
-        text_listener->onState(cur_state, cur_dialog_id);
 }
 
 void TextAgent::sendEventTextInput(const TextInputParam& text_input_param, bool include_dialog_attribute, EventResultCallback cb)
@@ -366,6 +362,16 @@ void TextAgent::notifyEventResponse(const std::string& msg_id, const std::string
     releaseFocus();
 }
 
+void TextAgent::notifyResponseTimeout()
+{
+    if (text_listener)
+        text_listener->onError(TextError::RESPONSE_TIMEOUT, cur_dialog_id);
+
+    cur_state = TextState::IDLE;
+    if (text_listener)
+        text_listener->onState(cur_state, cur_dialog_id);
+}
+
 void TextAgent::startInteractionControl(InteractionMode&& mode)
 {
     interaction_mode = mode;
@@ -380,12 +386,6 @@ void TextAgent::finishInteractionControl()
         interaction_mode = InteractionMode::NONE;
         handle_interaction_control = false;
     }
-}
-
-void TextAgent::onFocusChanged(FocusState state)
-{
-    nugu_info("Focus Changed(%s -> %s)", focus_manager->getStateString(state).c_str(), focus_manager->getStateString(state).c_str());
-    focus_state = state;
 }
 
 void TextAgent::requestFocus()

--- a/src/capability/text_agent.hh
+++ b/src/capability/text_agent.hh
@@ -40,8 +40,6 @@ public:
 
     std::string requestTextInput(const std::string& text, const std::string& token = "", bool include_dialog_attribute = true) override;
 
-    void notifyResponseTimeout();
-
     // implements IFocusResourceListener
     void onFocusChanged(FocusState state) override;
 
@@ -61,6 +59,7 @@ private:
     void parsingTextRedirect(const char* message);
     bool handleTextCommonProcess(const TextInputParam& text_input_param);
     void notifyEventResponse(const std::string& msg_id, const std::string& data, bool success) override;
+    void notifyResponseTimeout();
     void startInteractionControl(InteractionMode&& mode);
     void finishInteractionControl();
     void requestFocus();


### PR DESCRIPTION
It adjust the access specifier of some methods which are not used
by outside from public to private in TextAgent.

It adjust method order in TextAgent source file to match with header.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>