### PR TITLE
Fix Cppcheck analysis results

### DIFF
--- a/.cppcheck_suppress.txt
+++ b/.cppcheck_suppress.txt
@@ -21,3 +21,5 @@ knownConditionTrueFalse:tests/test_nugu_ringbuffer.c
 
 // Disabled
 useStlAlgorithm
+noCopyConstructor
+noOperatorEq

--- a/examples/capability_injection/battery_agent.hh
+++ b/examples/capability_injection/battery_agent.hh
@@ -44,7 +44,6 @@ public:
 private:
     std::string battery_level = "10";
     bool battery_charging = false;
-    SuspendPolicy suspend_policy = SuspendPolicy::STOP;
 
     IBatteryListener* battery_listener = nullptr;
 };

--- a/examples/standalone/capability/display_listener.cc
+++ b/examples/standalone/capability/display_listener.cc
@@ -19,8 +19,8 @@
 #include "display_listener.hh"
 
 DisplayListener::DisplayListener()
+    : capability_name("Display")
 {
-    capability_name = "Display";
 }
 
 void DisplayListener::setDisplayHandler(IDisplayHandler* display_handler)

--- a/examples/standalone/capability/sound_listener.hh
+++ b/examples/standalone/capability/sound_listener.hh
@@ -26,7 +26,7 @@ public:
     virtual ~SoundListener() = default;
 
     void setSoundHandler(ISoundHandler* sound_handler);
-    void handleBeep(BeepType beep_type, const std::string& dialog_id);
+    void handleBeep(BeepType beep_type, const std::string& dialog_id) override;
 
 private:
     ISoundHandler* sound_handler = nullptr;

--- a/examples/standalone/nugu_sample_manager.cc
+++ b/examples/standalone/nugu_sample_manager.cc
@@ -80,9 +80,9 @@ void NuguSampleManager::CommandBuilder::compose(std::string&& divider)
 }
 
 NuguSampleManager::NuguSampleManager()
-    : command_builder(new CommandBuilder(this))
+    : model_path(std::string { NUGU_ASSET_PATH } + "/model/")
+    , command_builder(new CommandBuilder(this))
 {
-    model_path = std::string { NUGU_ASSET_PATH } + "/model/";
 }
 
 NuguSampleManager::~NuguSampleManager()

--- a/include/clientkit/capability.hh
+++ b/include/clientkit/capability.hh
@@ -113,7 +113,7 @@ private:
  */
 class Capability : virtual public ICapabilityInterface {
 public:
-    Capability(const std::string& name, const std::string& ver = "1.0");
+    explicit Capability(const std::string& name, const std::string& ver = "1.0");
     virtual ~Capability();
 
     /**

--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -28,8 +28,19 @@ static const char* CAPABILITY_VERSION = "1.6";
 
 ASRAgent::ASRAgent()
     : Capability(CAPABILITY_NAME, CAPABILITY_VERSION)
+    , es_attr({})
+    , rec_event(nullptr)
+    , timer(nullptr)
+    , uniq(0)
+    , prev_listening_state(ListeningState::DONE)
+    , asr_initiator(NONE_INITIATOR)
+    , cur_state(ASRState::IDLE)
+    , asr_cancel(false)
+    , listen_timeout_fail_beep(true)
     , asr_user_listener(nullptr)
     , asr_dm_listener(nullptr)
+    , wakeup_power_noise(0)
+    , wakeup_power_speech(0)
     , model_path("")
     , epd_type(NUGU_ASR_EPD_TYPE)
     , asr_encoding(NUGU_ASR_ENCODING)
@@ -583,11 +594,11 @@ void ASRAgent::onListeningState(ListeningState state, const std::string& id)
         wakeup_power_noise = 0;
         wakeup_power_speech = 0;
 
-        std::string id = getRecognizeDialogId();
-        nugu_dbg("user request dialog id: %s", id.c_str());
+        std::string recognize_dialog_id = getRecognizeDialogId();
+        nugu_dbg("user request dialog id: %s", recognize_dialog_id.c_str());
 
-        if (rec_callback && !id.empty())
-            rec_callback(id);
+        if (rec_callback && !recognize_dialog_id.empty())
+            rec_callback(recognize_dialog_id);
 
         setASRState(ASRState::LISTENING);
         break;

--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -27,6 +27,27 @@ static const char* CAPABILITY_VERSION = "1.6";
 
 AudioPlayerAgent::AudioPlayerAgent()
     : Capability(CAPABILITY_NAME, CAPABILITY_VERSION)
+    , cur_player(nullptr)
+    , media_player(nullptr)
+    , tts_player(nullptr)
+    , speak_dir(nullptr)
+    , preprocess_dir(nullptr)
+    , focus_state(FocusState::NONE)
+    , is_tts_activate(false)
+    , stop_reason_by_play_another(false)
+    , has_play_directive(false)
+    , receive_new_play_directive(false)
+    , suspended_stop_policy(false)
+    , skip_intermediate_foreground_focus(false)
+    , cur_aplayer_state(AudioPlayerState::IDLE)
+    , prev_aplayer_state(AudioPlayerState::IDLE)
+    , is_paused(false)
+    , is_paused_by_unfocus(false)
+    , report_delay_time(-1)
+    , report_interval_time(-1)
+    , is_finished(false)
+    , volume_update(false)
+    , volume(-1)
     , render_helper(std::unique_ptr<DisplayRenderHelper>(new DisplayRenderHelper()))
     , display_listener(nullptr)
 {
@@ -1064,7 +1085,6 @@ void AudioPlayerAgent::parsingPlay(const char* message)
     long offset;
     bool new_content;
     std::string token;
-    std::string temp;
     std::string play_service_id;
 
     if (!reader.parse(message, root)) {
@@ -1220,7 +1240,6 @@ void AudioPlayerAgent::parsingPause(const char* message)
     Json::Value audio_item;
     Json::Reader reader;
     std::string playserviceid;
-    std::string active_playserviceid;
 
     if (cur_token.empty()) {
         nugu_warn("there is no media content in the playlist.");
@@ -1378,9 +1397,9 @@ void AudioPlayerAgent::parsingShowLyrics(const char* message)
             throw "fail to show lyrics";
 
         sendEventShowLyricsSucceeded();
-    } catch (const char* message) {
+    } catch (const char* exception_message) {
         sendEventShowLyricsFailed();
-        nugu_error(message);
+        nugu_error(exception_message);
     }
 }
 
@@ -1408,9 +1427,9 @@ void AudioPlayerAgent::parsingHideLyrics(const char* message)
             throw "fail to hide lyrics";
 
         sendEventHideLyricsSucceeded();
-    } catch (const char* message) {
+    } catch (const char* exception_message) {
         sendEventHideLyricsFailed();
-        nugu_error(message);
+        nugu_error(exception_message);
     }
 }
 

--- a/src/capability/routine_agent.cc
+++ b/src/capability/routine_agent.cc
@@ -255,9 +255,9 @@ void RoutineAgent::parsingContinue(const char* message)
 
         play_service_id = root["playServiceId"].asString();
         routine_manager->resume();
-    } catch (const char* message) {
+    } catch (const char* exception_message) {
         sendEventFailed();
-        nugu_error(message);
+        nugu_error(exception_message);
     }
 }
 

--- a/src/capability/session_agent.hh
+++ b/src/capability/session_agent.hh
@@ -39,8 +39,8 @@ private:
     void parsingSet(const char* message);
 
     // implements ISessionManagerListener
-    void activated(const std::string& dialog_id, Session session);
-    void deactivated(const std::string& dialog_id);
+    void activated(const std::string& dialog_id, Session session) override;
+    void deactivated(const std::string& dialog_id) override;
 
     ISessionListener* session_listener = nullptr;
     std::string play_service_id;

--- a/src/clientkit/nugu_client.cc
+++ b/src/clientkit/nugu_client.cc
@@ -38,8 +38,8 @@ bool NuguClient::CapabilityBuilder::construct()
 }
 
 NuguClient::NuguClient()
+    : impl(std::unique_ptr<NuguClientImpl>(new NuguClientImpl()))
 {
-    impl = std::unique_ptr<NuguClientImpl>(new NuguClientImpl());
     cap_builder = new CapabilityBuilder(impl.get());
 }
 

--- a/src/core/audio_recorder_manager.cc
+++ b/src/core/audio_recorder_manager.cc
@@ -314,7 +314,7 @@ NuguAudioProperty AudioRecorderManager::convertNuguAudioProperty(std::string& sa
     return property;
 }
 
-std::string AudioRecorderManager::extractRecorderKey(std::string& sample, std::string& format, std::string& channel)
+std::string AudioRecorderManager::extractRecorderKey(const std::string& sample, const std::string& format, const std::string& channel)
 {
     return sample + "," + format + "," + channel;
 }

--- a/src/core/audio_recorder_manager.hh
+++ b/src/core/audio_recorder_manager.hh
@@ -74,7 +74,7 @@ public:
 
 private:
     NuguAudioProperty convertNuguAudioProperty(std::string& sample, std::string& format, std::string& channel);
-    std::string extractRecorderKey(std::string& sample, std::string& format, std::string& channel);
+    std::string extractRecorderKey(const std::string& sample, const std::string& format, const std::string& channel);
     NuguRecorder* extractNuguRecorder(IAudioRecorder* recorder);
 
 private:

--- a/src/core/capability_manager.cc
+++ b/src/core/capability_manager.cc
@@ -30,14 +30,14 @@ static const char* CONTEXT_OS = "Linux";
 CapabilityManager* CapabilityManager::instance = nullptr;
 
 CapabilityManager::CapabilityManager()
-    : playsync_manager(std::unique_ptr<PlaySyncManager>(new PlaySyncManager()))
+    : wword(WAKEUP_WORD)
+    , playsync_manager(std::unique_ptr<PlaySyncManager>(new PlaySyncManager()))
     , focus_manager(std::unique_ptr<FocusManager>(new FocusManager()))
     , session_manager(std::unique_ptr<SessionManager>(new SessionManager()))
     , directive_sequencer(std::unique_ptr<DirectiveSequencer>(new DirectiveSequencer()))
     , interaction_control_manager(std::unique_ptr<InteractionControlManager>(new InteractionControlManager()))
     , routine_manager(std::unique_ptr<RoutineManager>(new RoutineManager()))
 {
-    wword = WAKEUP_WORD;
     no_command_directive_filter = { "System.Noop" };
 
     playsync_manager->setInteractionControlManager(interaction_control_manager.get());
@@ -279,7 +279,7 @@ std::string CapabilityManager::makeAllContextInfo()
     return writer.write(getBaseContextInfo(cap_ctx, std::move(playstack_ctx)));
 }
 
-Json::Value CapabilityManager::getBaseContextInfo(Json::Value& supported_interfaces, Json::Value&& playstack)
+Json::Value CapabilityManager::getBaseContextInfo(const Json::Value& supported_interfaces, Json::Value&& playstack)
 {
     Json::Value root;
     Json::Value client;

--- a/src/core/capability_manager.hh
+++ b/src/core/capability_manager.hh
@@ -83,7 +83,7 @@ public:
 
 private:
     ICapabilityInterface* findCapability(const std::string& cname);
-    Json::Value getBaseContextInfo(Json::Value& supported_interfaces, Json::Value&& playstack);
+    Json::Value getBaseContextInfo(const Json::Value& supported_interfaces, Json::Value&& playstack);
     bool isConditionToSendCommand(const NuguDirective* ndir);
 
     const unsigned int PROGRESS_DIALOGS_MAX = 5;

--- a/src/core/directive_sequencer.cc
+++ b/src/core/directive_sequencer.cc
@@ -220,7 +220,7 @@ bool DialogDirectiveList::remove(NuguDirective* ndir)
     /* remove the directive from directive list */
     dlist.erase(
         std::remove_if(dlist.begin(), dlist.end(),
-            [ndir](NuguDirective* target_ndir) {
+            [ndir](const NuguDirective* target_ndir) {
                 return (ndir == target_ndir);
             }),
         dlist.end());
@@ -430,8 +430,8 @@ void DirectiveSequencer::reset()
     policy_map.clear();
     scheduled_list.clear();
     msgid_lookup->clearWithUnref();
-    pending->clear([](NuguDirective* ndir){});
-    active->clear([](NuguDirective* ndir){});
+    pending->clear([](NuguDirective* ndir) {});
+    active->clear([](NuguDirective* ndir) {});
 
     last_cancel_dialog_id = "";
 }

--- a/src/core/playstack_manager.hh
+++ b/src/core/playstack_manager.hh
@@ -89,7 +89,7 @@ public:
 private:
     class StackTimer final : public IStackTimer {
     public:
-        bool isStarted();
+        bool isStarted() override;
         void start(unsigned int sec = 0) override;
         void stop() override;
         void notifyCallback() override;

--- a/src/core/speech_recognizer.hh
+++ b/src/core/speech_recognizer.hh
@@ -41,7 +41,7 @@ public:
 
 public:
     SpeechRecognizer();
-    SpeechRecognizer(Attribute&& attribute);
+    explicit SpeechRecognizer(Attribute&& attribute);
     virtual ~SpeechRecognizer();
 
     // implements ISpeechRecognizer

--- a/src/core/wakeup_detector.hh
+++ b/src/core/wakeup_detector.hh
@@ -51,7 +51,7 @@ public:
 
 public:
     WakeupDetector();
-    WakeupDetector(Attribute&& attribute);
+    explicit WakeupDetector(Attribute&& attribute);
     virtual ~WakeupDetector();
 
     void setListener(IWakeupDetectorListener* listener);

--- a/tests/core/test_core_playstack_manager.cc
+++ b/tests/core/test_core_playstack_manager.cc
@@ -30,13 +30,13 @@ static const unsigned int DEFAULT_LONG_HOLD_TIME_SEC = 600;
 
 class PlayStackManagerListener : public IPlayStackManagerListener {
 public:
-    void onStackAdded(const std::string& ps_id)
+    void onStackAdded(const std::string& ps_id) override
     {
         ps_ids.emplace_back(ps_id);
         stack_added_call_count++;
     }
 
-    void onStackRemoved(const std::string& ps_id)
+    void onStackRemoved(const std::string& ps_id) override
     {
         if (inter_hook_func)
             inter_hook_func();


### PR DESCRIPTION
It fix the some issues of Cppcheck analysis results.

It add the suppression cases because it's not effective.
* noCopyConstructor
* noOperatorEq

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>