### PR TITLE
fix double free on cancelDirective

### DIFF
--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -157,6 +157,11 @@ void TTSAgent::parsingDirective(const char* dname, const char* message)
 void TTSAgent::cancelDirective(NuguDirective* ndir)
 {
     sendClearNudgeCommand(ndir);
+
+    if (ndir == speak_dir) {
+        speak_dir = nullptr;
+        stopTTS();
+    }
 }
 
 void TTSAgent::updateInfoForContext(Json::Value& ctx)


### PR DESCRIPTION
fix double free issue on `cancelDirective()` handler and
`cancel()` API in the directive sequencer.

Signed-off-by: Inho Oh <webispy@gmail.com>