### PR TITLE
InteractionControl:Update handling InteractionControl

### DIFF
--- a/src/capability/message_agent.hh
+++ b/src/capability/message_agent.hh
@@ -87,6 +87,7 @@ private:
     std::string dialog_id;
     std::string received_time;
     InteractionMode interaction_mode;
+    std::pair<Json::Value, Json::Value> interaction_control_payloads;
 };
 
 } // NuguCapability

--- a/src/capability/phone_call_agent.hh
+++ b/src/capability/phone_call_agent.hh
@@ -68,6 +68,7 @@ private:
     std::string context_template;
     std::string context_recipient;
     std::string playstackctl_ps_id;
+    Json::Value interaction_control_payload;
 };
 
 } // NuguCapability

--- a/src/capability/text_agent.hh
+++ b/src/capability/text_agent.hh
@@ -64,8 +64,8 @@ private:
     std::string requestTextInput(TextInputParam&& text_input_param, bool routine_play, bool include_dialog_attribute = true);
     void sendEventTextInput(const TextInputParam& text_input_param, bool include_dialog_attribute = true, EventResultCallback cb = nullptr);
     void sendEventTextSourceFailed(const TextInputParam& text_input_param, EventResultCallback cb = nullptr);
-    void sendEventTextRedirectFailed(const TextInputParam& text_input_param, EventResultCallback cb = nullptr);
-    void sendEventFailed(std::string&& event_name, const TextInputParam& text_input_param, EventResultCallback cb = nullptr);
+    void sendEventTextRedirectFailed(const TextInputParam& text_input_param, const Json::Value& payload, EventResultCallback cb = nullptr);
+    void sendEventFailed(std::string&& event_name, const TextInputParam& text_input_param, Json::Value&& extra_payload, EventResultCallback cb = nullptr);
     void parsingTextSource(const char* message);
     void parsingTextRedirect(const char* message);
     void parsingExpectTyping(const char* message);


### PR DESCRIPTION
As the InteractionControl information is required
when sending the related events in some agents,
it update to include the payload of InteractionControl at that time.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>