### PR TITLE
AudioPlayerAgent: add pause reason

### DIFF
--- a/examples/standalone/capability/audio_player_listener.cc
+++ b/examples/standalone/capability/audio_player_listener.cc
@@ -61,8 +61,14 @@ void AudioPlayerListener::mediaEventReport(AudioPlayerEvent event, const std::st
     case AudioPlayerEvent::INVALID_URL:
         std::cout << "INVALID_URL\n";
         break;
-    case AudioPlayerEvent::HOLD_PAUSE:
-        std::cout << "HOLD_PAUSE\n";
+    case AudioPlayerEvent::PAUSE_BY_DIRECTIVE:
+        std::cout << "PAUSE_BY_DIRECTIVE\n";
+        break;
+    case AudioPlayerEvent::PAUSE_BY_FOCUS:
+        std::cout << "PAUSE_BY_FOCUS\n";
+        break;
+    case AudioPlayerEvent::PAUSE_BY_APPLICATION:
+        std::cout << "PAUSE_BY_APPLICATION\n";
         break;
     default:
         break;

--- a/include/capability/audio_player_interface.hh
+++ b/include/capability/audio_player_interface.hh
@@ -55,7 +55,9 @@ enum class AudioPlayerEvent {
     LOAD_FAILED, /**< This event is occurred when the content is not loaded successfully */
     LOAD_DONE, /**< This event is occurred when the content is loaded successfully */
     INVALID_URL, /**< This event is occurred when the content is not valid url */
-    HOLD_PAUSE /**< This event is occurred when the agent receives a pause directive, it blocks content playback until another directive is received. */
+    PAUSE_BY_DIRECTIVE, /**< This event is occurred when the agent receives a pause directive, it blocks content playback until another directive is received. */
+    PAUSE_BY_FOCUS,  /**< This event is occurred when the agent loses focus by another higher focus */
+    PAUSE_BY_APPLICATION /**< This event is occurred when the application pause the mediaplayer directly access */
 };
 
 /**


### PR DESCRIPTION
The AudioPlayerAgent is support now tell application why mediaplayer
is paused.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>