### PR TITLE
network: add FAILED error status

### DIFF
--- a/examples/capability_injection/main_capability_injection.cc
+++ b/examples/capability_injection/main_capability_injection.cc
@@ -50,6 +50,9 @@ public:
     void onError(NetworkError error)
     {
         switch (error) {
+        case NetworkError::FAILED:
+            std::cout << "Network failed !" << std::endl;
+            break;
         case NetworkError::TOKEN_ERROR:
             std::cout << "Token error !" << std::endl;
             break;

--- a/examples/profiling/main_prof.cc
+++ b/examples/profiling/main_prof.cc
@@ -238,6 +238,10 @@ public:
     void onError(NetworkError error)
     {
         switch (error) {
+        case NetworkError::FAILED:
+            nugu_error("Network failed");
+            g_main_loop_quit(loop);
+            break;
         case NetworkError::TOKEN_ERROR:
             nugu_error("Token error");
             g_main_loop_quit(loop);

--- a/examples/response_filter/main.cc
+++ b/examples/response_filter/main.cc
@@ -154,6 +154,9 @@ public:
     void onError(NetworkError error)
     {
         switch (error) {
+        case NetworkError::FAILED:
+            std::cout << "Network failed !" << std::endl;
+            break;
         case NetworkError::TOKEN_ERROR:
             std::cout << "Token error !" << std::endl;
             break;

--- a/examples/simple_asr/main_asr.cc
+++ b/examples/simple_asr/main_asr.cc
@@ -132,9 +132,14 @@ public:
     void onError(NetworkError error)
     {
         switch (error) {
+        case NetworkError::FAILED:
+            std::cout << "Network failed !" << std::endl;
+            break;
         case NetworkError::TOKEN_ERROR:
+            std::cout << "Token error !" << std::endl;
             break;
         case NetworkError::UNKNOWN:
+            std::cout << "Unknown error !" << std::endl;
             break;
         }
     }

--- a/examples/simple_text/main_text.cc
+++ b/examples/simple_text/main_text.cc
@@ -60,6 +60,9 @@ public:
     void onError(NetworkError error)
     {
         switch (error) {
+        case NetworkError::FAILED:
+            std::cout << "Network failed !" << std::endl;
+            break;
         case NetworkError::TOKEN_ERROR:
             std::cout << "Token error !" << std::endl;
             break;

--- a/examples/simple_tts/main_tts.cc
+++ b/examples/simple_tts/main_tts.cc
@@ -67,6 +67,9 @@ public:
     void onError(NetworkError error)
     {
         switch (error) {
+        case NetworkError::FAILED:
+            std::cout << "Network failed !" << std::endl;
+            break;
         case NetworkError::TOKEN_ERROR:
             std::cout << "Token error !" << std::endl;
             break;

--- a/examples/standalone/nugu_sdk_manager.cc
+++ b/examples/standalone/nugu_sdk_manager.cc
@@ -483,6 +483,9 @@ void NuguSDKManager::onStatusChanged(NetworkStatus status)
 void NuguSDKManager::onError(NetworkError error)
 {
     switch (error) {
+    case NetworkError::FAILED:
+        msg_error("Network error [FAILED].");
+        break;
     case NetworkError::TOKEN_ERROR:
         msg_error("Network error [TOKEN_ERROR].");
         break;

--- a/include/base/nugu_network_manager.h
+++ b/include/base/nugu_network_manager.h
@@ -63,6 +63,7 @@ typedef enum nugu_network_status {
 	NUGU_NETWORK_CONNECTING, /**< Connection in progress */
 	NUGU_NETWORK_READY, /**< Network ready for ondemand connection type */
 	NUGU_NETWORK_CONNECTED, /**< Network connected */
+	NUGU_NETWORK_FAILED, /**< Failed to connect to all servers */
 	NUGU_NETWORK_TOKEN_ERROR /**< Token error */
 } NuguNetworkStatus;
 

--- a/include/clientkit/network_manager_interface.hh
+++ b/include/clientkit/network_manager_interface.hh
@@ -42,6 +42,7 @@ enum class NetworkStatus {
 };
 
 enum class NetworkError {
+    FAILED, /**< Failed to connect to all servers */
     TOKEN_ERROR, /**< Occurs when the issued token expires */
     UNKNOWN /**< Unknown */
 };

--- a/src/core/network_manager.cc
+++ b/src/core/network_manager.cc
@@ -58,6 +58,12 @@ static void _status(NuguNetworkStatus status, void* userdata)
         for (const auto& listener : listeners) {
             listener->onStatusChanged(NetworkStatus::CONNECTED);
         }
+    } else if (status == NUGU_NETWORK_FAILED) {
+        nugu_error("Network failed");
+
+        for (const auto& listener : listeners) {
+            listener->onError(NetworkError::FAILED);
+        }
     } else if (status == NUGU_NETWORK_TOKEN_ERROR) {
         nugu_error("Network token error");
 


### PR DESCRIPTION
When a connection attempt fails for the entire device-gateway
server list, there is no separate FAILED event and there is only
a DISCONNECT event, so it is difficult to determine the exact
status in the application.

To solve this problem, add a FAILED event, and when the application
receives this event, it checks the network status and tries to
connect again.

Signed-off-by: Inho Oh <inho.oh@sk.com>