### PR TITLE
Display:Update to handle display close by app

### DIFF
--- a/src/capability/display_agent.hh
+++ b/src/capability/display_agent.hh
@@ -72,6 +72,7 @@ private:
     void activateSession(NuguDirective* ndir);
     void deactiveSession();
     void startPlaySync(const NuguDirective* ndir, const Json::Value& root);
+    bool hasPlayStack();
 
     DisplayRenderInfo* composeRenderInfo(const NuguDirective* ndir, const std::string& ps_id, const std::string& token);
     std::string getTemplateId(const std::string& ps_id);
@@ -84,6 +85,7 @@ private:
     IDisplayListener* display_listener;
     std::string disp_cur_ps_id;
     std::string disp_cur_token;
+    std::string playstackctl_ps_id;
 };
 
 } // NuguCapability

--- a/src/capability/display_render_helper.cc
+++ b/src/capability/display_render_helper.cc
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include <sys/time.h>
 #include <stdexcept>
+#include <sys/time.h>
 
 #include "base/nugu_log.h"
 #include "display_render_helper.hh"
@@ -182,6 +182,12 @@ void DisplayRenderHelper::clearDisplay(void* data, bool has_next_render)
     }
 
     auto render_info = reinterpret_cast<DisplayRenderInfo*>(data);
+
+    if (render_info->close) {
+        nugu_info("Display(id:%s) is already closed", render_info->id.c_str());
+        return;
+    }
+
     std::string id = render_info->id;
 
     display_listener->clearDisplay(id, true, has_next_render);


### PR DESCRIPTION
It update to handle the case which the display is closed by app correctly.
Because, it has to stop TTS and related play, it execute to release sync.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>