### PR TITLE
Audioplayer direct control

### DIFF
--- a/include/capability/audio_player_interface.hh
+++ b/include/capability/audio_player_interface.hh
@@ -153,9 +153,10 @@ public:
 
     /**
      * @brief Request the audio player to stop the current content.
-     * @return dialog request id if a NUGU service request succeeds with user text, otherwise empty string
+     * @param[in] direct_access control mediaplayer via sending event or directly access
+     * @return dialog request id if a NUGU service request succeeds with user text, otherwise empty string (only used direct_access is false)
      */
-    virtual std::string stop() = 0;
+    virtual std::string stop(bool direct_access = false) = 0;
 
     /**
      * @brief Request the audio player to play the next content.
@@ -171,15 +172,17 @@ public:
 
     /**
      * @brief Request the audio player to pause the current content.
-     * @return dialog request id if a NUGU service request succeeds with user text, otherwise empty string
+     * @param[in] direct_access control mediaplayer via sending event or directly access
+     * @return dialog request id if a NUGU service request succeeds with user text, otherwise empty string (only used direct_access is false)
      */
-    virtual std::string pause() = 0;
+    virtual std::string pause(bool direct_access = false) = 0;
 
     /**
      * @brief Request the audio player to resume the current content.
-     * @return dialog request id if a NUGU service request succeeds with user text, otherwise empty string
+     * @param[in] direct_access control mediaplayer via sending event or directly access
+     * @return dialog request id if a NUGU service request succeeds with user text, otherwise empty string (only used direct_access is false)
      */
-    virtual std::string resume() = 0;
+    virtual std::string resume(bool direct_access = false) = 0;
 
     /**
      * @brief Request the audio player to move the current content section.

--- a/src/capability/audio_player_agent.hh
+++ b/src/capability/audio_player_agent.hh
@@ -63,11 +63,11 @@ public:
     void addListener(IAudioPlayerListener* listener) override;
     void removeListener(IAudioPlayerListener* listener) override;
     std::string play() override;
-    std::string stop() override;
+    std::string stop(bool direct_access) override;
     std::string next() override;
     std::string prev() override;
-    std::string pause() override;
-    std::string resume() override;
+    std::string pause(bool direct_access) override;
+    std::string resume(bool direct_access) override;
     void seek(int msec) override;
     std::string requestFavoriteCommand(bool current_favorite) override;
     std::string requestRepeatCommand(RepeatType current_repeat) override;
@@ -107,7 +107,7 @@ private:
     void sendEventPlaybackFailed(PlaybackError err, const std::string& reason, EventResultCallback cb = nullptr);
     void sendEventProgressReportDelayElapsed(EventResultCallback cb = nullptr);
     void sendEventProgressReportIntervalElapsed(EventResultCallback cb = nullptr);
-    std::string sendEventByDisplayInterface(const std::string& command, EventResultCallback cb = nullptr);
+    std::string sendEventByMediaPlayerControl(const std::string& command, EventResultCallback cb = nullptr);
     void sendEventShowLyricsSucceeded(EventResultCallback cb = nullptr);
     void sendEventShowLyricsFailed(EventResultCallback cb = nullptr);
     void sendEventHideLyricsSucceeded(EventResultCallback cb = nullptr);


### PR DESCRIPTION
The AudioPlayerAgent is support to control player directly as belows.

	pause(bool direct_access = false)
	resume(bool direct_access = false)
	stop(bool direct_access = false)

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>