### PR TITLE
PlaySync:Fix PlayStack Holding in Media Paused

### DIFF
--- a/src/capability/display_agent.cc
+++ b/src/capability/display_agent.cc
@@ -270,7 +270,7 @@ void DisplayAgent::stopRenderingTimer(const std::string& id)
 
     if (!render_info->close && hasPlayStack()) {
         playsync_manager->postPoneRelease();
-        playsync_manager->clearHolding();
+        playsync_manager->stopHolding();
     }
 }
 

--- a/src/core/playstack_manager.cc
+++ b/src/core/playstack_manager.cc
@@ -182,7 +182,7 @@ void PlayStackManager::remove(const std::string& ps_id, PlayStackRemoveMode mode
     if (mode == PlayStackRemoveMode::Immediately) {
         removeFromContainer(ps_id);
 
-        if (has_long_timer) {
+        if (has_long_timer && getPlayStackActivity(ps_id) == PlayStackActivity::Media) {
             timer->stop();
             has_long_timer = false;
         }

--- a/src/core/playsync_manager.cc
+++ b/src/core/playsync_manager.cc
@@ -94,7 +94,7 @@ int PlaySyncManager::getListenerCount()
 void PlaySyncManager::prepareSync(const std::string& ps_id, NuguDirective* ndir)
 {
     clearPostPonedRelease();
-    clearHolding();
+    stopHolding();
 
     if (!playstack_manager->add(ps_id, ndir)) {
         nugu_warn("The condition is not satisfied to prepare sync.");


### PR DESCRIPTION
It fix not to remove the playstack holding for media paused
when another playstack is added during long timer is activating.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>