### PR TITLE
TTS:Add setMute API

### DIFF
--- a/include/capability/tts_interface.hh
+++ b/include/capability/tts_interface.hh
@@ -123,6 +123,13 @@ public:
     virtual bool setVolume(int volume) = 0;
 
     /**
+     * @brief set pcm player's mute
+     * @param[in] mute volume mute
+     * @return result of set mute
+     */
+    virtual bool setMute(bool mute) = 0;
+
+    /**
      * @brief Set attribute about speech synthesizer
      * @param[in] attribute attribute object
      */

--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -241,6 +241,17 @@ bool TTSAgent::setVolume(int volume)
     return true;
 }
 
+bool TTSAgent::setMute(bool mute)
+{
+    nugu_dbg("set pcm player's mute: %d", mute);
+
+    if (!player || !player->setMute(mute))
+        return false;
+
+    nugu_dbg("pcm player's mute(%d) changed..", mute);
+    return true;
+}
+
 void TTSAgent::setCapabilityListener(ICapabilityListener* clistener)
 {
     if (clistener)

--- a/src/capability/tts_agent.hh
+++ b/src/capability/tts_agent.hh
@@ -44,6 +44,7 @@ public:
     void stopTTS() override;
     std::string requestTTS(const std::string& text, const std::string& play_service_id, const std::string& referrer_id = "") override;
     bool setVolume(int volume) override;
+    bool setMute(bool mute) override;
 
     void setCapabilityListener(ICapabilityListener* clistener) override;
     void addListener(ITTSListener* listener) override;


### PR DESCRIPTION
It add the setMute API in TTS interface for controlling PCM mute.

In currently, that API is activated when using gstreamer_pcm plugin only.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>