### PR TITLE
TTS:remove unused variable

### DIFF
--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -455,7 +455,6 @@ void TTSAgent::parsingStop(const char* message)
 {
     Json::Value root;
     Json::Reader reader;
-    std::string token;
 
     if (!reader.parse(message, root)) {
         nugu_error("parsing error");


### PR DESCRIPTION
It remove the unused token variable in parsingStop.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>