### PR TITLE
PlaySync:revoke change about releaseSyncImmediately

### DIFF
--- a/src/core/playsync_manager.cc
+++ b/src/core/playsync_manager.cc
@@ -159,7 +159,6 @@ void PlaySyncManager::releaseSyncLater(const std::string& ps_id, const std::stri
 
 void PlaySyncManager::releaseSyncImmediately(const std::string& ps_id, const std::string& requester)
 {
-    clearPostPonedRelease();
     rawReleaseSync(ps_id, requester, PlayStackRemoveMode::Immediately);
 }
 


### PR DESCRIPTION
It revoke the change about releaseSyncImmediately,
because in some case, such condition is required.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>