### PR TITLE
core: add directive find API to sequencer

### DIFF
--- a/include/clientkit/directive_sequencer_interface.hh
+++ b/include/clientkit/directive_sequencer_interface.hh
@@ -173,6 +173,14 @@ public:
      * @return dialog_id
      */
     virtual const std::string& getCanceledDialogId() = 0;
+
+    /**
+     * @brief Find directive from pending list
+     * @param[in] name_space directive namespace
+     * @param[in] name directive name
+     * @return NuguDirective object or NULL
+     */
+    virtual const NuguDirective* findPending(const std::string& name_space, const std::string& name) = 0;
 };
 
 /**

--- a/src/core/directive_sequencer.hh
+++ b/src/core/directive_sequencer.hh
@@ -52,6 +52,8 @@ public:
 
     const std::string& getCanceledDialogId() override;
 
+    const NuguDirective* findPending(const std::string& name_space, const std::string& name) override;
+
     using BlockingPolicyMap = std::map<std::string, std::map<std::string, BlockingPolicy>>;
 
 private:


### PR DESCRIPTION
Added API for finding directives by 'namespace.name' in pending list
to handle exceptional scenario.

Signed-off-by: Inho Oh <inho.oh@sk.com>