### PR TITLE
AudioPlayerAgent: fix the bug

### DIFF
--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -330,8 +330,8 @@ std::string AudioPlayerAgent::play()
 
 std::string AudioPlayerAgent::stop()
 {
-    skip_intermediate_foreground_focus = true;
     std::string id = sendEventByDisplayInterface("StopCommandIssued");
+    skip_intermediate_foreground_focus = !id.empty();
     nugu_dbg("user request dialog id: %s", id.c_str());
     return id;
 }
@@ -352,8 +352,8 @@ std::string AudioPlayerAgent::prev()
 
 std::string AudioPlayerAgent::pause()
 {
-    skip_intermediate_foreground_focus = true;
     std::string id = sendEventByDisplayInterface("PauseCommandIssued");
+    skip_intermediate_foreground_focus = !id.empty();
     nugu_dbg("user request dialog id: %s", id.c_str());
     return id;
 }


### PR DESCRIPTION
The content is not played when it is failed to send event with the
flag `skip_intermediate_foreground_focus` set.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>