### PR TITLE
AudioPlayer:Update to handle display close by app

### DIFF
--- a/src/capability/audio_player_agent.hh
+++ b/src/capability/audio_player_agent.hh
@@ -163,6 +163,7 @@ private:
     bool is_paused;
     bool is_paused_by_unfocus;
     std::string ps_id;
+    std::string playstackctl_ps_id;
     long report_delay_time;
     long report_interval_time;
     std::string cur_token;


### PR DESCRIPTION
It update to close AudioPlayer display by app correctly.

Because, it has to stop TTS/media and related play simultaneously,
it execute to release play sync.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>