### PR TITLE
Display:Update handling history control

### DIFF
--- a/src/capability/display_agent.cc
+++ b/src/capability/display_agent.cc
@@ -327,13 +327,16 @@ void DisplayAgent::onSyncState(const std::string& ps_id, PlaySyncState state, vo
     if (state == PlaySyncState::Synced) {
         render_helper->renderDisplay(extra_data);
 
+        if (!history_control_stack.empty() && history_control_stack.top().id == render_helper->getId(extra_data))
+            history_control_stack.top().is_render = true;
+
         if (keep_history) {
             playsync_manager->releaseSync(ps_id, getName());
             keep_history = false;
         }
     } else if (state == PlaySyncState::Released) {
-        if (!keep_history && !history_control_stack.empty()) {
-            if (disp_cur_token != history_control_stack.top().token)
+        if (!keep_history && !history_control_stack.empty() && history_control_stack.top().is_render) {
+            if (render_helper->getToken(extra_data) != history_control_stack.top().token)
                 render_helper->removedRenderInfo(history_control_stack.top().id);
 
             history_control_stack.pop();

--- a/src/capability/display_agent.hh
+++ b/src/capability/display_agent.hh
@@ -63,6 +63,7 @@ private:
         std::string parent_token;
         std::string id;
         std::string token;
+        bool is_render = false;
     };
 
     void sendEventElementSelected(const std::string& item_token, const std::string& postback);

--- a/src/capability/display_render_helper.cc
+++ b/src/capability/display_render_helper.cc
@@ -146,6 +146,28 @@ DisplayRenderInfo* DisplayRenderHelper::getRenderInfo(const std::string& id) noe
     }
 }
 
+std::string DisplayRenderHelper::getId(void* raw_render_info)
+{
+    std::string id;
+    auto render_info = reinterpret_cast<DisplayRenderInfo*>(raw_render_info);
+
+    if (render_info)
+        id = render_info->id;
+
+    return id;
+}
+
+std::string DisplayRenderHelper::getToken(void* raw_render_info)
+{
+    std::string token;
+    auto render_info = reinterpret_cast<DisplayRenderInfo*>(raw_render_info);
+
+    if (render_info)
+        token = render_info->token;
+
+    return token;
+}
+
 std::string DisplayRenderHelper::getTemplateId(const std::string& ps_id)
 {
     for (const auto& info : render_infos)

--- a/src/capability/display_render_helper.hh
+++ b/src/capability/display_render_helper.hh
@@ -65,6 +65,8 @@ public:
     void setDisplayListener(IDisplayListener* display_listener);
     Builder* getRenderInfoBuilder();
     DisplayRenderInfo* getRenderInfo(const std::string& id) noexcept;
+    std::string getId(void* raw_render_info);
+    std::string getToken(void* raw_render_info);
     std::string getTemplateId(const std::string& ps_id);
     std::string renderDisplay(void* data);
     std::string updateDisplay(std::pair<void*, void*> datas, bool has_next_render);


### PR DESCRIPTION
It update the handling template history control
to manage whether the template is rendered or not.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>