### PR TITLE
TTS:Add TTS speech STOP state

### DIFF
--- a/examples/standalone/capability/tts_listener.cc
+++ b/examples/standalone/capability/tts_listener.cc
@@ -28,7 +28,10 @@ void TTSListener::onTTSState(TTSState state, const std::string& dialog_id)
     case TTSState::TTS_SPEECH_START:
         std::cout << "PLAYING...\n";
         break;
-
+    case TTSState::TTS_SPEECH_STOP:
+        std::cout << "PLAYING STOPPED\n";
+        nugu_prof_dump(NUGU_PROF_TYPE_TTS_SPEAK_DIRECTIVE, NUGU_PROF_TYPE_TTS_STOPPED);
+        break;
     case TTSState::TTS_SPEECH_FINISH:
         std::cout << "PLAYING FINISHED\n";
         nugu_prof_dump(NUGU_PROF_TYPE_TTS_SPEAK_DIRECTIVE, NUGU_PROF_TYPE_TTS_FINISHED);
@@ -43,8 +46,6 @@ void TTSListener::onTTSText(const std::string& text, const std::string& dialog_i
 
 void TTSListener::onTTSCancel(const std::string& dialog_id)
 {
-    nugu_prof_dump(NUGU_PROF_TYPE_TTS_SPEAK_DIRECTIVE, NUGU_PROF_TYPE_TTS_STOPPED);
-
     std::cout << "[TTS][id:" << dialog_id << "] CANCEL... " << std::endl;
 }
 

--- a/include/capability/tts_interface.hh
+++ b/include/capability/tts_interface.hh
@@ -41,6 +41,7 @@ using namespace NuguClientKit;
  */
 enum class TTSState {
     TTS_SPEECH_START, /**< Status starting speech in TTS */
+    TTS_SPEECH_STOP, /**< Status stopping speech in TTS */
     TTS_SPEECH_FINISH /**< Status finishing speech in TTS */
 };
 

--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -353,6 +353,9 @@ void TTSAgent::sendEventSpeechStopped(const std::string& token, EventResultCallb
     nugu_prof_mark_data(NUGU_PROF_TYPE_TTS_STOPPED,
         event.getDialogRequestId().c_str(),
         event.getMessageId().c_str(), NULL);
+
+    for (const auto& tts_listener : tts_listeners)
+        tts_listener->onTTSState(TTSState::TTS_SPEECH_STOP, dialog_id);
 }
 
 std::string TTSAgent::sendEventSpeechPlay(const std::string& token, const std::string& text, const std::string& play_service_id, EventResultCallback cb)


### PR DESCRIPTION
As there are no state to handle TTS stopped case,
it add the TTS_SPEECH_STOP state in TTSState enum.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>