### PR TITLE
AudioPlayer:fix handling cancel directive

### DIFF
--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -239,8 +239,13 @@ void AudioPlayerAgent::cancelDirective(NuguDirective* ndir)
     nugu_info("preprocessed directive '%s.%s' canceled",
         nugu_directive_peek_namespace(ndir), nugu_directive_peek_name(ndir));
 
-    nugu_info("remove '%s' from playstack", playstackctl_ps_id.c_str());
-    playsync_manager->releaseSyncUnconditionally(playstackctl_ps_id);
+    std::string cur_disp_playstackctl_ps_id;
+    capa_helper->getCapabilityProperty("Display", "currentPlaystack", cur_disp_playstackctl_ps_id);
+
+    if (cur_disp_playstackctl_ps_id != playstackctl_ps_id) {
+        nugu_info("remove '%s' from playstack", playstackctl_ps_id.c_str());
+        playsync_manager->releaseSyncUnconditionally(playstackctl_ps_id);
+    }
 
     preprocess_dir = nullptr;
 }

--- a/src/capability/display_agent.cc
+++ b/src/capability/display_agent.cc
@@ -137,6 +137,20 @@ void DisplayAgent::updateInfoForContext(Json::Value& ctx)
     ctx[getName()] = display;
 }
 
+bool DisplayAgent::getProperty(const std::string& property, std::string& value)
+{
+    value.clear();
+
+    if (property == "currentPlaystack") {
+        value = playstackctl_ps_id;
+    } else {
+        nugu_error("invalid property: %s", property.c_str());
+        return false;
+    }
+
+    return true;
+}
+
 void DisplayAgent::setCapabilityListener(ICapabilityListener* listener)
 {
     if (listener)
@@ -308,6 +322,7 @@ void DisplayAgent::onSyncState(const std::string& ps_id, PlaySyncState state, vo
         }
 
         render_helper->clearDisplay(extra_data, playsync_manager->hasNextPlayStack());
+        playstackctl_ps_id.clear();
     }
 }
 

--- a/src/capability/display_agent.hh
+++ b/src/capability/display_agent.hh
@@ -39,6 +39,7 @@ public:
     void preprocessDirective(NuguDirective* ndir) override;
     void parsingDirective(const char* dname, const char* message) override;
     void updateInfoForContext(Json::Value& ctx) override;
+    bool getProperty(const std::string& property, std::string& value) override;
     void setCapabilityListener(ICapabilityListener* clistener) override;
 
     void displayRendered(const std::string& id, const DisplayContextInfo& context_info) override;


### PR DESCRIPTION
It add the condition not to release PlaySync
if the current playstack is used in Display.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>