### PR TITLE
AudioPlayer:add to send LOAD_DONE media event

### DIFF
--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -666,6 +666,10 @@ void AudioPlayerAgent::mediaEventReport(MediaPlayerEvent event)
         break;
     case MediaPlayerEvent::LOADING_MEDIA_SUCCESS:
         nugu_dbg("LOADING_MEDIA_SUCCESS");
+
+        for (const auto& aplayer_listener : aplayer_listeners)
+            aplayer_listener->mediaEventReport(AudioPlayerEvent::LOAD_DONE, cur_dialog_id);
+
         break;
     case MediaPlayerEvent::PLAYING_MEDIA_FINISHED:
         nugu_dbg("PLAYING_MEDIA_FINISHED");


### PR DESCRIPTION
It add to send AudioPlayerEvent::LOAD_DONE event,
when handling MediaPlayerEvent::LOADING_MEDIA_SUCCESS in mediaEventReport.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>