### PR TITLE
clientkit: modify nugu runner policy

### DIFF
--- a/include/clientkit/nugu_runner.hh
+++ b/include/clientkit/nugu_runner.hh
@@ -67,9 +67,10 @@ public:
      * @param[in] tag tag name for debug output
      * @param[in] method request method
      * @param[in] type execute method type
+     * @param[in] timeout The invoked method is released blocking state when timeout. (unit: sec)
      * @see ExecuteType
      */
-    bool invokeMethod(const std::string& tag, request_method method, ExecuteType type = ExecuteType::Auto);
+    bool invokeMethod(const std::string& tag, request_method method, ExecuteType type = ExecuteType::Auto, int timeout = 0);
 
 private:
     void addMethod2Dispatcher(const std::string& tag, NuguRunner::request_method method, ExecuteType type);


### PR DESCRIPTION
GMainLoop is guaranteed to preempt the context and changes the default
policy so that the blocking method waits until execution is complete.
A timeout can be used if necessary.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>