### PR TITLE
fix mime_type to configurable

### DIFF
--- a/include/base/nugu_event.h
+++ b/include/base/nugu_event.h
@@ -212,6 +212,23 @@ int nugu_event_increase_seq(NuguEvent *nev);
 char *nugu_event_generate_payload(NuguEvent *nev);
 
 /**
+ * @brief Set the attachment mime type of NuguEvent
+ * @param[in] nev event object
+ * @param[in] type attachment type. e.g. "application/octet-stream"
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ */
+int nugu_event_set_mime_type(NuguEvent *nev, const char *type);
+
+/**
+ * @brief Get the attachment mime type of NuguEvent
+ * @param[in] nev event object
+ * @return attachment type. Please don't free the data manually.
+ */
+const char *nugu_event_peek_mime_type(NuguEvent *nev);
+
+/**
  * @}
  */
 

--- a/include/clientkit/capability.hh
+++ b/include/clientkit/capability.hh
@@ -84,6 +84,12 @@ public:
     void setType(enum nugu_event_type type);
 
     /**
+     * @brief Set mime type
+     * @param[in] type mime type
+     */
+    void setMimeType(const std::string& type);
+
+    /**
      * @brief Close event forcibly.
      */
     void forceClose();

--- a/include/clientkit/speech_recognizer_interface.hh
+++ b/include/clientkit/speech_recognizer_interface.hh
@@ -121,6 +121,12 @@ public:
      * @return mute
      */
     virtual bool isMute() = 0;
+
+    /**
+     * @brief Get mime type information of recorder
+     * @return mime type
+     */
+    virtual std::string getMimeType() = 0;
 };
 
 /**

--- a/src/base/network/dg_server.c
+++ b/src/base/network/dg_server.c
@@ -168,7 +168,7 @@ static int _send_v2_events_attachment(DGServer *server, NuguEvent *nev,
 				    NULL);
 
 	v2_events_send_binary(e, msg_id, nugu_event_get_seq(nev), is_end,
-			      length, data);
+			      nugu_event_peek_mime_type(nev), length, data);
 	free(msg_id);
 
 	if (is_end == 0)

--- a/src/base/network/http2/v2_events.c
+++ b/src/base/network/http2/v2_events.c
@@ -43,8 +43,7 @@
 
 #define PART_HEADER_BINARY_FMT                                                 \
 	"Content-Disposition: form-data; name=\"attachment\";"                 \
-	" filename=\"%d;%s\"" CRLF                                             \
-	"Content-Type: application/octet-stream" CRLF                          \
+	" filename=\"%d;%s\"" CRLF "Content-Type: %s" CRLF                     \
 	"Content-Length: %zd" CRLF "Message-Id: %s" CRLF CRLF
 
 struct _v2_events {
@@ -396,7 +395,8 @@ int v2_events_send_json(V2Events *event, const char *data, size_t length)
 }
 
 int v2_events_send_binary(V2Events *event, const char *msgid, int seq,
-			  int is_end, size_t length, unsigned char *data)
+			  int is_end, const char *mime_type, size_t length,
+			  unsigned char *data)
 {
 	char *part_header;
 
@@ -404,7 +404,7 @@ int v2_events_send_binary(V2Events *event, const char *msgid, int seq,
 
 	part_header = g_strdup_printf(PART_HEADER_BINARY_FMT, seq,
 				      (is_end == 1) ? "end" : "continued",
-				      length, msgid);
+				      mime_type, length, msgid);
 
 	http2_request_lock_send_data(event->req);
 

--- a/src/base/network/http2/v2_events.h
+++ b/src/base/network/http2/v2_events.h
@@ -34,7 +34,8 @@ int v2_events_set_info(V2Events *event, const char *msg_id,
 
 int v2_events_send_json(V2Events *event, const char *data, size_t length);
 int v2_events_send_binary(V2Events *event, const char *msgid, int seq,
-			  int is_end, size_t length, unsigned char *data);
+			  int is_end, const char *mime_type, size_t length,
+			  unsigned char *data);
 
 int v2_events_send_done(V2Events *event);
 

--- a/src/base/nugu_event.c
+++ b/src/base/nugu_event.c
@@ -40,10 +40,10 @@
  * }
  */
 #define TPL_EVENT                                                              \
-	"{ \"context\": %s, \"event\": { \"header\": {"                        \
-	" \"dialogRequestId\": \"%s\", \"messageId\": \"%s\","                 \
-	" \"name\": \"%s\", \"namespace\": \"%s\", \"version\": \"%s\" },"    \
-	" \"payload\": %s } }"
+	"{\"context\":%s,\"event\":{\"header\":{"                              \
+	"\"dialogRequestId\":\"%s\",\"messageId\":\"%s\","                     \
+	"\"name\":\"%s\",\"namespace\":\"%s\",\"version\":\"%s\"},"            \
+	"\"payload\":%s}}"
 
 /**
  * {
@@ -62,10 +62,10 @@
  * }
  */
 #define TPL_EVENT_REFERRER                                                     \
-	"{ \"context\": %s, \"event\": { \"header\": {"                        \
-	" \"referrerDialogRequestId\": \"%s\", \"dialogRequestId\": \"%s\","   \
-	" \"messageId\": \"%s\", \"name\": \"%s\", \"namespace\": \"%s\","     \
-	" \"version\": \"%s\" }, \"payload\": %s } }"
+	"{\"context\":%s,\"event\":{\"header\":{"                              \
+	"\"referrerDialogRequestId\":\"%s\",\"dialogRequestId\":\"%s\","       \
+	"\"messageId\":\"%s\",\"name\":\"%s\",\"namespace\":\"%s\","           \
+	"\"version\":\"%s\"},\"payload\":%s}}"
 
 struct _nugu_event {
 	char *name_space;
@@ -80,6 +80,7 @@ struct _nugu_event {
 	char *context;
 
 	enum nugu_event_type type;
+	char *mime_type;
 };
 
 EXPORT_API NuguEvent *nugu_event_new(const char *name_space, const char *name,
@@ -105,6 +106,7 @@ EXPORT_API NuguEvent *nugu_event_new(const char *name_space, const char *name,
 	nev->seq = 0;
 	nev->version = g_strdup(version);
 	nev->type = NUGU_EVENT_TYPE_DEFAULT;
+	nev->mime_type = NULL;
 
 	return nev;
 }
@@ -127,6 +129,9 @@ EXPORT_API void nugu_event_free(NuguEvent *nev)
 
 	if (nev->context)
 		free(nev->context);
+
+	if (nev->mime_type)
+		free(nev->mime_type);
 
 	memset(nev, 0, sizeof(NuguEvent));
 	free(nev);
@@ -314,4 +319,26 @@ EXPORT_API enum nugu_event_type nugu_event_get_type(NuguEvent *nev)
 	g_return_val_if_fail(nev != NULL, NUGU_EVENT_TYPE_DEFAULT);
 
 	return nev->type;
+}
+
+EXPORT_API int nugu_event_set_mime_type(NuguEvent *nev, const char *type)
+{
+	g_return_val_if_fail(nev != NULL, -1);
+
+	if (nev->mime_type)
+		free(nev->mime_type);
+
+	if (type)
+		nev->mime_type = g_strdup(type);
+	else
+		nev->mime_type = NULL;
+
+	return 0;
+}
+
+EXPORT_API const char *nugu_event_peek_mime_type(NuguEvent *nev)
+{
+	g_return_val_if_fail(nev != NULL, NULL);
+
+	return nev->mime_type;
 }

--- a/src/capability/asr_agent.cc
+++ b/src/capability/asr_agent.cc
@@ -570,6 +570,7 @@ void ASRAgent::onListeningState(ListeningState state, const std::string& id)
 
         rec_event = new CapabilityEvent("Recognize", this);
         rec_event->setType(NUGU_EVENT_TYPE_WITH_ATTACHMENT);
+        rec_event->setMimeType(speech_recognizer->getMimeType());
 
         sendEventRecognize(NULL, 0, false,
             [&](const std::string& ename, const std::string& msg_id, const std::string& dialog_id, bool success, int code) {

--- a/src/clientkit/capability.cc
+++ b/src/clientkit/capability.cc
@@ -85,6 +85,11 @@ void CapabilityEvent::setType(enum nugu_event_type type)
     nugu_event_set_type(pimpl->event, type);
 }
 
+void CapabilityEvent::setMimeType(const std::string& type)
+{
+    nugu_event_set_mime_type(pimpl->event, type.c_str());
+}
+
 void CapabilityEvent::forceClose()
 {
     if (nugu_event_get_type(pimpl->event) == NUGU_EVENT_TYPE_DEFAULT)

--- a/src/core/speech_recognizer.cc
+++ b/src/core/speech_recognizer.cc
@@ -24,6 +24,9 @@
 #include "nugu_timer.hh"
 #include "speech_recognizer.hh"
 
+#define EPD_MODEL_FILE "skt_epd_model.raw"
+#define OUT_DATA_SIZE (1024 * 9)
+
 namespace NuguCore {
 
 // define default property values
@@ -35,19 +38,17 @@ static const int ASR_EPD_TIMEOUT_SEC = 7;
 static const int ASR_EPD_MAX_DURATION_SEC = 10;
 static const int ASR_EPD_PAUSE_LENGTH_MSEC = 700;
 
-SpeechRecognizer::SpeechRecognizer()
+SpeechRecognizer::SpeechRecognizer(Attribute&& attribute)
+    : epd_ret(-1)
+    , listener(nullptr)
+    , mime_type("application/octet-stream")
 {
-    initialize(Attribute {});
+    initialize(std::move(attribute));
 }
 
 SpeechRecognizer::~SpeechRecognizer()
 {
     listener = nullptr;
-}
-
-SpeechRecognizer::SpeechRecognizer(Attribute&& attribute)
-{
-    initialize(std::move(attribute));
 }
 
 void SpeechRecognizer::sendListeningEvent(ListeningState state, const std::string& id)
@@ -330,4 +331,10 @@ bool SpeechRecognizer::isMute()
 
     return recorder->isMute();
 }
+
+std::string SpeechRecognizer::getMimeType()
+{
+    return mime_type;
+}
+
 } // NuguCore

--- a/src/core/speech_recognizer.hh
+++ b/src/core/speech_recognizer.hh
@@ -20,8 +20,6 @@
 #include "audio_input_processor.hh"
 #include "clientkit/speech_recognizer_interface.hh"
 
-#define EPD_MODEL_FILE "skt_epd_model.raw"
-
 namespace NuguCore {
 
 using namespace NuguClientKit;
@@ -40,7 +38,6 @@ public:
     };
 
 public:
-    SpeechRecognizer();
     explicit SpeechRecognizer(Attribute&& attribute);
     virtual ~SpeechRecognizer();
 
@@ -51,15 +48,16 @@ public:
     void setEpdAttribute(const EpdAttribute& attribute) override;
     EpdAttribute getEpdAttribute() override;
     bool isMute() override;
+    std::string getMimeType() override;
 
 private:
     void initialize(Attribute&& attribute);
     void loop() override;
     void sendListeningEvent(ListeningState state, const std::string& id);
 
-    const unsigned int OUT_DATA_SIZE = 1024 * 9;
-    int epd_ret = -1;
-    ISpeechRecognizerListener* listener = nullptr;
+    int epd_ret;
+    ISpeechRecognizerListener* listener;
+    std::string mime_type;
 
     // attribute
     std::string model_path = "";


### PR DESCRIPTION
Fixed attachment mime type information that were used as fixed
values so that they can be set through API.

Signed-off-by: Inho Oh <webispy@gmail.com>