### PR TITLE
clientkit: add uri information getter to auth

### DIFF
--- a/include/clientkit/nugu_auth.hh
+++ b/include/clientkit/nugu_auth.hh
@@ -158,14 +158,26 @@ public:
      */
     time_t getRemainExpireTime(const NuguToken* token, time_t base_time = 0);
 
+    /**
+     * @brief Get uri for device gateway registry
+     * @return std::string uri
+     */
+    std::string getGatewayRegistryUri();
+
+    /**
+     * @brief Get uri for template server
+     * @return std::string uri
+     */
+    std::string getTemplateServerUri();
+
 private:
     NuguDeviceConfig config;
     NuguHttpRest* rest;
     unsigned int supported_grant_types;
     std::string ep_token;
     std::string ep_authorization;
-    std::string url_gateway_registry;
-    std::string url_template_server;
+    std::string uri_gateway_registry;
+    std::string uri_template_server;
 };
 
 /**

--- a/src/clientkit/nugu_auth.cc
+++ b/src/clientkit/nugu_auth.cc
@@ -95,8 +95,8 @@ bool NuguAuth::discovery()
     ep_authorization = root["authorization_endpoint"].asString();
     ep_authorization.erase(0, url_len);
 
-    url_gateway_registry = root["device_gateway_server_h2_uri"].asString();
-    url_template_server = root["template_server_uri"].asString();
+    uri_gateway_registry = root["device_gateway_registry_uri"].asString();
+    uri_template_server = root["template_server_uri"].asString();
 
     supported_grant_types = 0;
     Json::Value grant_types = root["grant_types_supported"];
@@ -583,6 +583,16 @@ time_t NuguAuth::getRemainExpireTime(const NuguToken* token, time_t base_time)
         return expire_time - base_time;
 
     return 0;
+}
+
+std::string NuguAuth::getGatewayRegistryUri()
+{
+    return uri_gateway_registry;
+}
+
+std::string NuguAuth::getTemplateServerUri()
+{
+    return uri_template_server;
 }
 
 } // NuguClientKit

--- a/tests/clientkit/test_clientkit_auth.cc
+++ b/tests/clientkit/test_clientkit_auth.cc
@@ -49,6 +49,8 @@ static void test_nugu_auth_default()
     g_assert(auth->refresh(NULL) == false);
     g_assert(auth->isExpired(NULL) == true);
     g_assert(auth->getRemainExpireTime(NULL) == 0);
+    g_assert(auth->getGatewayRegistryUri().size() == 0);
+    g_assert(auth->getTemplateServerUri().size() == 0);
 
     NuguDeviceConfig config;
     NuguAuth* tmp_auth = new NuguAuth(config);
@@ -63,6 +65,8 @@ static void test_nugu_auth_default()
 static void test_nugu_auth_discovery()
 {
     g_assert(auth->discovery() == true);
+    g_assert(auth->getGatewayRegistryUri().size() != 0);
+    g_assert(auth->getTemplateServerUri().size() != 0);
 }
 
 static void test_nugu_auth_url()


### PR DESCRIPTION
add device gateway registry and template server uri getter to NuguAuth
module.

Signed-off-by: Inho Oh <webispy@gmail.com>