### PR TITLE
TTS:update parsing TTS.Speak directive

### DIFF
--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -438,7 +438,9 @@ void TTSAgent::parsingSpeak(const char* message)
     nugu_prof_mark_data(NUGU_PROF_TYPE_TTS_SPEAK_DIRECTIVE, dialog_id.c_str(),
         nugu_directive_peek_msg_id(speak_dir), NULL);
 
-    if (focus_state == FocusState::FOREGROUND)
+    if (is_stopped_by_explicit)
+        playsync_manager->releaseSyncImmediately(playstackctl_ps_id, getName());
+    else if (focus_state == FocusState::FOREGROUND)
         executeOnForegroundAction();
     else
         focus_manager->requestFocus(INFO_FOCUS_TYPE, CAPABILITY_NAME, this);


### PR DESCRIPTION
In the most case, the result of the stop play serivce is delivered by
TTS.Speak directive which does not contain any text data.

Because no TTS stream exist, there are no needs to play TTS.
So, it update to skip focus handling in the above case.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>