### PR TITLE
PlaySync:Add adjustPlayStackHoldTime API

### DIFF
--- a/include/clientkit/playsync_manager_interface.hh
+++ b/include/clientkit/playsync_manager_interface.hh
@@ -224,6 +224,12 @@ public:
      * @return Playstack items (play service id list)
      */
     virtual std::vector<std::string> getAllPlayStackItems() = 0;
+
+    /**
+     * @brief Adjust playstack hold time.
+     * @param[in] time playstack hold time (unit: second)
+     */
+    virtual void adjustPlayStackHoldTime(unsigned int time) = 0;
 };
 
 /**

--- a/src/core/playstack_manager.cc
+++ b/src/core/playstack_manager.cc
@@ -246,9 +246,18 @@ bool PlayStackManager::hasAddingPlayStack()
 void PlayStackManager::setPlayStackHoldTime(PlayStakcHoldTimes&& hold_times_sec)
 {
     this->hold_times_sec = hold_times_sec;
+
+    if (this->hold_times_sec.long_time <= 0)
+        this->hold_times_sec.long_time = DEFAULT_LONG_HOLD_TIME_SEC;
 }
 
-PlayStackManager::PlayStakcHoldTimes PlayStackManager::getPlayStackHoldTime()
+void PlayStackManager::resetPlayStackHoldTime()
+{
+    this->hold_times_sec.normal_time = DEFAULT_NORMAL_HOLD_TIME_SEC;
+    this->hold_times_sec.long_time = DEFAULT_LONG_HOLD_TIME_SEC;
+}
+
+const PlayStackManager::PlayStakcHoldTimes& PlayStackManager::getPlayStackHoldTime()
 {
     return hold_times_sec;
 }

--- a/src/core/playstack_manager.hh
+++ b/src/core/playstack_manager.hh
@@ -75,7 +75,8 @@ public:
     bool isActiveHolding();
     bool hasAddingPlayStack();
     void setPlayStackHoldTime(PlayStakcHoldTimes&& hold_times_sec);
-    PlayStakcHoldTimes getPlayStackHoldTime();
+    void resetPlayStackHoldTime();
+    const PlayStakcHoldTimes& getPlayStackHoldTime();
 
     PlayStackActivity getPlayStackActivity(const std::string& ps_id) noexcept;
     std::vector<std::string> getAllPlayStackItems();

--- a/src/core/playsync_manager.cc
+++ b/src/core/playsync_manager.cc
@@ -238,6 +238,19 @@ std::vector<std::string> PlaySyncManager::getAllPlayStackItems()
     return playstack_manager->getAllPlayStackItems();
 }
 
+void PlaySyncManager::adjustPlayStackHoldTime(unsigned int time)
+{
+    if (static_cast<int>(time) <= 0)
+        return;
+
+    playstack_manager->setPlayStackHoldTime({ time });
+}
+
+unsigned int PlaySyncManager::getPlayStackHoldTime()
+{
+    return playstack_manager->getPlayStackHoldTime().normal_time;
+}
+
 const PlaySyncManager::PlayStacks& PlaySyncManager::getPlayStacks()
 {
     return playstack_map;
@@ -265,6 +278,7 @@ void PlaySyncManager::onStackRemoved(const std::string& ps_id)
     notifyStateChanged(ps_id, PlaySyncState::Released);
 
     playstack_map.erase(ps_id);
+    playstack_manager->resetPlayStackHoldTime();
 }
 
 void PlaySyncManager::appendSync(const std::string& ps_id, const NuguDirective* ndir)

--- a/src/core/playsync_manager.hh
+++ b/src/core/playsync_manager.hh
@@ -66,6 +66,8 @@ public:
     bool hasActivity(const std::string& ps_id, PlayStackActivity activity) override;
     bool hasNextPlayStack() override;
     std::vector<std::string> getAllPlayStackItems() override;
+    void adjustPlayStackHoldTime(unsigned int time) override;
+    unsigned int getPlayStackHoldTime();
     const PlayStacks& getPlayStacks();
 
     // overriding IPlayStackManagerListener

--- a/tests/core/test_core_playstack_manager.cc
+++ b/tests/core/test_core_playstack_manager.cc
@@ -25,6 +25,9 @@
 
 using namespace NuguCore;
 
+static const unsigned int DEFAULT_NORMAL_HOLD_TIME_SEC = 7;
+static const unsigned int DEFAULT_LONG_HOLD_TIME_SEC = 600;
+
 class PlayStackManagerListener : public IPlayStackManagerListener {
 public:
     void onStackAdded(const std::string& ps_id)
@@ -297,15 +300,32 @@ static void test_playstack_manager_check_adding_playstack(TestFixture* fixture, 
 static void test_playstack_manager_adjust_playstack_hold_time(TestFixture* fixture, gconstpointer ignored)
 {
     // check default hold times
-    auto hold_times = fixture->playstack_manager->getPlayStackHoldTime();
-    g_assert(hold_times.normal_time == 7);
-    g_assert(hold_times.long_time == 600);
+    const auto& hold_times(fixture->playstack_manager->getPlayStackHoldTime());
+    g_assert(hold_times.normal_time == DEFAULT_NORMAL_HOLD_TIME_SEC);
+    g_assert(hold_times.long_time == DEFAULT_LONG_HOLD_TIME_SEC);
 
     // check custom hold times
     fixture->playstack_manager->setPlayStackHoldTime({ 5, 10 });
-    hold_times = fixture->playstack_manager->getPlayStackHoldTime();
     g_assert(hold_times.normal_time == 5);
     g_assert(hold_times.long_time == 10);
+
+    // check whether setting long time by default value if not pass 2nd argument
+    fixture->playstack_manager->setPlayStackHoldTime({ 15 });
+    g_assert(hold_times.normal_time == 15);
+    g_assert(hold_times.long_time == DEFAULT_LONG_HOLD_TIME_SEC);
+}
+
+static void test_playstack_manager_reset_playstack_hold_time(TestFixture* fixture, gconstpointer ignored)
+{
+    const auto& hold_times(fixture->playstack_manager->getPlayStackHoldTime());
+    fixture->playstack_manager->setPlayStackHoldTime({ 5, 10 });
+    g_assert(hold_times.normal_time == 5);
+    g_assert(hold_times.long_time == 10);
+
+    // reset hold time
+    fixture->playstack_manager->resetPlayStackHoldTime();
+    g_assert(hold_times.normal_time == DEFAULT_NORMAL_HOLD_TIME_SEC);
+    g_assert(hold_times.long_time == DEFAULT_LONG_HOLD_TIME_SEC);
 }
 
 static void test_playstack_manager_reset(TestFixture* fixture, gconstpointer ignored)
@@ -348,6 +368,7 @@ int main(int argc, char* argv[])
     G_TEST_ADD_FUNC("/core/PlayStackManager/checkExpectSpeech", test_playstack_manager_check_expect_speech);
     G_TEST_ADD_FUNC("/core/PlayStackManager/checkAddingPlayStack", test_playstack_manager_check_adding_playstack);
     G_TEST_ADD_FUNC("/core/PlayStackManager/adjustPlayStackHoldTime", test_playstack_manager_adjust_playstack_hold_time);
+    G_TEST_ADD_FUNC("/core/PlayStackManager/resetPlayStackHoldTime", test_playstack_manager_reset_playstack_hold_time);
     G_TEST_ADD_FUNC("/core/PlayStackManager/reset", test_playstack_manager_reset);
 
     return g_test_run();


### PR DESCRIPTION
It add the adjustPlayStackHoldTime API for adjusting playstack hold time.
(The default playstack hold time is 7 second.)

Because it has to be handled in specific case temporarily,
if the playstack is released, the hold time is reset to default by self.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>