### PR TITLE
AudioPlayerAgent: added explicit pause

### DIFF
--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -395,6 +395,8 @@ std::string AudioPlayerAgent::pause(bool direct_access)
             return "";
         }
 
+        is_paused = true;
+
         if (cur_aplayer_state != AudioPlayerState::PLAYING) {
             nugu_warn("there is no playing media content in the playlist.");
             return "";


### PR DESCRIPTION
The explicit pause is added when the media player is paused by user.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>