### PR TITLE
AudioPlayerAgent: fix the bug

### DIFF
--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -1433,11 +1433,6 @@ void AudioPlayerAgent::parsingRequestPlayCommand(const char* dname, const char* 
     std::string play_service_id;
     std::string payload;
 
-    if (cur_token.empty()) {
-        nugu_warn("there is no media content in the playlist.");
-        return;
-    }
-
     if (!reader.parse(message, root)) {
         nugu_error("parsing error");
         return;


### PR DESCRIPTION
There is unnecessary to check current media playlist.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>