### PR TITLE
capability: add cancel option to stopRecognition

### DIFF
--- a/examples/standalone/capability/speech_operator.cc
+++ b/examples/standalone/capability/speech_operator.cc
@@ -158,11 +158,21 @@ void SpeechOperator::stopWakeup()
 void SpeechOperator::stopListening()
 {
     if (!asr_handler) {
-        msg::error("It's fail to start speech recognition.");
+        msg::error("It's fail to stop speech recognition.");
         return;
     }
 
     asr_handler->stopRecognition();
+}
+
+void SpeechOperator::cancelListening()
+{
+    if (!asr_handler) {
+        msg::error("It's fail to cancel speech recognition.");
+        return;
+    }
+
+    asr_handler->stopRecognition(true);
 }
 
 void SpeechOperator::onWakeupState(WakeupDetectState state, float power_noise, float power_speech)

--- a/examples/standalone/capability/speech_operator.hh
+++ b/examples/standalone/capability/speech_operator.hh
@@ -34,6 +34,7 @@ public:
     void startListeningWithWakeup();
     void startListening(float noise = 0, float speech = 0, ASRInitiator initiator = ASRInitiator::TAP);
     void stopListeningAndWakeup();
+    void cancelListening();
     bool changeWakeupWord(const WakeupModelFile& model_file, const std::string& wakeup_word);
 
     void onWakeupState(WakeupDetectState state, float power_noise, float power_speech) override;

--- a/examples/standalone/nugu_sdk_manager.cc
+++ b/examples/standalone/nugu_sdk_manager.cc
@@ -191,6 +191,9 @@ void NuguSDKManager::composeSDKCommands()
         ->add("s", { "stop listening/wakeup", [&](int& flag) {
                         speech_operator->stopListeningAndWakeup();
                     } })
+        ->add("c", { "cancel listening", [&](int& flag) {
+                        speech_operator->cancelListening();
+                    } })
         ->add("t", { "text input", [&](int& flag) {
                         flag = TEXT_INPUT_TYPE_1;
                     } })

--- a/include/capability/asr_interface.hh
+++ b/include/capability/asr_interface.hh
@@ -172,8 +172,9 @@ public:
 
     /**
      * @brief Turn off the microphone and stop speech recognition
+     * @param[in] cancel If true, cancel the directives to be received for current dialog
      */
-    virtual void stopRecognition() = 0;
+    virtual void stopRecognition(bool cancel = false) = 0;
 
     /**
      * @brief Add the Listener object

--- a/include/clientkit/directive_sequencer_interface.hh
+++ b/include/clientkit/directive_sequencer_interface.hh
@@ -131,11 +131,12 @@ public:
      * @brief Cancel all pending directives related to the dialog_id.
      * The canceled directives are freed.
      * @param[in] dialog_id dialog-request-id
+     * @param[in] cancel_active_directive cancel including currently active directives
      * @return result
      * @retval true success
      * @retval false failure
      */
-    virtual bool cancel(const std::string& dialog_id) = 0;
+    virtual bool cancel(const std::string& dialog_id, bool cancel_active_directive = true) = 0;
 
     /**
      * @brief Cancels specific pending directives related to the dialog_id.

--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -186,12 +186,17 @@ void ASRAgent::startRecognition(ASRInitiator initiator, AsrRecognizeCallback cal
     asr_cancel = false;
 }
 
-void ASRAgent::stopRecognition()
+void ASRAgent::stopRecognition(bool cancel)
 {
-    nugu_dbg("stopRecognition()");
     focus_manager->releaseFocus(ASR_DM_FOCUS_TYPE, CAPABILITY_NAME);
     focus_manager->releaseFocus(ASR_USER_FOCUS_TYPE, CAPABILITY_NAME);
     asr_cancel = false;
+
+    if (cancel && dialog_id != "") {
+        nugu_info("cancel the dialog %s", dialog_id.c_str());
+        directive_sequencer->cancel(dialog_id, false);
+        dialog_id = "";
+    }
 }
 
 void ASRAgent::preprocessDirective(NuguDirective* ndir)

--- a/src/capability/asr_agent.hh
+++ b/src/capability/asr_agent.hh
@@ -47,7 +47,7 @@ public:
 
     void startRecognition(float power_noise, float power_speech, ASRInitiator initiator = ASRInitiator::TAP, AsrRecognizeCallback callback = nullptr) override;
     void startRecognition(ASRInitiator initiator = ASRInitiator::TAP, AsrRecognizeCallback callback = nullptr) override;
-    void stopRecognition() override;
+    void stopRecognition(bool cancel = false) override;
 
     void preprocessDirective(NuguDirective* ndir) override;
     void parsingDirective(const char* dname, const char* message) override;

--- a/src/core/directive_sequencer.hh
+++ b/src/core/directive_sequencer.hh
@@ -45,7 +45,7 @@ public:
     bool addPolicy(const std::string& name_space, const std::string& name, BlockingPolicy policy) override;
     BlockingPolicy getPolicy(const std::string& name_space, const std::string& name) override;
 
-    bool cancel(const std::string& dialog_id) override;
+    bool cancel(const std::string& dialog_id, bool cancel_active_directive = true) override;
     bool cancel(const std::string& dialog_id, std::set<std::string> groups) override;
     bool complete(NuguDirective* ndir) override;
     bool add(NuguDirective* ndir) override;
@@ -82,6 +82,8 @@ private:
      */
     std::vector<NuguDirective*> scheduled_list;
     guint idler_src;
+
+    std::string last_cancel_dialog_id;
 
     void assignPolicy(NuguDirective* ndir);
 

--- a/tests/core/test_core_directive_sequencer.cc
+++ b/tests/core/test_core_directive_sequencer.cc
@@ -1286,8 +1286,9 @@ static void test_sequencer_cancel3(void)
     g_idle_add(
         [](gpointer userdata) -> int {
             struct cancel3_data* data = (struct cancel3_data*)userdata;
+            std::set<std::string> groups = { "Extension.Action" };
 
-            data->seq->cancel("dlg1", { "Extension.Action" });
+            data->seq->cancel("dlg1", groups);
             data->seq->complete(data->speak_dir);
 
             return FALSE;
@@ -1301,9 +1302,10 @@ static void test_sequencer_cancel3(void)
     g_idle_add(
         [](gpointer userdata) -> int {
             struct cancel3_data* data = (struct cancel3_data*)userdata;
+            std::set<std::string> groups = { "Utility.Block" };
 
             /* Cancel the 'msg2' and 'msg4' directives */
-            data->seq->cancel("dlg1", { "Utility.Block" });
+            data->seq->cancel("dlg1", groups);
 
             return FALSE;
         },


### PR DESCRIPTION
If the cancel option is true, all directives corresponding to the
current dialog are canceled among the directives to be received in
the future. It also cancels directives that have already been
received but are still pending.

However, directives that have already been received and are in the
processing state (active state) are not canceled and remain.
In this case, it must be stopped manually via the corresponding
agent's function as needed.

Signed-off-by: Inho Oh <inho.oh@sk.com>