### PR TITLE
TTS:fix parsing TTS.Speak directive

### DIFF
--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -407,7 +407,11 @@ void TTSAgent::parsingSpeak(const char* message)
         return;
     }
 
-    is_stopped_by_explicit = isSpeakTextEmpty(text);
+    if ((is_stopped_by_explicit = isSpeakTextEmpty(text))) {
+        parsingStop(message);
+        return;
+    }
+
     destroy_directive_by_agent = true;
     speak_dir = nullptr;
 
@@ -438,9 +442,7 @@ void TTSAgent::parsingSpeak(const char* message)
     nugu_prof_mark_data(NUGU_PROF_TYPE_TTS_SPEAK_DIRECTIVE, dialog_id.c_str(),
         nugu_directive_peek_msg_id(speak_dir), NULL);
 
-    if (is_stopped_by_explicit)
-        playsync_manager->releaseSyncImmediately(playstackctl_ps_id, getName());
-    else if (focus_state == FocusState::FOREGROUND)
+    if (focus_state == FocusState::FOREGROUND)
         executeOnForegroundAction();
     else
         focus_manager->requestFocus(INFO_FOCUS_TYPE, CAPABILITY_NAME, this);


### PR DESCRIPTION
For handling the empty text case (play stop) correctly when parsing
TTS.Speak directive, it needs to process full flows of parsingStop method.

So, it update to call the parsingStop method in parsingSpeak,
if it has to stop play caused by receiving the empty text.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>