### PR TITLE
Message:Add to call base initialize

### DIFF
--- a/src/capability/message_agent.cc
+++ b/src/capability/message_agent.cc
@@ -40,6 +40,8 @@ void MessageAgent::initialize()
         return;
     }
 
+    Capability::initialize();
+
     speak_dir = nullptr;
 
     tts_player = core_container->createTTSPlayer();


### PR DESCRIPTION
It add to call the same overriding base method in initialize
of MessageAgent for initializing variables of base class.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>