### PR TITLE
base: fix encoder module

### DIFF
--- a/include/base/nugu_encoder.h
+++ b/include/base/nugu_encoder.h
@@ -92,13 +92,28 @@ void *nugu_encoder_get_driver_data(NuguEncoder *enc);
 /**
  * @brief Encode the encoded data
  * @param[in] enc encoder object
+ * @param[in] is_last last data hint (1 = last, 0 = not last)
  * @param[in] data pcm data
  * @param[in] data_len pcm data length
  * @param[out] output_len output buffer length
  * @return memory allocated encoded data. Developer must free the data manually.
  */
-void *nugu_encoder_encode(NuguEncoder *enc, const void *data, size_t data_len,
-			  size_t *output_len);
+void *nugu_encoder_encode(NuguEncoder *enc, int is_last, const void *data,
+		size_t data_len, size_t *output_len);
+
+/**
+ * @brief Get encoder codec. e.g. "OGG_OPUS" or "SPEEX"
+ * @param[in] enc encoder object
+ * @return encoder type string
+ */
+const char *nugu_encoder_get_codec(NuguEncoder *enc);
+
+/**
+ * @brief Get encoder mime type
+ * @param[in] enc encoder object
+ * @return encoder mime type string
+ */
+const char *nugu_encoder_get_mime_type(NuguEncoder *enc);
 
 /**
  * @}
@@ -141,7 +156,8 @@ struct nugu_encoder_driver_ops {
 	 * @see nugu_encoder_encode()
 	 */
 	int (*encode)(NuguEncoderDriver *driver, NuguEncoder *enc,
-		      const void *data, size_t data_len, NuguBuffer *out_buf);
+		      int is_last, const void *data, size_t data_len,
+		      NuguBuffer *out_buf);
 	/**
 	 * @brief Called when the encoder is destroyed.
 	 * @see nugu_encoder_free()

--- a/include/clientkit/speech_recognizer_interface.hh
+++ b/include/clientkit/speech_recognizer_interface.hh
@@ -123,6 +123,12 @@ public:
     virtual bool isMute() = 0;
 
     /**
+     * @brief Get codec information of recorder
+     * @return codec
+     */
+    virtual std::string getCodec() = 0;
+
+    /**
      * @brief Get mime type information of recorder
      * @return mime type
      */

--- a/src/base/nugu_encoder.c
+++ b/src/base/nugu_encoder.c
@@ -184,15 +184,15 @@ EXPORT_API int nugu_encoder_free(NuguEncoder *enc)
 	return 0;
 }
 
-EXPORT_API void *nugu_encoder_encode(NuguEncoder *enc, const void *data,
-				     size_t data_len, size_t *output_len)
+EXPORT_API void *nugu_encoder_encode(NuguEncoder *enc, int is_last,
+				     const void *data, size_t data_len,
+				     size_t *output_len)
 {
 	int ret;
 	void *out;
 
 	g_return_val_if_fail(enc != NULL, NULL);
 	g_return_val_if_fail(data != NULL, NULL);
-	g_return_val_if_fail(data_len > 0, NULL);
 	g_return_val_if_fail(enc->driver != NULL, NULL);
 	g_return_val_if_fail(output_len != NULL, NULL);
 
@@ -201,8 +201,8 @@ EXPORT_API void *nugu_encoder_encode(NuguEncoder *enc, const void *data,
 		return NULL;
 	}
 
-	ret = enc->driver->ops->encode(enc->driver, enc, data, data_len,
-				       enc->buf);
+	ret = enc->driver->ops->encode(enc->driver, enc, is_last, data,
+				       data_len, enc->buf);
 	if (ret != 0)
 		return NULL;
 
@@ -229,4 +229,28 @@ EXPORT_API void *nugu_encoder_get_driver_data(NuguEncoder *enc)
 	g_return_val_if_fail(enc != NULL, NULL);
 
 	return enc->driver_data;
+}
+
+EXPORT_API const char *nugu_encoder_get_codec(NuguEncoder *enc)
+{
+	g_return_val_if_fail(enc != NULL, NULL);
+	g_return_val_if_fail(enc->driver != NULL, NULL);
+
+	if (enc->driver->type == NUGU_ENCODER_TYPE_OPUS)
+		return "OGG_OPUS";
+	else if (enc->driver->type == NUGU_ENCODER_TYPE_SPEEX)
+		return "SPEEX";
+
+	return "CUSTOM";
+}
+
+EXPORT_API const char *nugu_encoder_get_mime_type(NuguEncoder *enc)
+{
+	g_return_val_if_fail(enc != NULL, NULL);
+	g_return_val_if_fail(enc->driver != NULL, NULL);
+
+	if (enc->driver->type == NUGU_ENCODER_TYPE_OPUS)
+		return "audio/ogg; codecs=opus";
+
+	return "application/octet-stream";
 }

--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -392,7 +392,7 @@ void ASRAgent::sendEventRecognize(unsigned char* data, size_t length, bool is_en
         return;
     }
 
-    root["codec"] = "SPEEX";
+    root["codec"] = speech_recognizer->getCodec();
     root["language"] = "KOR";
     root["endpointing"] = epd_type;
     root["encoding"] = asr_encoding;

--- a/src/core/speech_recognizer.cc
+++ b/src/core/speech_recognizer.cc
@@ -41,6 +41,7 @@ static const int ASR_EPD_PAUSE_LENGTH_MSEC = 700;
 SpeechRecognizer::SpeechRecognizer(Attribute&& attribute)
     : epd_ret(-1)
     , listener(nullptr)
+    , codec("SPEEX")
     , mime_type("application/octet-stream")
 {
     initialize(std::move(attribute));
@@ -330,6 +331,11 @@ bool SpeechRecognizer::isMute()
         return false;
 
     return recorder->isMute();
+}
+
+std::string SpeechRecognizer::getCodec()
+{
+    return codec;
 }
 
 std::string SpeechRecognizer::getMimeType()

--- a/src/core/speech_recognizer.hh
+++ b/src/core/speech_recognizer.hh
@@ -48,6 +48,7 @@ public:
     void setEpdAttribute(const EpdAttribute& attribute) override;
     EpdAttribute getEpdAttribute() override;
     bool isMute() override;
+    std::string getCodec() override;
     std::string getMimeType() override;
 
 private:
@@ -57,6 +58,7 @@ private:
 
     int epd_ret;
     ISpeechRecognizerListener* listener;
+    std::string codec;
     std::string mime_type;
 
     // attribute

--- a/tests/test_nugu_encoder.c
+++ b/tests/test_nugu_encoder.c
@@ -40,7 +40,8 @@ static int dummy_destroy(NuguEncoderDriver *driver, NuguEncoder *enc)
  * add '<>' to data
  */
 static int dummy_encode(NuguEncoderDriver *driver, NuguEncoder *enc,
-			const void *data, size_t data_len, NuguBuffer *out_buf)
+			int is_last, const void *data, size_t data_len,
+			NuguBuffer *out_buf)
 {
 	g_assert_cmpstr(data, ==, "hello");
 	_check_put_data = 1;
@@ -88,7 +89,7 @@ static void test_encoder_encode(void)
 	g_assert(nugu_encoder_driver_free(driver) == -1);
 
 	_check_put_data = 0;
-	output = nugu_encoder_encode(enc, "hello", 5, &result_length);
+	output = nugu_encoder_encode(enc, 0, "hello", 5, &result_length);
 	g_assert(output != NULL);
 	g_assert(result_length != 0);
 	g_assert(_check_put_data == 1);
@@ -153,8 +154,8 @@ static void test_encoder_default(void)
 	g_assert(nugu_encoder_driver_remove(driver2) == 0);
 
 	g_assert(nugu_encoder_new(NULL, prop) == NULL);
-	g_assert(nugu_encoder_encode(NULL, NULL, 0, NULL) == NULL);
-	g_assert(nugu_encoder_encode(NULL, "", 0, NULL) == NULL);
+	g_assert(nugu_encoder_encode(NULL, 0, NULL, 0, NULL) == NULL);
+	g_assert(nugu_encoder_encode(NULL, 0, "", 0, NULL) == NULL);
 	g_assert(nugu_encoder_set_driver_data(NULL, NULL) < 0);
 	g_assert(nugu_encoder_get_driver_data(NULL) == NULL);
 
@@ -162,13 +163,14 @@ static void test_encoder_default(void)
 	enc = nugu_encoder_new(driver, prop);
 	g_assert(enc != NULL);
 	g_assert(nugu_encoder_driver_free(driver) == -1);
+	g_assert_cmpstr(nugu_encoder_get_codec(enc), ==, "CUSTOM");
 
 	g_assert(nugu_encoder_set_driver_data(enc, mydata) == 0);
 	g_assert(nugu_encoder_get_driver_data(enc) == mydata);
 
-	g_assert(nugu_encoder_encode(enc, NULL, 0, &result_length) == NULL);
+	g_assert(nugu_encoder_encode(enc, 0, NULL, 0, &result_length) == NULL);
 	g_assert(result_length == 999);
-	g_assert(nugu_encoder_encode(enc, "test", 4, &result_length) == NULL);
+	g_assert(nugu_encoder_encode(enc, 0, "hh", 2, &result_length) == NULL);
 	g_assert(result_length == 999);
 
 	nugu_encoder_free(enc);


### PR DESCRIPTION
Add API for codec and mime_type to encoder module.
And add the 'is_end' parameter to the `.encode` API so that the
encoder plugin can check if that pcm is the last or not.

Signed-off-by: Inho Oh <webispy@gmail.com>