### PR TITLE
base: add null check to plugin_find

### DIFF
--- a/src/base/nugu_plugin.c
+++ b/src/base/nugu_plugin.c
@@ -287,7 +287,9 @@ EXPORT_API NuguPlugin *nugu_plugin_find(const char *name)
 
 	cur = _plugin_list;
 	while (cur) {
-		if (g_strcmp0(((NuguPlugin *)cur->data)->desc->name, name) == 0)
+		NuguPlugin *p = cur->data;
+
+		if (p && g_strcmp0(p->desc->name, name) == 0)
 			return cur->data;
 
 		cur = cur->next;


### PR DESCRIPTION
If `-1` is returned in the `init` handler of a specific plug-in
during the initialization process of all plug-ins, the plug-in is
checked for removal and is removed from the plug-in list after
initialization.

At this time, when searching with the `nugu_plugin_find` API in
other plugins, the list item may be `null` in the case of a plugin
scheduled to be removed.

    Plugin A: return -1 in init()
    Plugin B: nugu_plugin_find('A') in init() -> crash

Signed-off-by: Inho Oh <webispy@gmail.com>