### PR TITLE
TTS:refactor sending speech state event

### DIFF
--- a/src/capability/tts_agent.hh
+++ b/src/capability/tts_agent.hh
@@ -54,11 +54,14 @@ public:
     void onSyncState(const std::string& ps_id, PlaySyncState state, void* extra_data) override;
 
 private:
+    using SpeechStateEventParam = struct _SpeechStateEventParam;
+
     // send event
     void sendEventCommon(CapabilityEvent* event, const std::string& token, EventResultCallback cb = nullptr);
-    void sendEventSpeechStarted(const std::string& token, EventResultCallback cb = nullptr);
-    void sendEventSpeechFinished(const std::string& token, EventResultCallback cb = nullptr);
-    void sendEventSpeechStopped(const std::string& token, EventResultCallback cb = nullptr);
+    void sendEventSpeechStarted(EventResultCallback cb = nullptr);
+    void sendEventSpeechStopped(EventResultCallback cb = nullptr);
+    void sendEventSpeechFinished(EventResultCallback cb = nullptr);
+    void sendEventSpeechState(SpeechStateEventParam&& event_param, EventResultCallback&& cb = nullptr);
     std::string sendEventSpeechPlay(const std::string& token, const std::string& text, const std::string& play_service_id = "", EventResultCallback cb = nullptr);
 
     // parsing directive


### PR DESCRIPTION
It extract the sendEventSpeechState from sendEventSpeechStarted,
sendEventSpeechStopped, sendEventSpeechFinished,
because that methods have same codes except event name and state.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>