### PR TITLE
AudioPlayer:update condition to skip intermediate foreground focus

### DIFF
--- a/src/capability/audio_player_agent.hh
+++ b/src/capability/audio_player_agent.hh
@@ -117,6 +117,7 @@ private:
     void sendEventByRequestOthersDirective(const std::string& dname, EventResultCallback cb = nullptr);
     void sendEventRequestPlayCommandIssued(const std::string& dname, const std::string& payload, EventResultCallback cb = nullptr);
     void sendEventRequestCommandFailed(const std::string& play_service_id, const std::string& type, const std::string& reason, EventResultCallback cb = nullptr);
+    void notifyEventResponse(const std::string& msg_id, const std::string& data, bool success) override;
 
     bool isContentCached(const std::string& key, std::string& playurl);
     void parsingPlay(const char* message);
@@ -132,6 +133,7 @@ private:
 
     void clearContext();
     void checkAndUpdateVolume();
+    bool hasToSkipForegroundAction();
     void executeOnForegroundAction();
     void executeOnBackgroundAction();
 
@@ -154,6 +156,7 @@ private:
     std::string play_directive_dialog_id;
     bool receive_new_play_directive;
     bool suspended_stop_policy;
+    bool skip_intermediate_foreground_focus;
 
     AudioPlayerState cur_aplayer_state;
     AudioPlayerState prev_aplayer_state;


### PR DESCRIPTION
When sending StopCommandIssued and PauseCommandIssued event,
if the focus is mixed with ASR, before receiving related directive,
it could chance to get foreground focus intermediately,
so it play media in very short term.

For preventing this abnormal situation, it apply flag not to play media
even if it has foreground focus until receiving response of event.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>