### PR TITLE
capability: add check for canceled dialog-id

### DIFF
--- a/include/clientkit/directive_sequencer_interface.hh
+++ b/include/clientkit/directive_sequencer_interface.hh
@@ -167,6 +167,12 @@ public:
      * @retval false failure
      */
     virtual bool add(NuguDirective* ndir) = 0;
+
+    /**
+     * @brief Get the last canceled dialog_id
+     * @return dialog_id
+     */
+    virtual const std::string& getCanceledDialogId() = 0;
 };
 
 /**

--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -613,6 +613,11 @@ void AudioPlayerAgent::mediaStateChanged(MediaPlayerState state)
                 sendEventPlaybackStarted();
         }
         is_paused_by_unfocus = false;
+        if (play_directive_dialog_id == directive_sequencer->getCanceledDialogId()) {
+            nugu_error("stop the play request for canceled dialog_id");
+            cur_player->stop();
+            return;
+        }
         break;
     case MediaPlayerState::PAUSED:
         cur_aplayer_state = AudioPlayerState::PAUSED;
@@ -1051,6 +1056,12 @@ void AudioPlayerAgent::parsingPlay(const char* message)
         return;
     }
 
+    std::string dialog_id = nugu_directive_peek_dialog_id(getNuguDirective());
+    if (dialog_id == directive_sequencer->getCanceledDialogId()) {
+        nugu_error("ignore the play request for canceled dialog_id");
+        return;
+    }
+
     audio_item = root["audioItem"];
     if (audio_item.empty()) {
         nugu_error("directive message syntax error");
@@ -1129,7 +1140,6 @@ void AudioPlayerAgent::parsingPlay(const char* message)
     nugu_dbg("= report_delay_time: %d", report_delay_time);
     nugu_dbg("= report_interval_time: %d", report_interval_time);
 
-    std::string dialog_id = nugu_directive_peek_dialog_id(getNuguDirective());
     std::string dname = nugu_directive_peek_name(getNuguDirective());
 
     if (new_content) {

--- a/src/core/directive_sequencer.cc
+++ b/src/core/directive_sequencer.cc
@@ -887,4 +887,9 @@ void DirectiveSequencer::assignPolicy(NuguDirective* ndir)
     nugu_directive_set_blocking_policy(ndir, medium, is_block);
 }
 
+const std::string& DirectiveSequencer::getCanceledDialogId()
+{
+    return last_cancel_dialog_id;
+}
+
 }

--- a/src/core/directive_sequencer.hh
+++ b/src/core/directive_sequencer.hh
@@ -50,6 +50,8 @@ public:
     bool complete(NuguDirective* ndir) override;
     bool add(NuguDirective* ndir) override;
 
+    const std::string& getCanceledDialogId() override;
+
     using BlockingPolicyMap = std::map<std::string, std::map<std::string, BlockingPolicy>>;
 
 private:


### PR DESCRIPTION
To solve the timing issue, when the audio player state is changed
to play, a process has been added to check whether the corresponding
dialog-id has already been canceled.

Signed-off-by: Inho Oh <webispy@gmail.com>