### PR TITLE
clientkit: fix http rest issue

### DIFF
--- a/src/clientkit/nugu_http_rest.cc
+++ b/src/clientkit/nugu_http_rest.cc
@@ -105,6 +105,12 @@ NuguHttpResponse* NuguHttpRest::get(const std::string& path,
     resp = nugu_http_response_dup(nugu_http_request_response_get(req));
     nugu_http_request_free(req);
 
+    if (resp->code == -1) {
+        nugu_error("nugu_http_get_sync() failed");
+        nugu_http_response_free(resp);
+        return NULL;
+    }
+
     return resp;
 }
 
@@ -155,6 +161,12 @@ NuguHttpResponse* NuguHttpRest::post(const std::string& path, const std::string&
 
     resp = nugu_http_response_dup(nugu_http_request_response_get(req));
     nugu_http_request_free(req);
+
+    if (resp->code == -1) {
+        nugu_error("nugu_http_post_sync() failed");
+        nugu_http_response_free(resp);
+        return NULL;
+    }
 
     return resp;
 }
@@ -207,6 +219,12 @@ NuguHttpResponse* NuguHttpRest::put(const std::string& path, const std::string& 
     resp = nugu_http_response_dup(nugu_http_request_response_get(req));
     nugu_http_request_free(req);
 
+    if (resp->code == -1) {
+        nugu_error("nugu_http_put_sync() failed");
+        nugu_http_response_free(resp);
+        return NULL;
+    }
+
     return resp;
 }
 
@@ -257,6 +275,12 @@ NuguHttpResponse* NuguHttpRest::del(const std::string& path,
 
     resp = nugu_http_response_dup(nugu_http_request_response_get(req));
     nugu_http_request_free(req);
+
+    if (resp->code == -1) {
+        nugu_error("nugu_http_delete_sync() failed");
+        nugu_http_response_free(resp);
+        return NULL;
+    }
 
     return resp;
 }


### PR DESCRIPTION
HttpRest has no error checking when the network is unavailable.
This can be hangup caused by access to null pointer.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>