### PR TITLE
focus:add convertToFocusState in IFocusManager

### DIFF
--- a/include/clientkit/focus_manager_interface.hh
+++ b/include/clientkit/focus_manager_interface.hh
@@ -181,6 +181,14 @@ public:
     virtual std::string getStateString(FocusState state) = 0;
 
     /**
+     * @brief Convert state text to matched FocusState enum.
+     * @param[in] state_text state text
+     * @throw std::out_of_range exception thrown if matched FocusState not exist
+     * @return FocusState enum
+     */
+    virtual FocusState convertToFocusState(const std::string& state_text) = 0;
+
+    /**
      * @brief Add the Observer object
      * @param[in] observer observer object
      */

--- a/src/capability/text_agent.cc
+++ b/src/capability/text_agent.cc
@@ -396,8 +396,12 @@ void TextAgent::requestFocus()
     std::string asr_focus_state;
     capa_helper->getCapabilityProperty("ASR", "focusState", asr_focus_state);
 
-    if (asr_focus_state == "FOREGROUND")
-        focus_manager->requestFocus(ASR_USER_FOCUS_TYPE, CAPABILITY_NAME, this);
+    try {
+        if (focus_manager->convertToFocusState(asr_focus_state) == FocusState::FOREGROUND)
+            focus_manager->requestFocus(ASR_USER_FOCUS_TYPE, CAPABILITY_NAME, this);
+    } catch (std::out_of_range& exception) {
+        nugu_warn("The matched FocusState is not exist");
+    }
 }
 
 void TextAgent::releaseFocus()

--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -473,8 +473,12 @@ void TTSAgent::parsingStop(const char* message)
         std::string asr_focus_state;
         capa_helper->getCapabilityProperty("ASR", "focusState", asr_focus_state);
 
-        if (asr_focus_state == "FOREGROUND")
-            capa_helper->sendCommand("TTS", "ASR", "releaseFocus", "");
+        try {
+            if (focus_manager->convertToFocusState(asr_focus_state) == FocusState::FOREGROUND)
+                capa_helper->sendCommand("TTS", "ASR", "releaseFocus", "");
+        } catch (std::out_of_range& exception) {
+            nugu_warn("The matched FocusState is not exist");
+        }
 
         playsync_manager->releaseSyncImmediately(playstackctl_ps_id, getName());
     }

--- a/src/core/focus_manager.cc
+++ b/src/core/focus_manager.cc
@@ -226,7 +226,6 @@ bool FocusManager::releaseFocus(const std::string& type, const std::string& name
         return true;
     }
 
-
     nugu_info("[%s - %s] - FOREGROUND (priority - req:%d, rel:%d)", activate_focus->type.c_str(), activate_focus->name.c_str(), activate_focus->request_priority, activate_focus->release_priority);
     activate_focus->setState(FocusState::FOREGROUND);
     return true;
@@ -337,17 +336,29 @@ std::string FocusManager::getStateString(FocusState state)
 
     switch (state) {
     case FocusState::NONE:
-        name = "NONE";
+        name = FOCUS_STATE_NONE;
         break;
     case FocusState::FOREGROUND:
-        name = "FOREGROUND";
+        name = FOCUS_STATE_FOREGROUND;
         break;
     case FocusState::BACKGROUND:
-        name = "BACKGROUND";
+        name = FOCUS_STATE_BACKGROUND;
         break;
     }
 
     return name;
+}
+
+FocusState FocusManager::convertToFocusState(const std::string& state_text)
+{
+    if (state_text == FOCUS_STATE_FOREGROUND)
+        return FocusState::FOREGROUND;
+    else if (state_text == FOCUS_STATE_BACKGROUND)
+        return FocusState::BACKGROUND;
+    else if (state_text == FOCUS_STATE_NONE)
+        return FocusState::NONE;
+    else
+        throw std::out_of_range("The such FocusState is not exist.");
 }
 
 void FocusManager::onFocusChanged(const std::string& type, const std::string& name, FocusState state)

--- a/src/core/focus_manager.hh
+++ b/src/core/focus_manager.hh
@@ -73,6 +73,7 @@ public:
     void stopForegroundFocus() override;
 
     std::string getStateString(FocusState state) override;
+    FocusState convertToFocusState(const std::string& state_text) override;
 
     void addObserver(IFocusManagerObserver* observer) override;
     void removeObserver(IFocusManagerObserver* observer) override;
@@ -83,6 +84,10 @@ public:
     void printConfigurations();
 
 private:
+    const std::string FOCUS_STATE_FOREGROUND = "FOREGROUND";
+    const std::string FOCUS_STATE_BACKGROUND = "BACKGROUND";
+    const std::string FOCUS_STATE_NONE = "NONE";
+
     std::map<std::string, int> request_configuration_map;
     std::map<std::string, int> release_configuration_map;
     std::list<std::shared_ptr<FocusResource>> focus_resource_ordered_list;

--- a/tests/core/test_core_focus_manager.cc
+++ b/tests/core/test_core_focus_manager.cc
@@ -685,6 +685,27 @@ static void test_focusmanager_request_resource_hold_and_unhold_with_different_re
     ASSERT_EXPECTED_STATE(fixture->alert_resource, FocusState::FOREGROUND);
 }
 
+static void test_focusmanager_convert_state_text_to_focusstate_enum(ntimerFixture* fixture, gconstpointer ignored)
+{
+    FocusManager* focus_manager = fixture->focus_manager;
+    const std::string FOREGROUND_STATE = focus_manager->getStateString(FocusState::FOREGROUND);
+    const std::string BACKGROUND_STATE = focus_manager->getStateString(FocusState::BACKGROUND);
+    const std::string NONE_STATE = focus_manager->getStateString(FocusState::NONE);
+
+    // check normal case
+    g_assert(focus_manager->convertToFocusState(FOREGROUND_STATE) == FocusState::FOREGROUND);
+    g_assert(focus_manager->convertToFocusState(BACKGROUND_STATE) == FocusState::BACKGROUND);
+    g_assert(focus_manager->convertToFocusState(NONE_STATE) == FocusState::NONE);
+
+    // check abnormal case (incorrect text)
+    try {
+        focus_manager->convertToFocusState("abcd");
+        g_test_fail();
+    } catch (std::out_of_range& exception) {
+        g_assert_nonnull(exception.what());
+    }
+}
+
 int main(int argc, char* argv[])
 {
 #if !GLIB_CHECK_VERSION(2, 36, 0)
@@ -727,6 +748,7 @@ int main(int argc, char* argv[])
     G_TEST_ADD_FUNC("/core/FocusManager/NoStealResourceWithHigherResourceByRequestPriority", test_focusmanager_no_steal_resource_with_higher_resource_request_priority);
     G_TEST_ADD_FUNC("/core/FocusManager/ReleaseResourcesByReleasePriority", test_focusmanager_release_resources_by_release_priority);
     G_TEST_ADD_FUNC("/core/FocusManager/RequestResourceHoldAndUnHoldWithDifferentRequestReleasePriority", test_focusmanager_request_resource_hold_and_unhold_with_different_request_release_priority);
+    G_TEST_ADD_FUNC("/core/FocusManager/ConvertStateTextToFocusStateEnum", test_focusmanager_convert_state_text_to_focusstate_enum);
 
     return g_test_run();
 }


### PR DESCRIPTION
In some case, it needs to convert FocusState to string and vice versa.
For preventing incorrect string usage, it defines the matched string
in FocusManager and add the related API.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>