### PR TITLE
examples:Add override keyword

### DIFF
--- a/examples/capability_injection/main_capability_injection.cc
+++ b/examples/capability_injection/main_capability_injection.cc
@@ -30,7 +30,7 @@ using namespace NuguCapability;
 
 class MyNetwork : public INetworkManagerListener {
 public:
-    void onStatusChanged(NetworkStatus status)
+    void onStatusChanged(NetworkStatus status) override
     {
         switch (status) {
         case NetworkStatus::DISCONNECTED:
@@ -47,7 +47,7 @@ public:
         }
     }
 
-    void onError(NetworkError error)
+    void onError(NetworkError error) override
     {
         switch (error) {
         case NetworkError::FAILED:

--- a/examples/profiling/main_prof.cc
+++ b/examples/profiling/main_prof.cc
@@ -164,23 +164,23 @@ class MyASR : public IASRListener {
 public:
     virtual ~MyASR() = default;
 
-    void onState(ASRState state, const std::string& dialog_id, ASRInitiator initiator)
+    void onState(ASRState state, const std::string& dialog_id, ASRInitiator initiator) override
     {
     }
 
-    void onNone(const std::string& dialog_id)
+    void onNone(const std::string& dialog_id) override
     {
     }
 
-    void onPartial(const std::string& text, const std::string& dialog_id)
+    void onPartial(const std::string& text, const std::string& dialog_id) override
     {
     }
 
-    void onComplete(const std::string& text, const std::string& dialog_id)
+    void onComplete(const std::string& text, const std::string& dialog_id) override
     {
     }
 
-    void onError(ASRError error, const std::string& dialog_id, bool listen_timeout_fail_beep)
+    void onError(ASRError error, const std::string& dialog_id, bool listen_timeout_fail_beep) override
     {
         switch (error) {
         case ASRError::RESPONSE_TIMEOUT:
@@ -201,7 +201,7 @@ public:
         }
     }
 
-    void onCancel(const std::string& dialog_id)
+    void onCancel(const std::string& dialog_id) override
     {
     }
 
@@ -212,7 +212,7 @@ public:
 
 class MyNetwork : public INetworkManagerListener {
 public:
-    void onStatusChanged(NetworkStatus status)
+    void onStatusChanged(NetworkStatus status) override
     {
         switch (status) {
         case NetworkStatus::DISCONNECTED:
@@ -235,7 +235,7 @@ public:
         }
     }
 
-    void onError(NetworkError error)
+    void onError(NetworkError error) override
     {
         switch (error) {
         case NetworkError::FAILED:

--- a/examples/response_filter/filter.cc
+++ b/examples/response_filter/filter.cc
@@ -66,7 +66,7 @@ static const char* getReplacedString(const char* text)
 
 class DirListener : public IDirectiveSequencerListener {
 public:
-    bool onPreHandleDirective(NuguDirective* ndir)
+    bool onPreHandleDirective(NuguDirective* ndir) override
     {
         /* Drop all directives corresponding to the dialog id specified by the filter. */
         if (isFilteredDialogId(nugu_directive_peek_dialog_id(ndir))) {
@@ -113,17 +113,19 @@ public:
         return false;
     }
 
-    bool onHandleDirective(NuguDirective* ndir)
+    bool onHandleDirective(NuguDirective* ndir) override
     {
         return true;
     }
 
-    void onCancelDirective(NuguDirective* ndir) { }
+    void onCancelDirective(NuguDirective* ndir) override
+    {
+    }
 };
 
 class NetworkListener : public INetworkManagerListener {
 public:
-    void onEventSend(NuguEvent* nev)
+    void onEventSend(NuguEvent* nev) override
     {
         /* Check if the text command matches the filter. */
         if (g_strcmp0(nugu_event_peek_namespace(nev), "Text") != 0)

--- a/examples/response_filter/main.cc
+++ b/examples/response_filter/main.cc
@@ -52,7 +52,7 @@ class MyASR : public IASRListener {
 public:
     virtual ~MyASR() = default;
 
-    void onState(ASRState state, const std::string& dialog_id, ASRInitiator initiator)
+    void onState(ASRState state, const std::string& dialog_id, ASRInitiator initiator) override
     {
         switch (state) {
         case ASRState::IDLE:
@@ -73,22 +73,22 @@ public:
         }
     }
 
-    void onNone(const std::string& dialog_id)
+    void onNone(const std::string& dialog_id) override
     {
         std::cout << "ASR no recognition result, request dialog id: " << dialog_id << std::endl;
     }
 
-    void onPartial(const std::string& text, const std::string& dialog_id)
+    void onPartial(const std::string& text, const std::string& dialog_id) override
     {
         std::cout << "ASR partial result: " << text << ", request dialog id: " << dialog_id << std::endl;
     }
 
-    void onComplete(const std::string& text, const std::string& dialog_id)
+    void onComplete(const std::string& text, const std::string& dialog_id) override
     {
         std::cout << "ASR complete result: " << text << ", request dialog id: " << dialog_id << std::endl;
     }
 
-    void onError(ASRError error, const std::string& dialog_id, bool listen_timeout_fail_beep)
+    void onError(ASRError error, const std::string& dialog_id, bool listen_timeout_fail_beep) override
     {
         switch (error) {
         case ASRError::RESPONSE_TIMEOUT:
@@ -110,7 +110,7 @@ public:
         g_main_loop_quit(loop);
     }
 
-    void onCancel(const std::string& dialog_id)
+    void onCancel(const std::string& dialog_id) override
     {
         std::cout << "ASR canceled, request dialog id: " << dialog_id << std::endl;
     }
@@ -123,7 +123,7 @@ public:
 
 class MyNetwork : public INetworkManagerListener {
 public:
-    void onStatusChanged(NetworkStatus status)
+    void onStatusChanged(NetworkStatus status) override
     {
         switch (status) {
         case NetworkStatus::DISCONNECTED:
@@ -151,7 +151,7 @@ public:
         }
     }
 
-    void onError(NetworkError error)
+    void onError(NetworkError error) override
     {
         switch (error) {
         case NetworkError::FAILED:

--- a/examples/simple_asr/main_asr.cc
+++ b/examples/simple_asr/main_asr.cc
@@ -38,7 +38,7 @@ class MyASR : public IASRListener {
 public:
     virtual ~MyASR() = default;
 
-    void onState(ASRState state, const std::string& dialog_id, ASRInitiator initiator)
+    void onState(ASRState state, const std::string& dialog_id, ASRInitiator initiator) override
     {
         switch (state) {
         case ASRState::IDLE:
@@ -59,22 +59,22 @@ public:
         }
     }
 
-    void onNone(const std::string& dialog_id)
+    void onNone(const std::string& dialog_id) override
     {
         std::cout << "ASR no recognition result, request dialog id: " << dialog_id << std::endl;
     }
 
-    void onPartial(const std::string& text, const std::string& dialog_id)
+    void onPartial(const std::string& text, const std::string& dialog_id) override
     {
         std::cout << "ASR partial result: " << text << ", request dialog id: " << dialog_id << std::endl;
     }
 
-    void onComplete(const std::string& text, const std::string& dialog_id)
+    void onComplete(const std::string& text, const std::string& dialog_id) override
     {
         std::cout << "ASR complete result: " << text << ", request dialog id: " << dialog_id << std::endl;
     }
 
-    void onError(ASRError error, const std::string& dialog_id, bool listen_timeout_fail_beep)
+    void onError(ASRError error, const std::string& dialog_id, bool listen_timeout_fail_beep) override
     {
         switch (error) {
         case ASRError::RESPONSE_TIMEOUT:
@@ -95,7 +95,7 @@ public:
         }
     }
 
-    void onCancel(const std::string& dialog_id)
+    void onCancel(const std::string& dialog_id) override
     {
         std::cout << "ASR canceled, request dialog id: " << dialog_id << std::endl;
     }
@@ -108,7 +108,7 @@ public:
 
 class MyNetwork : public INetworkManagerListener {
 public:
-    void onStatusChanged(NetworkStatus status)
+    void onStatusChanged(NetworkStatus status) override
     {
         switch (status) {
         case NetworkStatus::DISCONNECTED:
@@ -129,7 +129,7 @@ public:
         }
     }
 
-    void onError(NetworkError error)
+    void onError(NetworkError error) override
     {
         switch (error) {
         case NetworkError::FAILED:

--- a/examples/simple_play/main_play.cc
+++ b/examples/simple_play/main_play.cc
@@ -12,7 +12,7 @@ class MediaPlayerListener : public IMediaPlayerListener {
 public:
     virtual ~MediaPlayerListener() = default;
 
-    void mediaStateChanged(MediaPlayerState state)
+    void mediaStateChanged(MediaPlayerState state) override
     {
         switch (state) {
         case MediaPlayerState::IDLE:
@@ -36,7 +36,7 @@ public:
         }
     }
 
-    void mediaEventReport(MediaPlayerEvent event)
+    void mediaEventReport(MediaPlayerEvent event) override
     {
         switch (event) {
         case MediaPlayerEvent::INVALID_MEDIA_URL:
@@ -58,27 +58,27 @@ public:
         }
     }
 
-    void mediaChanged(const std::string& url)
+    void mediaChanged(const std::string& url) override
     {
         std::cout << ">> mediaChanged: " << url << std::endl;
     }
 
-    void durationChanged(int duration)
+    void durationChanged(int duration) override
     {
         std::cout << ">> durationChanged: " << duration << std::endl;
     }
 
-    void positionChanged(int position)
+    void positionChanged(int position) override
     {
         std::cout << ">> positionChanged: " << position << std::endl;
     }
 
-    void volumeChanged(int volume)
+    void volumeChanged(int volume) override
     {
         std::cout << ">> volumeChanged: " << volume << std::endl;
     }
 
-    void muteChanged(int mute)
+    void muteChanged(int mute) override
     {
         std::cout << ">> muteChanged: " << mute << std::endl;
     }

--- a/examples/simple_text/main_text.cc
+++ b/examples/simple_text/main_text.cc
@@ -37,7 +37,7 @@ public:
 
 class MyNetwork : public INetworkManagerListener {
 public:
-    void onStatusChanged(NetworkStatus status)
+    void onStatusChanged(NetworkStatus status) override
     {
         switch (status) {
         case NetworkStatus::DISCONNECTED:
@@ -57,7 +57,7 @@ public:
         }
     }
 
-    void onError(NetworkError error)
+    void onError(NetworkError error) override
     {
         switch (error) {
         case NetworkError::FAILED:

--- a/examples/simple_tts/main_tts.cc
+++ b/examples/simple_tts/main_tts.cc
@@ -44,7 +44,7 @@ public:
 
 class MyNetwork : public INetworkManagerListener {
 public:
-    void onStatusChanged(NetworkStatus status)
+    void onStatusChanged(NetworkStatus status) override
     {
         switch (status) {
         case NetworkStatus::DISCONNECTED:
@@ -64,7 +64,7 @@ public:
         }
     }
 
-    void onError(NetworkError error)
+    void onError(NetworkError error) override
     {
         switch (error) {
         case NetworkError::FAILED:


### PR DESCRIPTION
It add the override keyword on methods which are inherited from parent.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>