### PR TITLE
clientkit: add Authentication API

### DIFF
--- a/include/clientkit/nugu_auth.hh
+++ b/include/clientkit/nugu_auth.hh
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2022 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NUGU_AUTH_H__
+#define __NUGU_AUTH_H__
+
+#include <clientkit/nugu_http_rest.hh>
+#include <string>
+#include <vector>
+
+namespace NuguClientKit {
+
+/**
+ * @file nugu_auth.hh
+ * @defgroup NuguAuth NuguAuth
+ * @ingroup SDKNuguClientKit
+ * @brief Authentication management
+ *
+ * The NuguAuth handles OAuth2 authentication.
+ *
+ * @{
+ */
+
+/**
+ * @brief GrantType
+ */
+enum GrantType {
+    AUTHORIZATION_CODE = 0x1, /* OAuth2 Authorization code */
+    CLIENT_CREDENTIALS = 0x2, /* OAuth2 Client credentials */
+    REFRESH_TOKEN = 0x4, /* OAuth2 refresh token */
+    DEVICE_CODE = 0x8 /* OAuth2 device code */
+};
+
+/**
+ * @brief NuguDeviceConfig
+ */
+struct NuguDeviceConfig {
+    std::string oauth_server_url; /* OAuth2 server url */
+    std::string oauth_client_id; /* Client id */
+    std::string oauth_client_secret; /* Client secret */
+    std::string oauth_redirect_uri; /* Redirect uri */
+    std::string device_type_code; /* Device type code */
+    std::string poc_id; /* PoC id */
+};
+
+/**
+ * @brief NuguToken
+ */
+struct NuguToken {
+    std::string access_token; /* OAuth2 access token */
+    std::string refresh_token; /* OAuth2 refresh token */
+    std::string token_type; /* OAuth2 token type. e.g. "Bearer" */
+    int expires_in; /* Expiration time remaining after token issuance (secs) */
+    time_t timestamp; /* Token issuance time */
+
+    std::vector<std::string> scope; /* scope */
+    int exp; /* Token expiration time (unix timestamp) */
+    std::string client_id; /* OAuth2 client id */
+    std::string ext_usr; /* user id */
+    std::string ext_dvc; /* device id */
+    std::string ext_srl; /* device serial */
+    std::string ext_poc; /* PoC id */
+
+    bool sid; /* flag for server-initiative-directive support */
+};
+
+/**
+ * @brief NuguAuth
+ */
+class NuguAuth {
+public:
+    explicit NuguAuth(const NuguDeviceConfig& config);
+    ~NuguAuth();
+
+    /**
+     * @brief OAuth2 discovery to get OAuth2 end-point and server url
+     * @return result
+     * @retval true success
+     * @retval false failure
+     */
+    bool discovery();
+
+    /**
+     * @brief Check whether the requested grant type is supported for the client
+     * @param[in] gtype grant type
+     * @return result
+     * @retval true supported
+     * @retval false not supported
+     */
+    bool isSupport(const GrantType& gtype);
+
+    /**
+     * @brief Get OAuth2 authorization url
+     * @param[in] device_serial device serial info
+     * @return std::string authorization url
+     */
+    std::string generateAuthorizeUrl(const std::string& device_serial);
+
+    /**
+     * @brief Get the token using authorization code (token exchange)
+     * @param[in] code OAuth2 authorization code
+     * @param[in] device_serial device serial info
+     * @return NuguToken* token information
+     */
+    NuguToken* getAuthorizationCodeToken(const std::string& code, const std::string& device_serial);
+
+    /**
+     * @brief Get the token using client credentials
+     * @param[in] device_serial device serial info
+     * @return NuguToken* token information
+     */
+    NuguToken* getClientCredentialsToken(const std::string& device_serial);
+
+    /**
+     * @brief Parsing the JWT access_token and fill the token information
+     * @param[in,out] token token information
+     * @return true parsing success
+     * @return false parsing failed
+     */
+    bool parseAccessToken(NuguToken* token);
+
+    /**
+     * @brief Refresh the access_token and update the token information
+     * @param[in,out] token token information
+     * @param[in] device_serial device serial info
+     * @return true success
+     * @return false failure
+     */
+    bool refresh(NuguToken* token, const std::string& device_serial = "");
+
+    /**
+     * @brief Check the token is expired or not
+     * @param token[in] token information
+     * @param base_time[in] base timestamp(secs), '0' means the current timestamp
+     * @return true token is expired
+     * @return false token is not expired
+     */
+    bool isExpired(const NuguToken* token, time_t base_time = 0);
+
+    /**
+     * @brief Get remaining expiration time based on base_time
+     * @param token[in] token information
+     * @param base_time[in] base timestamp(secs), '0' means the current timestamp
+     * @return time_t remain secs. '0' means the token is expired
+     */
+    time_t getRemainExpireTime(const NuguToken* token, time_t base_time = 0);
+
+private:
+    NuguDeviceConfig config;
+    NuguHttpRest* rest;
+    unsigned int supported_grant_types;
+    std::string ep_token;
+    std::string ep_authorization;
+    std::string url_gateway_registry;
+    std::string url_template_server;
+};
+
+/**
+ * @}
+ */
+
+} // NuguClientKit
+
+#endif /* __NUGU_AUTH_H__ */

--- a/src/clientkit/nugu_auth.cc
+++ b/src/clientkit/nugu_auth.cc
@@ -1,0 +1,588 @@
+/*
+ * Copyright (c) 2022 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <glib.h>
+#include <json/json.h>
+
+#include "base/nugu_log.h"
+
+#include "clientkit/nugu_auth.hh"
+
+#define EP_DISCOVERY "/.well-known/oauth-authorization-server/"
+
+namespace NuguClientKit {
+
+static char* base64_decode(const char* orig)
+{
+    /* add optional padding('==') for base64 decoding */
+    gchar* tmp = g_strdup_printf("%s==", orig);
+    if (!tmp) {
+        nugu_error_nomem();
+        return NULL;
+    }
+
+    gsize decoded_len = 0;
+    gchar* decoded = (gchar*)g_base64_decode(tmp, &decoded_len);
+    g_free(tmp);
+
+    return decoded;
+}
+
+NuguAuth::NuguAuth(const NuguDeviceConfig& config)
+    : config(config)
+    , supported_grant_types(0)
+{
+    rest = new NuguHttpRest(config.oauth_server_url);
+    rest->addHeader("Content-Type", "application/x-www-form-urlencoded");
+}
+
+NuguAuth::~NuguAuth()
+{
+    if (rest)
+        delete rest;
+}
+
+bool NuguAuth::discovery()
+{
+    if (!rest)
+        return false;
+
+    if (config.oauth_client_id.size() == 0) {
+        nugu_error("oauth_client_id is empty");
+        return false;
+    }
+
+    NuguHttpResponse* resp = rest->get(EP_DISCOVERY + config.oauth_client_id);
+    if (!resp) {
+        nugu_error("GET request failed");
+        return false;
+    }
+
+    nugu_info("%s", (char*)resp->body);
+
+    std::string message((char*)resp->body);
+    nugu_http_response_free(resp);
+
+    Json::Value root;
+    Json::Reader reader;
+
+    if (!reader.parse(message, root))
+        return false;
+
+    if (root["token_endpoint"].empty()) {
+        nugu_error("can't find token_endpoint from response");
+        return false;
+    }
+
+    size_t url_len = config.oauth_server_url.size();
+
+    ep_token = root["token_endpoint"].asString();
+    ep_token.erase(0, url_len);
+
+    ep_authorization = root["authorization_endpoint"].asString();
+    ep_authorization.erase(0, url_len);
+
+    url_gateway_registry = root["device_gateway_server_h2_uri"].asString();
+    url_template_server = root["template_server_uri"].asString();
+
+    supported_grant_types = 0;
+    Json::Value grant_types = root["grant_types_supported"];
+    if (grant_types.isArray()) {
+        Json::ArrayIndex type_len = grant_types.size();
+        for (Json::ArrayIndex i = 0; i < type_len; ++i) {
+            nugu_dbg("grant_types_supported[%d] = %s", i, grant_types[i].asCString());
+            if (grant_types[i].asString() == "authorization_code") {
+                supported_grant_types |= GrantType::AUTHORIZATION_CODE;
+            } else if (grant_types[i].asString() == "client_credentials") {
+                supported_grant_types |= GrantType::CLIENT_CREDENTIALS;
+            } else if (grant_types[i].asString() == "refresh_token") {
+                supported_grant_types |= GrantType::REFRESH_TOKEN;
+            } else if (grant_types[i].asString() == "device_code") {
+                supported_grant_types |= GrantType::DEVICE_CODE;
+            }
+        }
+        nugu_dbg("supported_grant_types = 0x%X", supported_grant_types);
+    }
+
+    return true;
+}
+
+bool NuguAuth::isSupport(const GrantType& gtype)
+{
+    if (supported_grant_types & gtype)
+        return true;
+
+    return false;
+}
+
+std::string NuguAuth::generateAuthorizeUrl(const std::string& device_serial)
+{
+    if (config.oauth_client_id.size() == 0 || config.oauth_redirect_uri.size() == 0) {
+        nugu_error("client info is empty");
+        return "";
+    }
+
+    if (device_serial.size() == 0) {
+        nugu_error("device_serial is empty");
+        return "";
+    }
+
+    gchar* query = g_strdup_printf("?response_type=code&client_id=%s"
+                                   "&redirect_uri=%s&data={\"deviceSerialNumber\":\"%s\"}",
+        config.oauth_client_id.c_str(), config.oauth_redirect_uri.c_str(), device_serial.c_str());
+    if (!query) {
+        nugu_error_nomem();
+        return "";
+    }
+
+    gchar* encoded = g_uri_escape_string(query, "?=&", true);
+    if (!encoded) {
+        nugu_error_nomem();
+        g_free(query);
+        return "";
+    }
+
+    std::string login_url = config.oauth_server_url + ep_authorization + encoded;
+    nugu_dbg("authorize_url: %s", login_url.c_str());
+
+    g_free(query);
+    g_free(encoded);
+
+    return login_url;
+}
+
+NuguToken* NuguAuth::getAuthorizationCodeToken(const std::string& code,
+    const std::string& device_serial)
+{
+    if (config.oauth_client_id.size() == 0
+        || config.oauth_client_secret.size() == 0
+        || config.oauth_redirect_uri.size() == 0) {
+        nugu_error("client info is empty");
+        return nullptr;
+    }
+
+    if (code.size() == 0 || device_serial.size() == 0) {
+        nugu_error("code or device_serial is empty");
+        return nullptr;
+    }
+
+    gchar* query = g_strdup_printf("grant_type=authorization_code&code=%s"
+                                   "&client_id=%s&client_secret=%s&redirect_uri=%s"
+                                   "&data={\"deviceSerialNumber\":\"%s\"}",
+        code.c_str(), config.oauth_client_id.c_str(), config.oauth_client_secret.c_str(),
+        config.oauth_redirect_uri.c_str(), device_serial.c_str());
+    if (!query) {
+        nugu_error_nomem();
+        return nullptr;
+    }
+
+    gchar* encoded = g_uri_escape_string(query, "?=&", true);
+    if (!encoded) {
+        nugu_error_nomem();
+        g_free(query);
+        return nullptr;
+    }
+
+    std::string body = encoded;
+
+    g_free(query);
+    g_free(encoded);
+
+    NuguHttpResponse* resp = rest->post(ep_token, body);
+    if (!resp) {
+        nugu_error("POST request failed");
+        return nullptr;
+    }
+
+    if (resp->code != 200) {
+        nugu_error("error response code: %d", resp->code);
+        if (resp->body_len > 0)
+            nugu_error("error response body: %s", (char*)resp->body);
+
+        nugu_http_response_free(resp);
+        return nullptr;
+    }
+
+    nugu_info("response: %s", (char*)resp->body);
+
+    std::string message((char*)resp->body);
+    nugu_http_response_free(resp);
+
+    Json::Value root;
+    Json::Reader reader;
+
+    if (!reader.parse(message, root)) {
+        nugu_error("JSON parsing error: %s", message.c_str());
+        return nullptr;
+    }
+
+    if (!root["access_token"].isString()) {
+        nugu_error("can't find access_token from response");
+        return nullptr;
+    }
+
+    NuguToken* token = new NuguToken();
+    if (!token) {
+        nugu_error_nomem();
+        return nullptr;
+    }
+
+    token->access_token = root["access_token"].asString();
+    token->timestamp = time(NULL);
+
+    if (root["refresh_token"].isString())
+        token->refresh_token = root["refresh_token"].asString();
+
+    if (root["token_type"].isString())
+        token->token_type = root["token_type"].asString();
+
+    if (root["expires_in"].isInt())
+        token->expires_in = root["expires_in"].asInt();
+    else
+        token->expires_in = 0;
+
+    parseAccessToken(token);
+
+    return token;
+}
+
+NuguToken* NuguAuth::getClientCredentialsToken(const std::string& device_serial)
+{
+    if (config.oauth_client_id.size() == 0 || config.oauth_client_secret.size() == 0) {
+        nugu_error("client info is empty");
+        return nullptr;
+    }
+
+    if (device_serial.size() == 0) {
+        nugu_error("device_serial is empty");
+        return nullptr;
+    }
+
+    gchar* query = g_strdup_printf("grant_type=client_credentials&client_id=%s"
+                                   "&client_secret=%s&data={\"deviceSerialNumber\":\"%s\"}",
+        config.oauth_client_id.c_str(), config.oauth_client_secret.c_str(), device_serial.c_str());
+    if (!query) {
+        nugu_error_nomem();
+        return nullptr;
+    }
+
+    gchar* encoded = g_uri_escape_string(query, "?=&", true);
+    if (!encoded) {
+        nugu_error_nomem();
+        g_free(query);
+        return nullptr;
+    }
+
+    std::string body = encoded;
+
+    g_free(query);
+    g_free(encoded);
+
+    NuguHttpResponse* resp = rest->post(ep_token, body);
+    if (!resp) {
+        nugu_error("POST request failed");
+        return nullptr;
+    }
+
+    if (resp->code != 200) {
+        nugu_error("error response code: %d", resp->code);
+        if (resp->body_len > 0)
+            nugu_error("error response body: %s", (char*)resp->body);
+
+        nugu_http_response_free(resp);
+        return nullptr;
+    }
+
+    nugu_info("response: %s", (char*)resp->body);
+
+    std::string message((char*)resp->body);
+    nugu_http_response_free(resp);
+
+    Json::Value root;
+    Json::Reader reader;
+
+    if (!reader.parse(message, root)) {
+        nugu_error("JSON parsing error: %s", message.c_str());
+        return nullptr;
+    }
+
+    if (!root["access_token"].isString()) {
+        nugu_error("can't find access_token from response");
+        return nullptr;
+    }
+
+    NuguToken* token = new NuguToken();
+    if (!token) {
+        nugu_error_nomem();
+        return nullptr;
+    }
+
+    token->access_token = root["access_token"].asString();
+    token->timestamp = time(NULL);
+
+    if (root["refresh_token"].isString())
+        token->refresh_token = root["refresh_token"].asString();
+
+    if (root["token_type"].isString())
+        token->token_type = root["token_type"].asString();
+
+    if (root["expires_in"].isInt())
+        token->expires_in = root["expires_in"].asInt();
+    else
+        token->expires_in = 0;
+
+    parseAccessToken(token);
+
+    return token;
+}
+
+bool NuguAuth::parseAccessToken(NuguToken* token)
+{
+    if (!token)
+        return false;
+
+    if (token->access_token.size() == 0)
+        return false;
+
+    /* Parsing JWT */
+    gchar** splited_text;
+    splited_text = g_strsplit(token->access_token.c_str(), ".", -1);
+    if (!splited_text || !splited_text[1]) {
+        nugu_error("invalid access_token");
+        return false;
+    }
+
+    gchar* decoded = base64_decode(splited_text[1]);
+    g_strfreev(splited_text);
+
+    if (!decoded) {
+        nugu_error("base64 decoding failed");
+        return false;
+    }
+
+    nugu_dbg("token: %s", decoded);
+
+    Json::Value root;
+    Json::Reader reader;
+
+    if (!reader.parse(decoded, root)) {
+        nugu_error("JSON parsing error: %s", decoded);
+        g_free(decoded);
+        return false;
+    }
+
+    g_free(decoded);
+
+    if (root["exp"].isInt()) {
+        token->exp = root["exp"].asInt();
+        nugu_dbg("exp: %d", token->exp);
+    } else {
+        token->exp = 0;
+    }
+
+    if (root["client_id"].isString()) {
+        token->client_id = root["client_id"].asString();
+        nugu_dbg("client_id: %s", token->client_id.c_str());
+    } else {
+        token->client_id = "";
+    }
+
+    token->sid = false;
+    token->scope.clear();
+
+    Json::Value scope = root["scope"];
+    if (scope.isArray()) {
+        Json::ArrayIndex scope_len = scope.size();
+        for (Json::ArrayIndex i = 0; i < scope_len; ++i) {
+            nugu_dbg("scope[%d] = %s", i, scope[i].asCString());
+            token->scope.push_back(scope[i].asCString());
+
+            if (scope[i].asString() == "device:S.I.D.") {
+                token->sid = true;
+                break;
+            }
+        }
+    }
+
+    token->ext_usr = "";
+    token->ext_dvc = "";
+    token->ext_srl = "";
+    token->ext_poc = "";
+
+    if (root["ext"].isObject()) {
+        Json::Value ext = root["ext"];
+
+        if (ext["usr"].isString()) {
+            token->ext_usr = ext["usr"].asString();
+            nugu_dbg("ext[usr]: %s", token->ext_usr.c_str());
+        }
+
+        if (ext["usr"].isString()) {
+            token->ext_dvc = ext["dvc"].asString();
+            nugu_dbg("ext[dvc]: %s", token->ext_dvc.c_str());
+        }
+
+        if (ext["usr"].isString()) {
+            token->ext_srl = ext["srl"].asString();
+            nugu_dbg("ext[srl]: %s", token->ext_srl.c_str());
+        }
+
+        if (ext["usr"].isString()) {
+            token->ext_poc = ext["poc"].asString();
+            nugu_dbg("ext[poc]: %s", token->ext_poc.c_str());
+        }
+    }
+
+    return true;
+}
+
+bool NuguAuth::refresh(NuguToken* token, const std::string& device_serial)
+{
+    std::string serial;
+
+    if (!token)
+        return false;
+
+    if (config.oauth_client_id.size() == 0 || config.oauth_client_secret.size() == 0) {
+        nugu_error("client info is empty");
+        return false;
+    }
+
+    if (token->refresh_token.size() == 0) {
+        nugu_error("refresh_token is empty");
+        return false;
+    }
+
+    if (device_serial.size() == 0) {
+        if (token->ext_srl.size() == 0) {
+            nugu_error("can't find device serial info");
+            return false;
+        } else {
+            serial = token->ext_srl;
+        }
+    } else {
+        serial = device_serial;
+    }
+
+    gchar* query = g_strdup_printf("grant_type=refresh_token&refresh_token=%s&client_id=%s"
+                                   "&client_secret=%s&data={\"deviceSerialNumber\":\"%s\"}",
+        token->refresh_token.c_str(), config.oauth_client_id.c_str(),
+        config.oauth_client_secret.c_str(), serial.c_str());
+    if (!query) {
+        nugu_error_nomem();
+        return false;
+    }
+
+    gchar* encoded = g_uri_escape_string(query, "?=&", true);
+    if (!encoded) {
+        nugu_error_nomem();
+        g_free(query);
+        return false;
+    }
+
+    std::string body = encoded;
+
+    g_free(query);
+    g_free(encoded);
+
+    NuguHttpResponse* resp = rest->post(ep_token, body);
+    if (!resp) {
+        nugu_error("POST request failed");
+        return false;
+    }
+
+    if (resp->code != 200) {
+        nugu_error("error response code: %d", resp->code);
+        if (resp->body_len > 0)
+            nugu_error("error response body: %s", (char*)resp->body);
+
+        nugu_http_response_free(resp);
+        return false;
+    }
+
+    nugu_info("response: %s", (char*)resp->body);
+
+    std::string message((char*)resp->body);
+    nugu_http_response_free(resp);
+
+    Json::Value root;
+    Json::Reader reader;
+
+    if (!reader.parse(message, root)) {
+        nugu_error("JSON parsing error: %s", message.c_str());
+        return false;
+    }
+
+    if (!root["access_token"].isString()) {
+        nugu_error("can't find access_token from response");
+        return false;
+    }
+
+    token->access_token = root["access_token"].asString();
+    token->timestamp = time(NULL);
+
+    if (root["refresh_token"].isString())
+        token->refresh_token = root["refresh_token"].asString();
+
+    if (root["token_type"].isString())
+        token->token_type = root["token_type"].asString();
+
+    if (root["expires_in"].isInt())
+        token->expires_in = root["expires_in"].asInt();
+    else
+        token->expires_in = 0;
+
+    parseAccessToken(token);
+
+    return true;
+}
+
+bool NuguAuth::isExpired(const NuguToken* token, time_t base_time)
+{
+    time_t remainTime = getRemainExpireTime(token, base_time);
+    if (remainTime == 0)
+        return true;
+
+    return false;
+}
+
+time_t NuguAuth::getRemainExpireTime(const NuguToken* token, time_t base_time)
+{
+    time_t expire_time;
+
+    if (!token)
+        return 0;
+
+    expire_time = token->exp;
+    if (expire_time == 0) {
+        if (token->timestamp == 0 || token->expires_in == 0) {
+            nugu_error("Unable to check whether token has expired");
+            return 0;
+        }
+
+        expire_time = token->timestamp + token->expires_in;
+    }
+
+    if (base_time == 0)
+        base_time = time(NULL);
+
+    if (expire_time >= base_time)
+        return expire_time - base_time;
+
+    return 0;
+}
+
+} // NuguClientKit

--- a/tests/clientkit/CMakeLists.txt
+++ b/tests/clientkit/CMakeLists.txt
@@ -1,6 +1,7 @@
 SET(UNIT_TESTS
 	test_clientkit_nugu_runner
 	test_clientkit_http_rest
+	test_clientkit_auth
 	test_clientkit_capability)
 
 # Add Compile Sources with Mock for test

--- a/tests/clientkit/test_clientkit_auth.cc
+++ b/tests/clientkit/test_clientkit_auth.cc
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2022 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <glib.h>
+
+#include "base/nugu_log.h"
+#include "clientkit/nugu_auth.hh"
+
+#define ENV_AUTH_SERVER "AUTH_SERVER"
+#define ENV_CLIENT_ID "CLIENT_ID"
+#define ENV_CLIENT_SECRET "CLIENT_SECRET"
+#define ENV_REDIRECT_URI "REDIRECT_URI"
+#define ENV_AUTHORIZATION_CODE "AUTHORIZATION_CODE"
+
+#define ENV_NUGU_TOKEN "TOKEN"
+#define ENV_NUGU_REFRESH_TOKEN "REFRESH_TOKEN"
+
+#define SECS_1YEAR (3600 * 24 * 365)
+#define SECS_10MIN (60 * 30)
+
+using namespace NuguClientKit;
+
+static NuguAuth* auth;
+
+static void test_nugu_auth_default()
+{
+    g_assert(auth != nullptr);
+    g_assert(auth->isSupport(GrantType::AUTHORIZATION_CODE) == false);
+    g_assert(auth->isSupport(GrantType::CLIENT_CREDENTIALS) == false);
+    g_assert(auth->isSupport(GrantType::REFRESH_TOKEN) == false);
+    g_assert(auth->isSupport(GrantType::DEVICE_CODE) == false);
+    g_assert(auth->generateAuthorizeUrl("").size() == 0);
+    g_assert(auth->getAuthorizationCodeToken("", "") == nullptr);
+    g_assert(auth->getClientCredentialsToken("") == nullptr);
+    g_assert(auth->parseAccessToken(NULL) == false);
+    g_assert(auth->refresh(NULL) == false);
+    g_assert(auth->isExpired(NULL) == true);
+    g_assert(auth->getRemainExpireTime(NULL) == 0);
+
+    NuguDeviceConfig config;
+    NuguAuth* tmp_auth = new NuguAuth(config);
+    g_assert(tmp_auth != nullptr);
+    g_assert(tmp_auth->discovery() == false);
+    g_assert(tmp_auth->generateAuthorizeUrl("1234").size() == 0);
+    g_assert(tmp_auth->getAuthorizationCodeToken("xxxx", "1234") == nullptr);
+    g_assert(tmp_auth->getClientCredentialsToken("1234") == nullptr);
+    delete tmp_auth;
+}
+
+static void test_nugu_auth_discovery()
+{
+    g_assert(auth->discovery() == true);
+}
+
+static void test_nugu_auth_url()
+{
+    if (auth->isSupport(GrantType::AUTHORIZATION_CODE) == false)
+        return;
+
+    std::string url = auth->generateAuthorizeUrl("1234");
+    g_assert(url.size() > 0);
+}
+
+static void test_nugu_auth_code()
+{
+    if (auth->isSupport(GrantType::AUTHORIZATION_CODE) == false)
+        return;
+
+    char* code = getenv(ENV_AUTHORIZATION_CODE);
+    if (!code)
+        return;
+
+    NuguToken* token = auth->getAuthorizationCodeToken(code, "1234");
+    g_assert(token != nullptr);
+
+    g_assert(auth->getRemainExpireTime(token) > 0);
+    g_assert(auth->isExpired(token) == false);
+    g_assert(auth->isExpired(token, time(NULL) + SECS_10MIN) == false);
+    g_assert(auth->isExpired(token, time(NULL) + SECS_1YEAR) == true);
+
+    delete token;
+}
+
+static void test_nugu_auth_refresh()
+{
+    if (getenv(ENV_NUGU_TOKEN) == NULL || getenv(ENV_NUGU_REFRESH_TOKEN) == NULL)
+        return;
+
+    if (auth->isSupport(GrantType::REFRESH_TOKEN) == false)
+        return;
+
+    NuguToken* token = new NuguToken();
+    g_assert(token != nullptr);
+
+    token->access_token = getenv(ENV_NUGU_TOKEN);
+    token->refresh_token = getenv(ENV_NUGU_REFRESH_TOKEN);
+    token->ext_srl = "1234";
+
+    g_assert(auth->parseAccessToken(token) == true);
+    g_assert(auth->refresh(token) == true);
+
+    g_assert_cmpstr(getenv(ENV_NUGU_TOKEN), !=, token->access_token.c_str());
+
+    g_assert(auth->getRemainExpireTime(token) > 0);
+    g_assert(auth->isExpired(token) == false);
+    g_assert(auth->isExpired(token, time(NULL) + SECS_10MIN) == false);
+    g_assert(auth->isExpired(token, time(NULL) + SECS_1YEAR) == true);
+
+    delete token;
+}
+
+static void test_nugu_client_cred()
+{
+    /* Skip the test if the PoC is support AuthorizationCode grant type */
+    if (auth->isSupport(GrantType::AUTHORIZATION_CODE) == true)
+        return;
+
+    if (auth->isSupport(GrantType::CLIENT_CREDENTIALS) == false)
+        return;
+
+    NuguToken* token = auth->getClientCredentialsToken("1234");
+    g_assert(token != nullptr);
+
+    g_assert(auth->getRemainExpireTime(token) > 0);
+    g_assert(auth->isExpired(token) == false);
+    g_assert(auth->isExpired(token, time(NULL) + SECS_10MIN) == false);
+    g_assert(auth->isExpired(token, time(NULL) + SECS_1YEAR) == true);
+
+    delete token;
+}
+
+static void test_nugu_auth_finalize()
+{
+    if (auth)
+        delete auth;
+}
+
+int main(int argc, char* argv[])
+{
+    NuguDeviceConfig config;
+
+#if !GLIB_CHECK_VERSION(2, 36, 0)
+    g_type_init();
+#endif
+
+    g_test_init(&argc, &argv, (void*)NULL);
+    g_log_set_always_fatal((GLogLevelFlags)G_LOG_FATAL_MASK);
+
+    if (getenv(ENV_AUTH_SERVER) != NULL)
+        config.oauth_server_url = getenv(ENV_AUTH_SERVER);
+    else
+        config.oauth_server_url = "https://api.sktnugu.com";
+
+    if (getenv(ENV_CLIENT_ID) != NULL)
+        config.oauth_client_id = getenv(ENV_CLIENT_ID);
+
+    if (getenv(ENV_CLIENT_SECRET) != NULL)
+        config.oauth_client_secret = getenv(ENV_CLIENT_SECRET);
+
+    if (getenv(ENV_REDIRECT_URI) != NULL)
+        config.oauth_redirect_uri = getenv(ENV_REDIRECT_URI);
+
+    auth = new NuguAuth(config);
+    g_test_add_func("/auth/default", test_nugu_auth_default);
+
+    if (config.oauth_client_id.size() > 0) {
+        g_test_add_func("/auth/discovery", test_nugu_auth_discovery);
+
+        if (config.oauth_client_secret.size() > 0) {
+            if (config.oauth_redirect_uri.size() > 0) {
+                g_test_add_func("/auth/auth_url", test_nugu_auth_url);
+                g_test_add_func("/auth/auth_code", test_nugu_auth_code);
+            }
+
+            g_test_add_func("/auth/refresh", test_nugu_auth_refresh);
+            g_test_add_func("/auth/client_cred", test_nugu_client_cred);
+        }
+
+        g_test_add_func("/auth/finalize", test_nugu_auth_finalize);
+    }
+
+    return g_test_run();
+}


### PR DESCRIPTION
add authentication API to support OAuth2 discovery, client_credentials
and token refresh feature.

Signed-off-by: Inho Oh <webispy@gmail.com>