### PR TITLE
PlaySync:Add setDefaultPlayStackHoldTime API

### DIFF
--- a/include/clientkit/playsync_manager_interface.hh
+++ b/include/clientkit/playsync_manager_interface.hh
@@ -235,6 +235,12 @@ public:
      * @param[in] time playstack hold time (unit: second)
      */
     virtual void adjustPlayStackHoldTime(unsigned int time) = 0;
+
+    /**
+     * @brief Set default playstack hold time.
+     * @param[in] time playstack hold time (unit: second)
+     */
+    virtual void setDefaultPlayStackHoldTime(unsigned int time) = 0;
 };
 
 /**

--- a/src/core/playstack_manager.cc
+++ b/src/core/playstack_manager.cc
@@ -243,6 +243,17 @@ bool PlayStackManager::hasAddingPlayStack()
     return has_adding_playstack;
 }
 
+void PlayStackManager::setDefaultPlayStackHoldTime(PlayStakcHoldTimes&& hold_times_sec)
+{
+    if (hold_times_sec.normal_time > 0)
+        default_hold_times_sec.normal_time = hold_times_sec.normal_time;
+
+    if (hold_times_sec.long_time > 0)
+        default_hold_times_sec.long_time = hold_times_sec.long_time;
+
+    setPlayStackHoldTime(PlayStakcHoldTimes { default_hold_times_sec });
+}
+
 void PlayStackManager::setPlayStackHoldTime(PlayStakcHoldTimes&& hold_times_sec)
 {
     this->hold_times_sec = hold_times_sec;
@@ -253,8 +264,7 @@ void PlayStackManager::setPlayStackHoldTime(PlayStakcHoldTimes&& hold_times_sec)
 
 void PlayStackManager::resetPlayStackHoldTime()
 {
-    this->hold_times_sec.normal_time = DEFAULT_NORMAL_HOLD_TIME_SEC;
-    this->hold_times_sec.long_time = DEFAULT_LONG_HOLD_TIME_SEC;
+    hold_times_sec = default_hold_times_sec;
 }
 
 const PlayStackManager::PlayStakcHoldTimes& PlayStackManager::getPlayStackHoldTime()

--- a/src/core/playstack_manager.hh
+++ b/src/core/playstack_manager.hh
@@ -74,6 +74,7 @@ public:
     void clearHolding();
     bool isActiveHolding();
     bool hasAddingPlayStack();
+    void setDefaultPlayStackHoldTime(PlayStakcHoldTimes&& hold_times_sec);
     void setPlayStackHoldTime(PlayStakcHoldTimes&& hold_times_sec);
     void resetPlayStackHoldTime();
     const PlayStakcHoldTimes& getPlayStackHoldTime();
@@ -117,7 +118,8 @@ private:
     PlayStack playstack_container;
     std::vector<IPlayStackManagerListener*> listeners;
     std::unique_ptr<IStackTimer> timer = nullptr;
-    PlayStakcHoldTimes hold_times_sec { DEFAULT_NORMAL_HOLD_TIME_SEC, DEFAULT_LONG_HOLD_TIME_SEC };
+    PlayStakcHoldTimes default_hold_times_sec { DEFAULT_NORMAL_HOLD_TIME_SEC, DEFAULT_LONG_HOLD_TIME_SEC };
+    PlayStakcHoldTimes hold_times_sec { default_hold_times_sec };
 
     bool has_long_timer = false;
     bool has_holding = false;

--- a/src/core/playsync_manager.cc
+++ b/src/core/playsync_manager.cc
@@ -252,6 +252,14 @@ void PlaySyncManager::adjustPlayStackHoldTime(unsigned int time)
     playstack_manager->setPlayStackHoldTime({ time });
 }
 
+void PlaySyncManager::setDefaultPlayStackHoldTime(unsigned int time)
+{
+    if (static_cast<int>(time) <= 0)
+        return;
+
+    playstack_manager->setDefaultPlayStackHoldTime({ time });
+}
+
 unsigned int PlaySyncManager::getPlayStackHoldTime()
 {
     return playstack_manager->getPlayStackHoldTime().normal_time;

--- a/src/core/playsync_manager.hh
+++ b/src/core/playsync_manager.hh
@@ -68,6 +68,7 @@ public:
     bool hasNextPlayStack() override;
     std::vector<std::string> getAllPlayStackItems() override;
     void adjustPlayStackHoldTime(unsigned int time) override;
+    void setDefaultPlayStackHoldTime(unsigned int time) override;
     unsigned int getPlayStackHoldTime();
     const PlayStacks& getPlayStacks();
 

--- a/tests/core/test_core_playstack_manager.cc
+++ b/tests/core/test_core_playstack_manager.cc
@@ -328,6 +328,44 @@ static void test_playstack_manager_reset_playstack_hold_time(TestFixture* fixtur
     g_assert(hold_times.long_time == DEFAULT_LONG_HOLD_TIME_SEC);
 }
 
+static void test_playstack_manager_set_default_playstack_hold_time(TestFixture* fixture, gconstpointer ignored)
+{
+    using HoldTimes = PlayStackManager::PlayStakcHoldTimes;
+    const HoldTimes NEW_DEFAULT_HOLD_TIME { 3, 300 };
+    const auto& hold_times(fixture->playstack_manager->getPlayStackHoldTime());
+
+    g_assert(hold_times.normal_time == DEFAULT_NORMAL_HOLD_TIME_SEC);
+    g_assert(hold_times.long_time == DEFAULT_LONG_HOLD_TIME_SEC);
+
+    // check validation
+    fixture->playstack_manager->setDefaultPlayStackHoldTime({});
+    g_assert(hold_times.normal_time == DEFAULT_NORMAL_HOLD_TIME_SEC);
+    g_assert(hold_times.long_time == DEFAULT_LONG_HOLD_TIME_SEC);
+
+    fixture->playstack_manager->setDefaultPlayStackHoldTime({ 0, 100 });
+    g_assert(hold_times.normal_time == DEFAULT_NORMAL_HOLD_TIME_SEC);
+    g_assert(hold_times.long_time == 100);
+
+    fixture->playstack_manager->setDefaultPlayStackHoldTime({ 4, 0 });
+    g_assert(hold_times.normal_time == 4);
+    g_assert(hold_times.long_time == 100);
+
+    // change default hold time
+    fixture->playstack_manager->setDefaultPlayStackHoldTime(HoldTimes { NEW_DEFAULT_HOLD_TIME });
+    g_assert(hold_times.normal_time == NEW_DEFAULT_HOLD_TIME.normal_time);
+    g_assert(hold_times.long_time == NEW_DEFAULT_HOLD_TIME.long_time);
+
+    // adjust hold time
+    fixture->playstack_manager->setPlayStackHoldTime({ 5, 100 });
+    g_assert(hold_times.normal_time == 5);
+    g_assert(hold_times.long_time == 100);
+
+    // reset hold time
+    fixture->playstack_manager->resetPlayStackHoldTime();
+    g_assert(hold_times.normal_time == NEW_DEFAULT_HOLD_TIME.normal_time);
+    g_assert(hold_times.long_time == NEW_DEFAULT_HOLD_TIME.long_time);
+}
+
 static void test_playstack_manager_reset(TestFixture* fixture, gconstpointer ignored)
 {
     const auto& playstack_container = fixture->playstack_manager->getPlayStackContainer();
@@ -369,6 +407,7 @@ int main(int argc, char* argv[])
     G_TEST_ADD_FUNC("/core/PlayStackManager/checkAddingPlayStack", test_playstack_manager_check_adding_playstack);
     G_TEST_ADD_FUNC("/core/PlayStackManager/adjustPlayStackHoldTime", test_playstack_manager_adjust_playstack_hold_time);
     G_TEST_ADD_FUNC("/core/PlayStackManager/resetPlayStackHoldTime", test_playstack_manager_reset_playstack_hold_time);
+    G_TEST_ADD_FUNC("/core/PlayStackManager/setDefaultPlayStackHoldTime", test_playstack_manager_set_default_playstack_hold_time);
     G_TEST_ADD_FUNC("/core/PlayStackManager/reset", test_playstack_manager_reset);
 
     return g_test_run();


### PR DESCRIPTION
It add the setDefaultPlayStackHoldTime method in IPlaySyncManager
for changing default playstack hold time. (default : 7sec).

The main purpose is to customize default playstack hold time by PoC.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>