### PR TITLE
playsync:update releaseSyncImmediately condition

### DIFF
--- a/src/core/playsync_manager.cc
+++ b/src/core/playsync_manager.cc
@@ -159,6 +159,7 @@ void PlaySyncManager::releaseSyncLater(const std::string& ps_id, const std::stri
 
 void PlaySyncManager::releaseSyncImmediately(const std::string& ps_id, const std::string& requester)
 {
+    clearPostPonedRelease();
     rawReleaseSync(ps_id, requester, PlayStackRemoveMode::Immediately);
 }
 


### PR DESCRIPTION
If the postPoneRelease is called before releaseSyncImmediately,
the release is not activated until the continueRelease is called.

Because the requirement of releaseSyncImmediately is to release at once,
it update to active like that, even if the postPoneRelease is called.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>