### PR TITLE
PlaySync:Add restartHolding API

### DIFF
--- a/include/clientkit/playsync_manager_interface.hh
+++ b/include/clientkit/playsync_manager_interface.hh
@@ -193,6 +193,11 @@ public:
     virtual void clearHolding() = 0;
 
     /**
+     * @brief Restart timer for releasing sync.
+     */
+    virtual void restartHolding() = 0;
+
+    /**
      * @brief Clear all playstack info.
      */
     virtual void clear() = 0;

--- a/src/core/playsync_manager.cc
+++ b/src/core/playsync_manager.cc
@@ -208,6 +208,12 @@ void PlaySyncManager::clearHolding()
     playstack_manager->clearHolding();
 }
 
+void PlaySyncManager::restartHolding()
+{
+    stopHolding();
+    resetHolding();
+}
+
 void PlaySyncManager::clear()
 {
     reset();

--- a/src/core/playsync_manager.hh
+++ b/src/core/playsync_manager.hh
@@ -59,6 +59,7 @@ public:
     void stopHolding() override;
     void resetHolding() override;
     void clearHolding() override;
+    void restartHolding() override;
     void clear() override;
     bool hasPostPoneRelease();
 


### PR DESCRIPTION
It add the restartHolding API for restarting playstack holding timer.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>