### PR TITLE
fix last attachment data for ASR

### DIFF
--- a/include/clientkit/speech_recognizer_interface.hh
+++ b/include/clientkit/speech_recognizer_interface.hh
@@ -73,8 +73,9 @@ public:
      * @brief Get current audio input stream
      * @param[in] buf audio input data
      * @param[in] length audio input length
+     * @param[in] is_end whether final data
      */
-    virtual void onRecordData(unsigned char* buf, int length) = 0;
+    virtual void onRecordData(unsigned char* buf, int length, bool is_end) = 0;
 };
 
 /**

--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -608,7 +608,6 @@ void ASRAgent::onListeningState(ListeningState state, const std::string& id)
             || prev_listening_state == ListeningState::SPEECH_START) {
             releaseASRFocus(true, ASRError::UNKNOWN, (request_listening_id == id));
         } else if (prev_listening_state == ListeningState::SPEECH_END) {
-            close_stream = true;
             checkResponseTimeout();
         } else if (prev_listening_state == ListeningState::TIMEOUT) {
             sendEventListenTimeout([&, id](const std::string& ename, const std::string& msg_id, const std::string& dialog_id, bool success, int code) {
@@ -622,7 +621,6 @@ void ASRAgent::onListeningState(ListeningState state, const std::string& id)
                 }
             });
             notifyASRErrorCancel(ASRError::LISTEN_TIMEOUT);
-            close_stream = true;
         } else if (prev_listening_state == ListeningState::FAILED) {
             releaseASRFocus(false, ASRError::LISTEN_FAILED, (request_listening_id == id));
             close_stream = true;
@@ -651,9 +649,10 @@ void ASRAgent::onListeningState(ListeningState state, const std::string& id)
 /*
  * The callback is invoked in the thread context.
  */
-void ASRAgent::onRecordData(unsigned char* buf, int length)
+void ASRAgent::onRecordData(unsigned char* buf, int length, bool is_end)
 {
-    sendEventRecognize((unsigned char*)buf, length, false);
+    nugu_dbg("recording data %d bytes, is_end=%d", length, is_end);
+    sendEventRecognize((unsigned char*)buf, length, is_end);
 }
 
 void ASRAgent::saveAllContextInfo()

--- a/src/capability/asr_agent.hh
+++ b/src/capability/asr_agent.hh
@@ -84,7 +84,7 @@ private:
 
     // implements ISpeechRecognizerListener
     void onListeningState(ListeningState state, const std::string& id) override;
-    void onRecordData(unsigned char* buf, int length) override;
+    void onRecordData(unsigned char* buf, int length, bool is_end) override;
 
     void saveAllContextInfo();
     std::string getRecognizeDialogId();


### PR DESCRIPTION
When recognizing the end of a voice, a separate end attachment packet
was transmitted without body data, but it was inefficient because it
had to send an unnecessary header.

In order to reduce unnecessary network transmission, it has been
modified to send the end mark in the header together with the last
data when recognizing the end of the voice.

Signed-off-by: Inho Oh <webispy@gmail.com>