### PR TITLE
base: add encoder driver

### DIFF
--- a/include/base/nugu_encoder.h
+++ b/include/base/nugu_encoder.h
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2021 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NUGU_ENCODER_H__
+#define __NUGU_ENCODER_H__
+
+#include <base/nugu_pcm.h>
+#include <base/nugu_buffer.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file nugu_encoder.h
+ */
+
+/**
+ * @brief encoder object
+ * @ingroup NuguEncoder
+ */
+typedef struct _nugu_encoder NuguEncoder;
+
+/**
+ * @brief encoder driver object
+ * @ingroup NuguEncoderDriver
+ */
+typedef struct _nugu_encoder_driver NuguEncoderDriver;
+
+/**
+ * @defgroup NuguEncoder Encoder
+ * @ingroup SDKBase
+ * @brief Encoder functions
+ *
+ * The encoder object encodes the pcm data to specific encoded data.
+ *
+ * @{
+ */
+
+/**
+ * @brief Create new encoder object
+ * @param[in] driver encoder driver
+ * @param[in] property audio property(channel,type,sample-rate)
+ * @return encoder object
+ * @see nugu_encoder_free()
+ */
+NuguEncoder *nugu_encoder_new(NuguEncoderDriver *driver,
+			      NuguAudioProperty property);
+
+/**
+ * @brief Destroy the encoder object
+ * @param[in] enc encoder object
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ * @see nugu_encoder_new()
+ */
+int nugu_encoder_free(NuguEncoder *enc);
+
+/**
+ * @brief Set custom data for driver
+ * @param[in] enc encoder object
+ * @param[in] data custom data managed by driver
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ * @see nugu_encoder_get_driver_data()
+ */
+int nugu_encoder_set_driver_data(NuguEncoder *enc, void *data);
+
+/**
+ * @brief Get custom data for driver
+ * @param[in] enc encoder object
+ * @return data
+ * @see nugu_encoder_set_driver_data()
+ */
+void *nugu_encoder_get_driver_data(NuguEncoder *enc);
+
+/**
+ * @brief Encode the encoded data
+ * @param[in] enc encoder object
+ * @param[in] data pcm data
+ * @param[in] data_len pcm data length
+ * @param[out] output_len output buffer length
+ * @return memory allocated encoded data. Developer must free the data manually.
+ */
+void *nugu_encoder_encode(NuguEncoder *enc, const void *data, size_t data_len,
+			  size_t *output_len);
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup NuguEncoderDriver Encoder driver
+ * @ingroup SDKDriver
+ * @brief Encoder driver
+ *
+ * The encoder driver performs a function of encoding the received pcm data.
+ *
+ * @{
+ */
+
+/**
+ * @brief encoder type
+ * @see nugu_encoder_driver_new()
+ */
+enum nugu_encoder_type {
+	NUGU_ENCODER_TYPE_SPEEX, /**< SPEEX */
+	NUGU_ENCODER_TYPE_OPUS, /**< OPUS */
+	NUGU_ENCODER_TYPE_CUSTOM = 99 /**< Custom type */
+};
+
+/**
+ * @brief encoder driver operations
+ * @see nugu_encoder_driver_new()
+ */
+struct nugu_encoder_driver_ops {
+	/**
+	 * @brief Called when creating a new encoder.
+	 * @see nugu_encoder_new()
+	 */
+	int (*create)(NuguEncoderDriver *driver, NuguEncoder *enc,
+		      NuguAudioProperty property);
+
+	/**
+	 * @brief Called when a encoding request is received from the encoder.
+	 * @see nugu_encoder_encode()
+	 */
+	int (*encode)(NuguEncoderDriver *driver, NuguEncoder *enc,
+		      const void *data, size_t data_len, NuguBuffer *out_buf);
+	/**
+	 * @brief Called when the encoder is destroyed.
+	 * @see nugu_encoder_free()
+	 */
+	int (*destroy)(NuguEncoderDriver *driver, NuguEncoder *enc);
+};
+
+/**
+ * @brief Create new encoder driver
+ * @param[in] name driver name
+ * @param[in] type encoder type
+ * @param[in] ops operation table
+ * @return encoder driver object
+ * @see nugu_encoder_driver_free()
+ */
+NuguEncoderDriver *nugu_encoder_driver_new(const char *name,
+					   enum nugu_encoder_type type,
+					   struct nugu_encoder_driver_ops *ops);
+
+/**
+ * @brief Destroy the encoder driver
+ * @param[in] driver encoder driver object
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ */
+int nugu_encoder_driver_free(NuguEncoderDriver *driver);
+
+/**
+ * @brief Register the driver to driver list
+ * @param[in] driver encoder driver object
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ */
+int nugu_encoder_driver_register(NuguEncoderDriver *driver);
+
+/**
+ * @brief Remove the driver from driver list
+ * @param[in] driver encoder driver object
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ */
+int nugu_encoder_driver_remove(NuguEncoderDriver *driver);
+
+/**
+ * @brief Find a driver by name in the driver list
+ * @param[in] name encoder driver name
+ * @return encoder driver object
+ * @see nugu_encoder_driver_find_bytype()
+ */
+NuguEncoderDriver *nugu_encoder_driver_find(const char *name);
+
+/**
+ * @brief Find a driver by type in the driver list
+ * @param[in] type encoder driver type
+ * @return encoder driver object
+ * @see nugu_encoder_driver_find
+ */
+NuguEncoderDriver *nugu_encoder_driver_find_bytype(enum nugu_encoder_type type);
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/base/nugu_decoder.c
+++ b/src/base/nugu_decoder.c
@@ -157,7 +157,10 @@ EXPORT_API NuguDecoder *nugu_decoder_new(NuguDecoderDriver *driver,
 	if (driver->ops->create(driver, dec) == 0)
 		return dec;
 
+	nugu_error("create() failed from driver");
+
 	driver->ref_count--;
+	nugu_buffer_free(dec->buf, 1);
 	memset(dec, 0, sizeof(struct _nugu_decoder));
 	free(dec);
 

--- a/src/base/nugu_encoder.c
+++ b/src/base/nugu_encoder.c
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2021 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <glib.h>
+
+#include "base/nugu_log.h"
+#include "base/nugu_encoder.h"
+
+#define DEFAULT_ENCODE_BUFFER_SIZE 4096
+
+struct _nugu_encoder {
+	NuguEncoderDriver *driver;
+	void *driver_data;
+
+	NuguBuffer *buf;
+};
+
+struct _nugu_encoder_driver {
+	char *name;
+	enum nugu_encoder_type type;
+	struct nugu_encoder_driver_ops *ops;
+	int ref_count;
+};
+
+static GList *_encoder_drivers;
+
+EXPORT_API NuguEncoderDriver *
+nugu_encoder_driver_new(const char *name, enum nugu_encoder_type type,
+			struct nugu_encoder_driver_ops *ops)
+{
+	NuguEncoderDriver *driver;
+
+	g_return_val_if_fail(name != NULL, NULL);
+	g_return_val_if_fail(ops != NULL, NULL);
+
+	driver = malloc(sizeof(struct _nugu_encoder_driver));
+	driver->name = g_strdup(name);
+	driver->type = type;
+	driver->ops = ops;
+	driver->ref_count = 0;
+
+	return driver;
+}
+
+EXPORT_API int nugu_encoder_driver_free(NuguEncoderDriver *driver)
+{
+	g_return_val_if_fail(driver != NULL, -1);
+
+	if (driver->ref_count != 0)
+		return -1;
+
+	g_free(driver->name);
+
+	memset(driver, 0, sizeof(struct _nugu_encoder_driver));
+	free(driver);
+
+	return 0;
+}
+
+EXPORT_API int nugu_encoder_driver_register(NuguEncoderDriver *driver)
+{
+	g_return_val_if_fail(driver != NULL, -1);
+
+	if (nugu_encoder_driver_find(driver->name)) {
+		nugu_error("'%s' encoder driver already exist.", driver->name);
+		return -1;
+	}
+
+	_encoder_drivers = g_list_append(_encoder_drivers, driver);
+
+	return 0;
+}
+
+EXPORT_API int nugu_encoder_driver_remove(NuguEncoderDriver *driver)
+{
+	GList *l;
+
+	l = g_list_find(_encoder_drivers, driver);
+	if (!l)
+		return -1;
+
+	_encoder_drivers = g_list_remove_link(_encoder_drivers, l);
+
+	return 0;
+}
+
+EXPORT_API NuguEncoderDriver *nugu_encoder_driver_find(const char *name)
+{
+	GList *cur;
+
+	g_return_val_if_fail(name != NULL, NULL);
+
+	cur = _encoder_drivers;
+	while (cur) {
+		if (g_strcmp0(((NuguEncoderDriver *)cur->data)->name, name) ==
+		    0)
+			return cur->data;
+
+		cur = cur->next;
+	}
+
+	return NULL;
+}
+
+EXPORT_API NuguEncoderDriver *
+nugu_encoder_driver_find_bytype(enum nugu_encoder_type type)
+{
+	GList *cur;
+
+	cur = _encoder_drivers;
+	while (cur) {
+		if (((NuguEncoderDriver *)cur->data)->type == type)
+			return cur->data;
+
+		cur = cur->next;
+	}
+
+	return NULL;
+}
+
+EXPORT_API NuguEncoder *nugu_encoder_new(NuguEncoderDriver *driver,
+					 NuguAudioProperty property)
+{
+	NuguEncoder *enc;
+
+	g_return_val_if_fail(driver != NULL, NULL);
+
+	enc = malloc(sizeof(struct _nugu_encoder));
+	enc->driver = driver;
+	enc->buf = nugu_buffer_new(DEFAULT_ENCODE_BUFFER_SIZE);
+	enc->driver_data = NULL;
+
+	driver->ref_count++;
+
+	if (driver->ops->create == NULL)
+		return enc;
+
+	if (driver->ops->create(driver, enc, property) == 0)
+		return enc;
+
+	nugu_error("create() failed from driver");
+
+	driver->ref_count--;
+	nugu_buffer_free(enc->buf, 1);
+	memset(enc, 0, sizeof(struct _nugu_encoder));
+	free(enc);
+
+	return NULL;
+}
+
+EXPORT_API int nugu_encoder_free(NuguEncoder *enc)
+{
+	g_return_val_if_fail(enc != NULL, -1);
+
+	if (enc->driver->ops->destroy &&
+	    enc->driver->ops->destroy(enc->driver, enc) < 0)
+		return -1;
+
+	enc->driver->ref_count--;
+
+	if (enc->buf)
+		nugu_buffer_free(enc->buf, 1);
+
+	memset(enc, 0, sizeof(struct _nugu_encoder));
+	free(enc);
+
+	return 0;
+}
+
+EXPORT_API void *nugu_encoder_encode(NuguEncoder *enc, const void *data,
+				     size_t data_len, size_t *output_len)
+{
+	int ret;
+	void *out;
+
+	g_return_val_if_fail(enc != NULL, NULL);
+	g_return_val_if_fail(data != NULL, NULL);
+	g_return_val_if_fail(data_len > 0, NULL);
+	g_return_val_if_fail(enc->driver != NULL, NULL);
+	g_return_val_if_fail(output_len != NULL, NULL);
+
+	if (enc->driver->ops->encode == NULL) {
+		nugu_error("Not supported");
+		return NULL;
+	}
+
+	ret = enc->driver->ops->encode(enc->driver, enc, data, data_len,
+				       enc->buf);
+	if (ret != 0)
+		return NULL;
+
+	*output_len = nugu_buffer_get_size(enc->buf);
+
+	out = nugu_buffer_pop(enc->buf, 0);
+	if (!out)
+		return NULL;
+
+	return out;
+}
+
+EXPORT_API int nugu_encoder_set_driver_data(NuguEncoder *enc, void *data)
+{
+	g_return_val_if_fail(enc != NULL, -1);
+
+	enc->driver_data = data;
+
+	return 0;
+}
+
+EXPORT_API void *nugu_encoder_get_driver_data(NuguEncoder *enc)
+{
+	g_return_val_if_fail(enc != NULL, NULL);
+
+	return enc->driver_data;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ SET(UNIT_TESTS
 	test_nugu_plugin
 	test_nugu_recorder
 	test_nugu_decoder
+	test_nugu_encoder
 	test_nugu_pcm
 	test_nugu_player
 	test_nugu_timer

--- a/tests/test_nugu_encoder.c
+++ b/tests/test_nugu_encoder.c
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2021 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <glib.h>
+
+#include "base/nugu_encoder.h"
+
+static int _check_put_data;
+static NuguAudioProperty prop;
+
+static int dummy_create(NuguEncoderDriver *driver, NuguEncoder *enc,
+			NuguAudioProperty property)
+{
+	return 0;
+}
+
+static int dummy_destroy(NuguEncoderDriver *driver, NuguEncoder *enc)
+{
+	return 0;
+}
+
+/**
+ * add '<>' to data
+ */
+static int dummy_encode(NuguEncoderDriver *driver, NuguEncoder *enc,
+			const void *data, size_t data_len, NuguBuffer *out_buf)
+{
+	g_assert_cmpstr(data, ==, "hello");
+	_check_put_data = 1;
+
+	nugu_buffer_add(out_buf, "<", 1);
+	nugu_buffer_add(out_buf, data, 5);
+	nugu_buffer_add(out_buf, ">", 1);
+
+	return 0;
+}
+
+static struct nugu_encoder_driver_ops encoder_driver_ops = {
+	.create = dummy_create,
+	.encode = dummy_encode,
+	.destroy = dummy_destroy
+};
+
+static int fail_create(NuguEncoderDriver *driver, NuguEncoder *enc,
+			NuguAudioProperty property)
+{
+	return -1;
+}
+
+static struct nugu_encoder_driver_ops fail_ops = {
+	.create = fail_create,
+	.encode = NULL,
+	.destroy = NULL
+};
+
+static struct nugu_encoder_driver_ops empty_ops = { .encode = NULL };
+
+static void test_encoder_encode(void)
+{
+	NuguEncoderDriver *driver;
+	NuguEncoder *enc;
+	size_t result_length = 0;
+	void *output;
+
+	driver = nugu_encoder_driver_new("test", NUGU_ENCODER_TYPE_CUSTOM,
+					 &encoder_driver_ops);
+	g_assert(driver != NULL);
+
+	enc = nugu_encoder_new(driver, prop);
+	g_assert(enc != NULL);
+	g_assert(nugu_encoder_driver_free(driver) == -1);
+
+	_check_put_data = 0;
+	output = nugu_encoder_encode(enc, "hello", 5, &result_length);
+	g_assert(output != NULL);
+	g_assert(result_length != 0);
+	g_assert(_check_put_data == 1);
+	g_assert_cmpstr((char *)output, ==, "<hello>");
+	free(output);
+
+	nugu_encoder_free(enc);
+	g_assert(nugu_encoder_driver_free(driver) == 0);
+}
+
+static void test_encoder_default(void)
+{
+	NuguEncoderDriver *driver;
+	NuguEncoderDriver *driver2;
+	NuguEncoderDriver *fail_driver;
+	NuguEncoder *enc;
+	char *mydata = "test";
+	size_t result_length = 999;
+
+	/* invalid input */
+	g_assert(nugu_encoder_driver_new(NULL, NUGU_ENCODER_TYPE_CUSTOM,
+					 NULL) == NULL);
+	g_assert(nugu_encoder_driver_new("test", NUGU_ENCODER_TYPE_CUSTOM,
+					 NULL) == NULL);
+	g_assert(nugu_encoder_driver_new(NULL, NUGU_ENCODER_TYPE_CUSTOM,
+					 &empty_ops) == NULL);
+	g_assert(nugu_encoder_driver_register(NULL) < 0);
+	g_assert(nugu_encoder_driver_remove(NULL) < 0);
+	g_assert(nugu_encoder_driver_find(NULL) == NULL);
+	g_assert(nugu_encoder_driver_find("") == NULL);
+
+	driver = nugu_encoder_driver_new("test", NUGU_ENCODER_TYPE_CUSTOM,
+					 &empty_ops);
+	g_assert(driver != NULL);
+
+	g_assert(nugu_encoder_driver_find("test") == NULL);
+	g_assert(nugu_encoder_driver_register(driver) == 0);
+	g_assert(nugu_encoder_driver_find("test") == driver);
+	g_assert(nugu_encoder_driver_find_bytype(NUGU_ENCODER_TYPE_CUSTOM) ==
+		 driver);
+	g_assert(nugu_encoder_driver_find_bytype(NUGU_ENCODER_TYPE_OPUS) ==
+		 NULL);
+	g_assert(nugu_encoder_driver_remove(driver) == 0);
+	g_assert(nugu_encoder_driver_find("test") == NULL);
+
+	nugu_encoder_driver_free(driver);
+
+	driver = nugu_encoder_driver_new("test1", NUGU_ENCODER_TYPE_CUSTOM,
+					 &empty_ops);
+	g_assert(driver != NULL);
+	g_assert(nugu_encoder_driver_register(driver) == 0);
+
+	driver2 = nugu_encoder_driver_new("test2", NUGU_ENCODER_TYPE_CUSTOM,
+					  &empty_ops);
+	g_assert(driver2 != NULL);
+	g_assert(nugu_encoder_driver_register(driver2) == 0);
+
+	g_assert(nugu_encoder_driver_find("test1") == driver);
+	g_assert(nugu_encoder_driver_find("test2") == driver2);
+
+	g_assert(nugu_encoder_driver_remove(driver) == 0);
+	g_assert(nugu_encoder_driver_remove(driver2) == 0);
+
+	g_assert(nugu_encoder_new(NULL, prop) == NULL);
+	g_assert(nugu_encoder_encode(NULL, NULL, 0, NULL) == NULL);
+	g_assert(nugu_encoder_encode(NULL, "", 0, NULL) == NULL);
+	g_assert(nugu_encoder_set_driver_data(NULL, NULL) < 0);
+	g_assert(nugu_encoder_get_driver_data(NULL) == NULL);
+
+	/* normal encoding test */
+	enc = nugu_encoder_new(driver, prop);
+	g_assert(enc != NULL);
+	g_assert(nugu_encoder_driver_free(driver) == -1);
+
+	g_assert(nugu_encoder_set_driver_data(enc, mydata) == 0);
+	g_assert(nugu_encoder_get_driver_data(enc) == mydata);
+
+	g_assert(nugu_encoder_encode(enc, NULL, 0, &result_length) == NULL);
+	g_assert(result_length == 999);
+	g_assert(nugu_encoder_encode(enc, "test", 4, &result_length) == NULL);
+	g_assert(result_length == 999);
+
+	nugu_encoder_free(enc);
+
+	/* always encoder creation fail driver */
+	fail_driver = nugu_encoder_driver_new("test2", NUGU_ENCODER_TYPE_CUSTOM,
+					      &fail_ops);
+	g_assert(fail_driver != NULL);
+	g_assert(nugu_encoder_driver_register(fail_driver) == 0);
+
+	enc = nugu_encoder_new(fail_driver, prop);
+	g_assert(enc == NULL);
+
+	g_assert(nugu_encoder_driver_free(driver2) == 0);
+	g_assert(nugu_encoder_driver_free(driver) == 0);
+}
+
+int main(int argc, char *argv[])
+{
+#if !GLIB_CHECK_VERSION(2, 36, 0)
+	g_type_init();
+#endif
+
+	g_test_init(&argc, &argv, NULL);
+	g_log_set_always_fatal((GLogLevelFlags)G_LOG_FATAL_MASK);
+
+	prop.channel = 1;
+	prop.format = NUGU_AUDIO_FORMAT_S16_LE;
+	prop.samplerate = NUGU_AUDIO_SAMPLE_RATE_16K;
+
+	g_test_add_func("/encoder/driver_default", test_encoder_default);
+	g_test_add_func("/encoder/encode", test_encoder_encode);
+
+	return g_test_run();
+}


### PR DESCRIPTION
Add an encoder driver base implementation to support various encoding
types such as SPEEX and OPUS.

Signed-off-by: Inho Oh <inho.oh@sk.com>