### PR TITLE
PlaySyncManager:Add onStackChanged API in IPlaySyncManagerListener

### DIFF
--- a/include/clientkit/playsync_manager_interface.hh
+++ b/include/clientkit/playsync_manager_interface.hh
@@ -71,14 +71,20 @@ public:
      * @param[in] state play sync state
      * @param[in] extra_data an extra_data which is sent at starting sync
      */
-    virtual void onSyncState(const std::string& ps_id, PlaySyncState state, void* extra_data) = 0;
+    virtual void onSyncState(const std::string& ps_id, PlaySyncState state, void* extra_data);
 
     /**
      * @brief Receive callback when the extra data is changed.
      * @param[in] ps_is play service id
      * @param[in] extra_datas the extra_datas which are composed by previous and new
      */
-    virtual void onDataChanged(const std::string& ps_id, std::pair<void*, void*> extra_datas) = 0;
+    virtual void onDataChanged(const std::string& ps_id, std::pair<void*, void*> extra_datas);
+
+    /**
+     * @brief Receive callback when the play stack is changed.
+     * @param[in] ps_ids play service ids (first:added stack, second:removed stack)
+     */
+    virtual void onStackChanged(const std::pair<std::string, std::string>& ps_ids);
 };
 
 /**

--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include <string.h>
 #include <regex>
+#include <string.h>
 
 #include "base/nugu_log.h"
 #include "base/nugu_prof.h"
@@ -290,10 +290,6 @@ void TTSAgent::onSyncState(const std::string& ps_id, PlaySyncState state, void* 
         postProcessDirective(true);
         suspend();
     }
-}
-
-void TTSAgent::onDataChanged(const std::string& ps_id, std::pair<void*, void*> extra_datas)
-{
 }
 
 void TTSAgent::sendEventCommon(CapabilityEvent* event, const std::string& token, EventResultCallback cb)

--- a/src/capability/tts_agent.hh
+++ b/src/capability/tts_agent.hh
@@ -52,7 +52,6 @@ public:
     // implements IPlaySyncManagerListener, IFocusResourceListener
     void onFocusChanged(FocusState state) override;
     void onSyncState(const std::string& ps_id, PlaySyncState state, void* extra_data) override;
-    void onDataChanged(const std::string& ps_id, std::pair<void*, void*> extra_datas) override;
 
 private:
     // send event

--- a/src/clientkit/playsync_manager_interface.cc
+++ b/src/clientkit/playsync_manager_interface.cc
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "clientkit/playsync_manager_interface.hh"
+
+namespace NuguClientKit {
+void IPlaySyncManagerListener::onSyncState(const std::string& ps_id, PlaySyncState state, void* extra_data)
+{
+}
+
+void IPlaySyncManagerListener::onDataChanged(const std::string& ps_id, std::pair<void*, void*> extra_datas)
+{
+}
+
+void IPlaySyncManagerListener::onStackChanged(const std::pair<std::string, std::string>& ps_ids)
+{
+}
+
+} // NuguClientKit

--- a/src/core/playsync_manager.cc
+++ b/src/core/playsync_manager.cc
@@ -237,10 +237,13 @@ const PlaySyncManager::PlayStacks& PlaySyncManager::getPlayStacks()
 
 void PlaySyncManager::onStackAdded(const std::string& ps_id)
 {
+    notifyStackChanged({ ps_id, "" });
 }
 
 void PlaySyncManager::onStackRemoved(const std::string& ps_id)
 {
+    notifyStackChanged({ "", ps_id });
+
     if (playstack_map.find(ps_id) == playstack_map.cend()) {
         nugu_warn("The PlaySyncContainer is not exist.");
         return;
@@ -286,6 +289,12 @@ void PlaySyncManager::notifyStateChanged(const std::string& ps_id, PlaySyncState
             nugu_warn("The requester is not exist.");
         }
     }
+}
+
+void PlaySyncManager::notifyStackChanged(std::pair<std::string, std::string>&& ps_ids)
+{
+    for (const auto& listener : listener_map)
+        listener.second->onStackChanged(ps_ids);
 }
 
 bool PlaySyncManager::isConditionToSyncAction(const std::string& ps_id, const std::string& requester, PlaySyncState state)

--- a/src/core/playsync_manager.hh
+++ b/src/core/playsync_manager.hh
@@ -74,6 +74,7 @@ public:
 private:
     void updateExtraData(const std::string& ps_id, const std::string& requester, void* extra_data) noexcept;
     void notifyStateChanged(const std::string& ps_id, PlaySyncState state);
+    void notifyStackChanged(std::pair<std::string, std::string>&& ps_ids);
     bool isConditionToSyncAction(const std::string& ps_id, const std::string& requester, PlaySyncState state);
     void rawReleaseSync(const std::string& ps_id, const std::string& requester, PlayStackRemoveMode stack_remove_mode);
     void clearContainer();


### PR DESCRIPTION
It add the onStackChanged API in IPlaySyncManagerListener
which is possible to be notified playstack changes regardless sync state.

It define no-op methods about IPlaySyncManagerListener
for preventing unnecessary overriding.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>