### PR TITLE
base: add request_id to manage http2 requests

### DIFF
--- a/src/base/network/http2/http2_network.h
+++ b/src/base/network/http2/http2_network.h
@@ -29,10 +29,8 @@ HTTP2Network *http2_network_new();
 void http2_network_free(HTTP2Network *net);
 
 int http2_network_add_request(HTTP2Network *net, HTTP2Request *req);
-
-int http2_network_resume_request(HTTP2Network *net, HTTP2Request *req);
-
-int http2_network_remove_request(HTTP2Network *net, HTTP2Request *req);
+int http2_network_resume_request(HTTP2Network *net, int request_id);
+int http2_network_remove_request(HTTP2Network *net, int request_id);
 
 int http2_network_start(HTTP2Network *net);
 int http2_network_wakeup(HTTP2Network *net);

--- a/src/base/network/http2/http2_request.c
+++ b/src/base/network/http2/http2_request.c
@@ -36,6 +36,7 @@
 struct _http2_request {
 	CURL *easy;
 	enum http2_result result;
+	int id;
 
 	struct curl_slist *headers;
 	enum http2_request_content_type type;
@@ -322,6 +323,7 @@ HTTP2Request *http2_request_new()
 	}
 
 	req->ref_count = 1;
+	req->id = -1;
 	req->code = -1;
 	req->response_header = nugu_buffer_new(0);
 	req->response_body = nugu_buffer_new(0);
@@ -421,6 +423,22 @@ int http2_request_unref(HTTP2Request *req)
 	http2_request_free(req);
 
 	return 0;
+}
+
+int http2_request_set_id(HTTP2Request *req, int id)
+{
+	g_return_val_if_fail(req != NULL, -1);
+
+	req->id = id;
+
+	return 0;
+}
+
+int http2_request_get_id(HTTP2Request *req)
+{
+	g_return_val_if_fail(req != NULL, -1);
+
+	return req->id;
 }
 
 int http2_request_set_result(HTTP2Request *req, enum http2_result result)

--- a/src/base/network/http2/http2_request.h
+++ b/src/base/network/http2/http2_request.h
@@ -73,6 +73,9 @@ HTTP2Request *http2_request_new();
 int http2_request_ref(HTTP2Request *req);
 int http2_request_unref(HTTP2Request *req);
 
+int http2_request_set_id(HTTP2Request *req, int id);
+int http2_request_get_id(HTTP2Request *req);
+
 int http2_request_set_result(HTTP2Request *req, enum http2_result result);
 enum http2_result http2_request_get_result(HTTP2Request *req);
 


### PR DESCRIPTION
Change the HTTP2Network module to use request_id instead of a direct
HTTP2Request pointer to manage each HTTP2Request handle.

The request_id is assigned by the HTTP2Network module using the
`http2_network_add_request()` API.

Signed-off-by: Inho Oh <inho.oh@sk.com>