### PR TITLE
CapabilityManager:Handle Network Disconnected Status

### DIFF
--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -285,6 +285,11 @@ void AudioPlayerAgent::receiveCommandAll(const std::string& command, const std::
     convert_command.resize(command.size());
     std::transform(command.cbegin(), command.cend(), convert_command.begin(), ::tolower);
 
+    if (convert_command == "network_disconnected") {
+        skip_intermediate_foreground_focus = false;
+        return;
+    }
+
     if (receive_new_play_directive)
         return;
 

--- a/src/core/capability_manager.cc
+++ b/src/core/capability_manager.cc
@@ -178,6 +178,12 @@ void CapabilityManager::requestEventResult(NuguEvent* event)
     nugu_dbg("request event[%s] result - %s", msg_id, event_desc.c_str());
 }
 
+void CapabilityManager::onStatusChanged(NetworkStatus status)
+{
+    if (status == NetworkStatus::DISCONNECTED)
+        sendCommandAll("network_disconnected", "");
+}
+
 void CapabilityManager::onEventSendResult(const char* msg_id, bool success, int code)
 {
     if (events.find(msg_id) == events.end()) {

--- a/src/core/capability_manager.hh
+++ b/src/core/capability_manager.hh
@@ -57,6 +57,7 @@ public:
     void requestEventResult(NuguEvent* event);
 
     // overriding INetworkManagerListener
+    void onStatusChanged(NetworkStatus status) override;
     void onEventSendResult(const char* msg_id, bool success, int code) override;
     void onEventResponse(const char* msg_id, const char* data, bool success) noexcept override;
 


### PR DESCRIPTION
In some case, there needs to reset some variables in CapabilityAgent
when the network is disconnected.

So, it implements onStatusChanged callback in CapabilityManager
and send the network_disconnected command to each Agent in above case.

In currently, the AudioPlayerAgent needs that command,
it update to handle as resetting skip_intermediate_foreground_focus.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>