### PR TITLE
nugu_sample:Refactor SpeakerController setup

### DIFF
--- a/examples/standalone/capability/speaker_listener.cc
+++ b/examples/standalone/capability/speaker_listener.cc
@@ -69,3 +69,13 @@ void SpeakerListener::setMuteNuguSpeakerCallback(nugu_mute_func mns)
 {
     nugu_speaker_mute = std::move(mns);
 }
+
+auto SpeakerListener::getNuguSpeakerVolumeControl() -> decltype(nugu_speaker_volume)
+{
+    return nugu_speaker_volume;
+}
+
+auto SpeakerListener::getNuguSpeakerMuteControl() -> decltype(nugu_speaker_mute)
+{
+    return nugu_speaker_mute;
+}

--- a/examples/standalone/capability/speaker_listener.hh
+++ b/examples/standalone/capability/speaker_listener.hh
@@ -23,8 +23,8 @@
 using namespace NuguCapability;
 
 class SpeakerListener : public ISpeakerListener {
-    typedef std::function<bool(int volume)> nugu_volume_func;
-    typedef std::function<bool(bool mute)> nugu_mute_func;
+    using nugu_volume_func = std::function<bool(int volume)>;
+    using nugu_mute_func = std::function<bool(bool mute)>;
 
 public:
     virtual ~SpeakerListener() = default;
@@ -37,9 +37,13 @@ public:
     void setMuteNuguSpeakerCallback(nugu_mute_func mns);
 
 private:
-    ISpeakerHandler* speaker_handler;
-    nugu_volume_func nugu_speaker_volume;
-    nugu_mute_func nugu_speaker_mute;
+    ISpeakerHandler* speaker_handler = nullptr;
+    nugu_volume_func nugu_speaker_volume = nullptr;
+    nugu_mute_func nugu_speaker_mute = nullptr;
+
+public:
+    auto getNuguSpeakerVolumeControl() -> decltype(nugu_speaker_volume);
+    auto getNuguSpeakerMuteControl() -> decltype(nugu_speaker_mute);
 };
 
 #endif /* __SPEAKER_LISTENER_H__ */

--- a/examples/standalone/nugu_sdk_manager.hh
+++ b/examples/standalone/nugu_sdk_manager.hh
@@ -30,29 +30,26 @@
 
 class SpeakerController {
 public:
-    using CapabilityHandler = struct {
-        ITTSHandler* tts;
-        IAudioPlayerHandler* audio_player;
-        ISpeakerHandler* speaker;
-    };
+    using VolumeControl = std::function<bool(int)>;
+    using MuteControl = std::function<bool(bool)>;
 
 public:
-    SpeakerController();
     virtual ~SpeakerController() = default;
 
-    void setCapabilityHandler(CapabilityHandler&& handler);
+    void setSpeakerHandler(ISpeakerHandler* handler);
+    void setVolumeControl(const VolumeControl& volume_control);
+    void setMuteControl(const MuteControl& mute_control);
+
     void setVolumeUp();
     void setVolumeDown();
     void toggleMute();
 
 private:
-    void composeVolumeControl();
-    void composeMuteControl();
     void adjustVolume(int volume);
 
-    std::function<bool(int)> nugu_speaker_volume = nullptr;
-    std::function<bool(bool)> nugu_speaker_mute = nullptr;
-    CapabilityHandler capability_handler {};
+    ISpeakerHandler* speaker_handler = nullptr;
+    VolumeControl volume_control = nullptr;
+    MuteControl mute_control = nullptr;
 };
 
 class NuguSDKManager : public IFocusManagerObserver,


### PR DESCRIPTION
In previous, the SpeakerController compose volume/mute controls by self
using by TTS/AudioPlayer handlers.

Because, those controls are composed in SpeakerListener
by CapabilityCollection, in result, it generated the duplication.

So, it refactor to use the pre-composed volume/mute controls
of SpeakerListener in SpeakerController singly.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>