### PR TITLE
AudioPlayerAgent: modified suspend (pause policy)

### DIFF
--- a/src/capability/audio_player_agent.hh
+++ b/src/capability/audio_player_agent.hh
@@ -153,6 +153,7 @@ private:
     bool has_play_directive;
     std::string play_directive_dialog_id;
     bool receive_new_play_directive;
+    bool suspended_stop_policy;
 
     AudioPlayerState cur_aplayer_state;
     AudioPlayerState prev_aplayer_state;


### PR DESCRIPTION
AudioPlayerAgent is blocked to media playback on foreground action
only if the suspend policy is `SuspendPolicy::STOP`.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>