### PR TITLE
packaging:fix libnugu and libnugu-example install

### DIFF
--- a/packaging/bionic/libnugu-examples.install
+++ b/packaging/bionic/libnugu-examples.install
@@ -1,2 +1,2 @@
 debian/tmp/usr/bin/*
-debian/tmp/usr/share/*
+debian/tmp/usr/share/nugu/testcases/*

--- a/packaging/bionic/libnugu.install
+++ b/packaging/bionic/libnugu.install
@@ -1,2 +1,2 @@
 debian/tmp/usr/lib/*/*.so.*
-debian/tmp/usr/share/*
+debian/tmp/usr/share/nugu/model/*

--- a/packaging/xenial/libnugu-examples.install
+++ b/packaging/xenial/libnugu-examples.install
@@ -1,2 +1,2 @@
 debian/tmp/usr/bin/*
-debian/tmp/usr/share/*
+debian/tmp/usr/share/nugu/testcases/*

--- a/packaging/xenial/libnugu.install
+++ b/packaging/xenial/libnugu.install
@@ -1,2 +1,2 @@
 debian/tmp/usr/lib/*/*.so.*
-debian/tmp/usr/share/*
+debian/tmp/usr/share/nugu/model/*


### PR DESCRIPTION
It fix the install option of libnugu and libnugu-example.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>