### PR TITLE
base: remove unused http2 network API

### DIFF
--- a/src/base/network/http2/http2_network.h
+++ b/src/base/network/http2/http2_network.h
@@ -33,7 +33,6 @@ int http2_network_add_request(HTTP2Network *net, HTTP2Request *req);
 int http2_network_resume_request(HTTP2Network *net, HTTP2Request *req);
 
 int http2_network_remove_request(HTTP2Network *net, HTTP2Request *req);
-int http2_network_remove_request_sync(HTTP2Network *net, HTTP2Request *req);
 
 int http2_network_start(HTTP2Network *net);
 int http2_network_wakeup(HTTP2Network *net);


### PR DESCRIPTION
`http2_network_remove_request_sync()` API is no more used.

Signed-off-by: Inho Oh <inho.oh@sk.com>