### PR TITLE
AudioPlayerAgent: hold pause event

### DIFF
--- a/examples/standalone/capability/audio_player_listener.cc
+++ b/examples/standalone/capability/audio_player_listener.cc
@@ -61,6 +61,9 @@ void AudioPlayerListener::mediaEventReport(AudioPlayerEvent event, const std::st
     case AudioPlayerEvent::INVALID_URL:
         std::cout << "INVALID_URL\n";
         break;
+    case AudioPlayerEvent::HOLD_PAUSE:
+        std::cout << "HOLD_PAUSE\n";
+        break;
     default:
         break;
     }

--- a/include/capability/audio_player_interface.hh
+++ b/include/capability/audio_player_interface.hh
@@ -54,7 +54,8 @@ enum class AudioPlayerEvent {
     UNDERRUN, /**< This event is occurred when the content is reloaded because of bad quality network */
     LOAD_FAILED, /**< This event is occurred when the content is not loaded successfully */
     LOAD_DONE, /**< This event is occurred when the content is loaded successfully */
-    INVALID_URL /**< This event is occurred when the content is not valid url */
+    INVALID_URL, /**< This event is occurred when the content is not valid url */
+    HOLD_PAUSE /**< This event is occurred when the agent receives a pause directive, it blocks content playback until another directive is received. */
 };
 
 /**

--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -1150,6 +1150,10 @@ void AudioPlayerAgent::parsingPause(const char* message)
         playsync_manager->releaseSyncLater(playserviceid, getName());
 
         cur_dialog_id = nugu_directive_peek_dialog_id(getNuguDirective());
+
+        for (const auto& aplayer_listener : aplayer_listeners)
+            aplayer_listener->mediaEventReport(AudioPlayerEvent::HOLD_PAUSE, cur_dialog_id);
+
         if (!cur_player->pause()) {
             nugu_error("pause media failed");
             sendEventPlaybackFailed(PlaybackError::MEDIA_ERROR_INTERNAL_DEVICE_ERROR, "player can't pause");


### PR DESCRIPTION
This event is occurred when the agent receives a pause directive, it
blocks content playback until another directive is received.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>