### PR TITLE
capability: fix SKML empty string check logic

### DIFF
--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -15,6 +15,7 @@
  */
 
 #include <string.h>
+#include <regex>
 
 #include "base/nugu_log.h"
 #include "base/nugu_prof.h"
@@ -532,7 +533,14 @@ void TTSAgent::checkAndUpdateVolume()
 
 bool TTSAgent::isSpeakTextEmpty(const std::string& raw_text)
 {
-    return raw_text.find("></skml>") != std::string::npos;
+    const std::regex pattern("\\<.*?\\>");
+    std::string text = regex_replace(raw_text, pattern, "");
+    nugu_dbg("plain_text = [%s]", text.c_str());
+
+    if (text.size() == 0)
+        return true;
+
+    return false;
 }
 
 void TTSAgent::mediaStateChanged(MediaPlayerState state)


### PR DESCRIPTION
Because the existing check logic was simply checked with a string,
there is a bug that it does not work properly when tags are included
in SKML.

So, modified it to check through a regular expression.

Signed-off-by: Inho Oh <webispy@gmail.com>