### PR TITLE
TTS:update TTS playsync release

### DIFF
--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -410,7 +410,7 @@ void TTSAgent::parsingSpeak(const char* message)
         return;
     }
 
-    is_stopped_by_explicit = false;
+    is_stopped_by_explicit = isSpeakTextEmpty(text);
     destroy_directive_by_agent = true;
     speak_dir = nullptr;
 
@@ -528,6 +528,11 @@ void TTSAgent::checkAndUpdateVolume()
         player->setVolume(volume);
         volume_update = false;
     }
+}
+
+bool TTSAgent::isSpeakTextEmpty(const std::string& raw_text)
+{
+    return raw_text.find("></skml>") != std::string::npos;
 }
 
 void TTSAgent::mediaStateChanged(MediaPlayerState state)

--- a/src/capability/tts_agent.hh
+++ b/src/capability/tts_agent.hh
@@ -70,6 +70,7 @@ private:
     void sendClearNudgeCommand(NuguDirective* ndir);
     void executeOnForegroundAction();
     void checkAndUpdateVolume();
+    bool isSpeakTextEmpty(const std::string& raw_text);
 
     void mediaStateChanged(MediaPlayerState state) override;
     void mediaEventReport(MediaPlayerEvent event) override;


### PR DESCRIPTION
In so many case, when the specific play is stopped by user command,
TTS.Speak direcive which has not contain text are delivered from server.

Because the playsync has to be released immediatley in this situation,
it update to check whether TTS.Speak direcive has contain text or not,
so progressing release sync correctly.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>