### PR TITLE
core: add input/output type to epd_param

### DIFF
--- a/src/core/speech_recognizer.cc
+++ b/src/core/speech_recognizer.cc
@@ -106,6 +106,9 @@ void SpeechRecognizer::loop()
     else
         epd_param.sample_rate = 16000;
 
+    epd_param.input_type = EPD_DATA_TYPE_LINEAR_PCM16;
+    epd_param.output_type = EPD_DATA_TYPE_SPEEX_STREAM;
+
     nugu_dbg("Listening Thread: started");
 
     if (model_path.size()) {


### PR DESCRIPTION
The EPD library updated to set the input and output data format using
epd_param.

Signed-off-by: Inho Oh <webispy@gmail.com>