### PR TITLE
externals: update nghttp2 to v1.44.0

### DIFF
--- a/externals/0001_curl_find_nghttp2.patch
+++ b/externals/0001_curl_find_nghttp2.patch
@@ -7,7 +7,7 @@
 +find_path(NGHTTP2_INCLUDE_DIR "nghttp2/nghttp2.h" HINTS ${NGHTTP2_INCLUDE_DIR})
  
 -find_library(NGHTTP2_LIBRARY NAMES nghttp2)
-+find_library(NGHTTP2_LIBRARY NAMES libnghttp2_static.a HINTS ${NGHTTP2_LIBRARY})
++find_library(NGHTTP2_LIBRARY NAMES libnghttp2.a HINTS ${NGHTTP2_LIBRARY})
  
  find_package_handle_standard_args(NGHTTP2
      FOUND_VAR

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,7 +15,7 @@ ADD_LIBRARY(libnugu SHARED
 
 TARGET_LINK_LIBRARIES(libnugu PUBLIC
 	${CMAKE_BINARY_DIR}/curl/lib/libcurl.a
-	${CMAKE_BINARY_DIR}/nghttp2/lib/libnghttp2_static.a
+	${CMAKE_BINARY_DIR}/nghttp2/lib/libnghttp2.a
 	${pkgs_LDFLAGS} ${LDFLAG_SOCKET} ${LDFLAG_DL})
 
 SET_TARGET_PROPERTIES(libnugu


### PR DESCRIPTION
update the nghttp2 library v1.40.0 to v1.44.0

Signed-off-by: Inho Oh <inho.oh@sk.com>