### PR TITLE
TTS: apply destroy directive by agent option

### DIFF
--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -292,7 +292,7 @@ void TTSAgent::onSyncState(const std::string& ps_id, PlaySyncState state, void* 
         return;
     }
 
-    if (state == PlaySyncState::Released && !is_finished && !is_prehandling) {
+    if (state == PlaySyncState::Released && cur_state == MediaPlayerState::PLAYING && !is_prehandling) {
         postProcessDirective(true);
         suspend();
     }
@@ -467,6 +467,7 @@ void TTSAgent::parsingStop(const char* message)
         ps_id = root["playServiceId"].asString();
 
     if (cur_state == MediaPlayerState::PLAYING) {
+        destroy_directive_by_agent = true;
         focus_manager->releaseFocus(INFO_FOCUS_TYPE, CAPABILITY_NAME);
     } else {
         std::string asr_focus_state;


### PR DESCRIPTION
When processing TTS.Stop directive, as the directive is destroyed by Agent
itself in some case, it apply the destroy_directive_by_agent option.

Also, when handling onSyncState callback, as the is_finish flag is not
sufficient to check TTS stopped, it change to check the media play state.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>