### PR TITLE
AudioPlayer:refactor AudioPlayer Display Interface

### DIFF
--- a/examples/standalone/capability/audio_player_listener.hh
+++ b/examples/standalone/capability/audio_player_listener.hh
@@ -23,6 +23,7 @@
 using namespace NuguCapability;
 
 class AudioPlayerListener : public IAudioPlayerListener,
+                            public IAudioPlayerDisplayListener,
                             public DisplayListener {
 public:
     AudioPlayerListener();

--- a/examples/standalone/capability_collection.cc
+++ b/examples/standalone/capability_collection.cc
@@ -73,6 +73,7 @@ void CapabilityCollection::composeCapabilityFactory()
         if (!audio_player_handler) {
             aplayer_listener = make_unique<AudioPlayerListener>();
             audio_player_handler = makeCapability<AudioPlayerAgent, IAudioPlayerHandler>(aplayer_listener.get());
+            audio_player_handler->setDisplayListener(aplayer_listener.get());
         }
 
         return audio_player_handler.get();

--- a/include/capability/audio_player_interface.hh
+++ b/include/capability/audio_player_interface.hh
@@ -56,7 +56,7 @@ enum class AudioPlayerEvent {
     LOAD_DONE, /**< This event is occurred when the content is loaded successfully */
     INVALID_URL, /**< This event is occurred when the content is not valid url */
     PAUSE_BY_DIRECTIVE, /**< This event is occurred when the agent receives a pause directive, it blocks content playback until another directive is received. */
-    PAUSE_BY_FOCUS,  /**< This event is occurred when the agent loses focus by another higher focus */
+    PAUSE_BY_FOCUS, /**< This event is occurred when the agent loses focus by another higher focus */
     PAUSE_BY_APPLICATION /**< This event is occurred when the application pause the mediaplayer directly access */
 };
 
@@ -73,7 +73,7 @@ enum class RepeatType {
  * @brief audioplayer listener interface
  * @see IAudioPlayerHandler
  */
-class IAudioPlayerListener : public IAudioPlayerDisplayListener {
+class IAudioPlayerListener : virtual public ICapabilityListener {
 public:
     virtual ~IAudioPlayerListener() = default;
 
@@ -136,6 +136,44 @@ public:
      * @return return true if cached content, otherwise false
      */
     virtual bool requestToGetCachedContent(const std::string& key, std::string& filepath) = 0;
+};
+
+/**
+ * @brief audioplayer's display listener interface
+ * @see IAudioPlayerHandler
+ */
+class IAudioPlayerDisplayListener : virtual public IDisplayListener {
+public:
+    virtual ~IAudioPlayerDisplayListener() = default;
+
+    /**
+     * @brief SDK request information about device's lyrics page available
+     * @param[in] id display template id
+     * @param[out] visible show lyrics page visible
+     * @return return device's lyrics page available
+     */
+    virtual bool requestLyricsPageAvailable(const std::string& id, bool& visible) = 0;
+
+    /**
+     * @brief Request to the user to show the lyrics page.
+     * @param[in] id display template id
+     * @return return true if show lyrics success, otherwise false.
+     */
+    virtual bool showLyrics(const std::string& id) = 0;
+
+    /**
+     * @brief Request to the user to hide the lyrics page.
+     * @param[in] id display template id
+     * @return return true if hide lyrics success, otherwise false.
+     */
+    virtual bool hideLyrics(const std::string& id) = 0;
+
+    /**
+     * @brief Request to update metadata the current display
+     * @param[in] id display template id
+     * @param[in] json_payload template in json format for display
+     */
+    virtual void updateMetaData(const std::string& id, const std::string& json_payload) = 0;
 };
 
 /**

--- a/include/capability/display_interface.hh
+++ b/include/capability/display_interface.hh
@@ -49,7 +49,7 @@ enum class ControlType {
  * @brief display listener interface
  * @see IDisplayHandler
  */
-class IDisplayListener : public ICapabilityListener {
+class IDisplayListener : virtual public ICapabilityListener {
 public:
     virtual ~IDisplayListener() = default;
     /**
@@ -87,44 +87,6 @@ public:
 };
 
 /**
- * @brief audioplayer's display listener interface
- * @see IDisplayListener
- */
-class IAudioPlayerDisplayListener : virtual public IDisplayListener {
-public:
-    virtual ~IAudioPlayerDisplayListener() = default;
-
-    /**
-     * @brief SDK request information about device's lyrics page available
-     * @param[in] id display template id
-     * @param[out] visible show lyrics page visible
-     * @return return device's lyrics page available
-     */
-    virtual bool requestLyricsPageAvailable(const std::string& id, bool& visible) = 0;
-
-    /**
-     * @brief Request to the user to show the lyrics page.
-     * @param[in] id display template id
-     * @return return true if show lyrics success, otherwise false.
-     */
-    virtual bool showLyrics(const std::string& id) = 0;
-
-    /**
-     * @brief Request to the user to hide the lyrics page.
-     * @param[in] id display template id
-     * @return return true if hide lyrics success, otherwise false.
-     */
-    virtual bool hideLyrics(const std::string& id) = 0;
-
-    /**
-     * @brief Request to update metadata the current display
-     * @param[in] id display template id
-     * @param[in] json_payload template in json format for display
-     */
-    virtual void updateMetaData(const std::string& id, const std::string& json_payload) = 0;
-};
-
-/**
  * @brief display handler interface
  * @see IDisplayListener
  */
@@ -136,13 +98,13 @@ public:
      * @brief The user reports that the display was rendered.
      * @param[in] id display template id
      */
-    virtual void displayRendered(const std::string& id) = 0;
+    virtual void displayRendered(const std::string& id);
 
     /**
      * @brief The user reports that the display is cleared.
      * @param[in] id display template id
      */
-    virtual void displayCleared(const std::string& id) = 0;
+    virtual void displayCleared(const std::string& id);
 
     /**
      * @brief The user informs the selected item of the list and reports the token information of the item.
@@ -150,7 +112,7 @@ public:
      * @param[in] item_token parsed token from metadata
      * @param[in] postback postback data if the item is selectable
      */
-    virtual void elementSelected(const std::string& id, const std::string& item_token, const std::string& postback = "") = 0;
+    virtual void elementSelected(const std::string& id, const std::string& item_token, const std::string& postback = "");
 
     /**
      * @brief The user informs the control result
@@ -158,30 +120,30 @@ public:
      * @param[in] type control type
      * @param[in] direction control direction
      */
-    virtual void informControlResult(const std::string& id, ControlType type, ControlDirection direction) = 0;
+    virtual void informControlResult(const std::string& id, ControlType type, ControlDirection direction);
 
     /**
-     * @brief Set the Listener object
+     * @brief Set the IDisplayListener object
      * @param[in] listener listener object
      */
-    virtual void setListener(IDisplayListener* listener) = 0;
+    virtual void setDisplayListener(IDisplayListener* listener);
 
     /**
-     * @brief Remove the Listener object
+     * @brief Remove the IDisplayListener object
      */
-    virtual void removeListener(IDisplayListener* listener) = 0;
+    virtual void removeDisplayListener(IDisplayListener* listener);
 
     /**
      * @brief Stop display rendering hold timer.
      * @param[in] id display template id
      */
-    virtual void stopRenderingTimer(const std::string& id) = 0;
+    virtual void stopRenderingTimer(const std::string& id);
 
     /**
      * @brief Refresh display rendering hold timer.
      * @param[in] id display template id
      */
-    virtual void refreshRenderingTimer(const std::string& id) = 0;
+    virtual void refreshRenderingTimer(const std::string& id);
 };
 
 /**

--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -305,10 +305,8 @@ void AudioPlayerAgent::receiveCommandAll(const std::string& command, const std::
 
 void AudioPlayerAgent::setCapabilityListener(ICapabilityListener* listener)
 {
-    if (listener) {
+    if (listener)
         addListener(dynamic_cast<IAudioPlayerListener*>(listener));
-        setListener(dynamic_cast<IAudioPlayerDisplayListener*>(listener));
-    }
 }
 
 void AudioPlayerAgent::addListener(IAudioPlayerListener* listener)
@@ -544,11 +542,6 @@ bool AudioPlayerAgent::setMute(bool mute)
     return true;
 }
 
-void AudioPlayerAgent::displayRendered(const std::string& id)
-{
-    // TODO: integrate with playsync and session manager
-}
-
 void AudioPlayerAgent::displayCleared(const std::string& id)
 {
     auto render_info = render_helper->getRenderInfo(id);
@@ -566,17 +559,12 @@ void AudioPlayerAgent::displayCleared(const std::string& id)
     render_helper->removedRenderInfo(id);
 }
 
-void AudioPlayerAgent::elementSelected(const std::string& id, const std::string& item_token, const std::string& postback)
-{
-    // ignore
-}
-
 void AudioPlayerAgent::informControlResult(const std::string& id, ControlType type, ControlDirection direction)
 {
     sendEventControlLyricsPageSucceeded(direction == ControlDirection::NEXT ? "NEXT" : "PREVIOUS");
 }
 
-void AudioPlayerAgent::setListener(IDisplayListener* listener)
+void AudioPlayerAgent::setDisplayListener(IDisplayListener* listener)
 {
     if (listener == nullptr)
         return;
@@ -585,7 +573,7 @@ void AudioPlayerAgent::setListener(IDisplayListener* listener)
     render_helper->setDisplayListener(display_listener);
 }
 
-void AudioPlayerAgent::removeListener(IDisplayListener* listener)
+void AudioPlayerAgent::removeDisplayListener(IDisplayListener* listener)
 {
     if (listener == nullptr)
         return;
@@ -594,16 +582,6 @@ void AudioPlayerAgent::removeListener(IDisplayListener* listener)
 
     if (audio_display_listener == display_listener)
         display_listener = nullptr;
-}
-
-void AudioPlayerAgent::stopRenderingTimer(const std::string& id)
-{
-    // TODO: integrate with playsync and session manager
-}
-
-void AudioPlayerAgent::refreshRenderingTimer(const std::string& id)
-{
-    // ignore
 }
 
 void AudioPlayerAgent::mediaStateChanged(MediaPlayerState state)
@@ -1353,10 +1331,8 @@ void AudioPlayerAgent::parsingUpdateMetadata(const char* message)
             aplayer_listener->shuffleChanged(shuffle, dialog_id);
     }
 
-    if (!template_id.empty()) {
-        for (const auto& aplayer_listener : aplayer_listeners)
-            aplayer_listener->updateMetaData(template_id, writer.write(root["metadata"]));
-    }
+    if (!template_id.empty() && display_listener)
+        display_listener->updateMetaData(template_id, writer.write(root["metadata"]));
 }
 
 void AudioPlayerAgent::parsingShowLyrics(const char* message)

--- a/src/capability/audio_player_agent.hh
+++ b/src/capability/audio_player_agent.hh
@@ -75,18 +75,14 @@ public:
     bool setVolume(int volume) override;
     bool setMute(bool mute) override;
 
-    void displayRendered(const std::string& id) override;
     void displayCleared(const std::string& id) override;
-    void elementSelected(const std::string& id, const std::string& item_token, const std::string& postback) override;
     void informControlResult(const std::string& id, ControlType type, ControlDirection direction) override;
-    void setListener(IDisplayListener* listener) override;
-    void removeListener(IDisplayListener* listener) override;
-    void stopRenderingTimer(const std::string& id) override;
-    void refreshRenderingTimer(const std::string& id) override;
+    void setDisplayListener(IDisplayListener* listener) override;
+    void removeDisplayListener(IDisplayListener* listener) override;
 
+    // implements IMediaPlayerListener
     void mediaStateChanged(MediaPlayerState state) override;
     void mediaEventReport(MediaPlayerEvent event) override;
-
     void mediaChanged(const std::string& url) override;
     void durationChanged(int duration) override;
     void positionChanged(int position) override;

--- a/src/capability/display_agent.cc
+++ b/src/capability/display_agent.cc
@@ -173,7 +173,7 @@ void DisplayAgent::updateInfoForContext(Json::Value& ctx)
 void DisplayAgent::setCapabilityListener(ICapabilityListener* listener)
 {
     if (listener)
-        setListener(dynamic_cast<IDisplayListener*>(listener));
+        setDisplayListener(dynamic_cast<IDisplayListener*>(listener));
 }
 
 void DisplayAgent::displayRendered(const std::string& id)
@@ -244,7 +244,7 @@ void DisplayAgent::informControlResult(const std::string& id, ControlType type, 
         : sendEventControlFocusSucceeded(render_info->ps_id, direction);
 }
 
-void DisplayAgent::setListener(IDisplayListener* listener)
+void DisplayAgent::setDisplayListener(IDisplayListener* listener)
 {
     if (!listener)
         return;
@@ -253,7 +253,7 @@ void DisplayAgent::setListener(IDisplayListener* listener)
     render_helper->setDisplayListener(display_listener);
 }
 
-void DisplayAgent::removeListener(IDisplayListener* listener)
+void DisplayAgent::removeDisplayListener(IDisplayListener* listener)
 {
     if (!display_listener && (display_listener == listener))
         display_listener = nullptr;

--- a/src/capability/display_agent.hh
+++ b/src/capability/display_agent.hh
@@ -44,8 +44,8 @@ public:
     void displayCleared(const std::string& id) override;
     void elementSelected(const std::string& id, const std::string& item_token, const std::string& postback) override;
     void informControlResult(const std::string& id, ControlType type, ControlDirection direction) override;
-    void setListener(IDisplayListener* listener) override;
-    void removeListener(IDisplayListener* listener) override;
+    void setDisplayListener(IDisplayListener* listener) override;
+    void removeDisplayListener(IDisplayListener* listener) override;
     void stopRenderingTimer(const std::string& id) override;
     void refreshRenderingTimer(const std::string& id) override;
 

--- a/src/capability/display_interface.cc
+++ b/src/capability/display_interface.cc
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "capability/display_interface.hh"
+
+namespace NuguCapability {
+
+void IDisplayHandler::displayRendered(const std::string& id) {}
+void IDisplayHandler::displayCleared(const std::string& id) {}
+void IDisplayHandler::elementSelected(const std::string& id, const std::string& item_token, const std::string& postback) {}
+void IDisplayHandler::informControlResult(const std::string& id, ControlType type, ControlDirection direction) {}
+void IDisplayHandler::setDisplayListener(IDisplayListener* listener) {}
+void IDisplayHandler::removeDisplayListener(IDisplayListener* listener) {}
+void IDisplayHandler::stopRenderingTimer(const std::string& id) {}
+void IDisplayHandler::refreshRenderingTimer(const std::string& id) {}
+
+} // NuguCapability


### PR DESCRIPTION
It divide the IAudioPlayerDisplayListener from IAudioPlayerListener.

It change the API for setting/removing IAudioPlayerDisplayListener.
* from setListener to setDisplayListener
* from removeListener to removeDisplayListener

It define the no-op methods of IDisplayHandler for preventing
unnecessary methods overriding even if those are not used.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>