### PR TITLE
plugins: adjust pcm driver priority

### DIFF
--- a/plugins/gstreamer.c
+++ b/plugins/gstreamer.c
@@ -789,7 +789,11 @@ static int init(NuguPlugin *p)
 		gst_init(NULL, NULL);
 
 	driver = nugu_player_driver_new(PLUGIN_DRIVER_NAME, &player_ops);
-	g_return_val_if_fail(driver != NULL, -1);
+	if (!driver) {
+		nugu_error("nugu_player_driver_new() failed");
+		return -1;
+	}
+
 	if (nugu_player_driver_register(driver) != 0) {
 		nugu_player_driver_free(driver);
 		driver = NULL;

--- a/plugins/portaudio.c
+++ b/plugins/portaudio.c
@@ -80,7 +80,7 @@ static void unload(NuguPlugin *p)
 NUGU_PLUGIN_DEFINE(
 	/* NUGU SDK Plug-in description */
 	PLUGIN_DRIVER_NAME, /* Plugin name */
-	NUGU_PLUGIN_PRIORITY_HIGH, /* Plugin priority */
+	NUGU_PLUGIN_PRIORITY_DEFAULT + 1, /* Plugin priority */
 	"0.0.2", /* Plugin version */
 	load, /* dlopen */
 	unload, /* dlclose */

--- a/plugins/portaudio_pcm_async.c
+++ b/plugins/portaudio_pcm_async.c
@@ -566,11 +566,6 @@ static int init(NuguPlugin *p)
 		return -1;
 	}
 
-	if (nugu_pcm_driver_get_default() != pcm_driver) {
-		nugu_dbg("set default driver to portaudio");
-		nugu_pcm_driver_set_default(pcm_driver);
-	}
-
 	nugu_dbg("'%s' plugin initialized done",
 		 nugu_plugin_get_description(p)->name);
 
@@ -601,7 +596,7 @@ static void unload(NuguPlugin *p)
 NUGU_PLUGIN_DEFINE(
 	/* NUGU SDK Plug-in description */
 	PLUGIN_DRIVER_NAME, /* Plugin name */
-	NUGU_PLUGIN_PRIORITY_DEFAULT - 1, /* Plugin priority */
+	NUGU_PLUGIN_PRIORITY_DEFAULT + 2, /* Plugin priority */
 	"0.0.2", /* Plugin version */
 	load, /* dlopen */
 	unload, /* dlclose */

--- a/plugins/portaudio_pcm_sync.c
+++ b/plugins/portaudio_pcm_sync.c
@@ -631,7 +631,7 @@ static void unload(NuguPlugin *p)
 NUGU_PLUGIN_DEFINE(
 	/* NUGU SDK Plug-in description */
 	PLUGIN_DRIVER_NAME, /* Plugin name */
-	NUGU_PLUGIN_PRIORITY_DEFAULT + 1, /* Plugin priority */
+	NUGU_PLUGIN_PRIORITY_DEFAULT + 3, /* Plugin priority */
 	"0.0.2", /* Plugin version */
 	load, /* dlopen */
 	unload, /* dlclose */

--- a/plugins/portaudio_recorder.c
+++ b/plugins/portaudio_recorder.c
@@ -402,8 +402,6 @@ static int init(NuguPlugin *p)
 		return -1;
 	}
 
-	nugu_recorder_driver_set_default(rec_driver);
-
 	nugu_dbg("'%s' plugin initialized done",
 		 nugu_plugin_get_description(p)->name);
 
@@ -434,7 +432,7 @@ static void unload(NuguPlugin *p)
 NUGU_PLUGIN_DEFINE(
 	/* NUGU SDK Plug-in description */
 	PLUGIN_DRIVER_NAME, /* Plugin name */
-	NUGU_PLUGIN_PRIORITY_DEFAULT, /* Plugin priority */
+	NUGU_PLUGIN_PRIORITY_DEFAULT + 2, /* Plugin priority */
 	"0.0.2", /* Plugin version */
 	load, /* dlopen */
 	unload, /* dlclose */


### PR DESCRIPTION
Lowered the priority of the PortAudio PCM plugin so that the
Gstreamer plugin works by default.

PCM plugin priority:

    gstreamer_pcm (default) -> Default PCM driver
    gstreamer_recorder (default) -> Default recorder driver
    portaudio (default + 1)
      portaudio_pcm_async (default + 2)
        portaudio_pcm_sync (default + 3)
      portaudio_recorder (default + 2)

Signed-off-by: Inho Oh <webispy@gmail.com>