### PR TITLE
Display:Fix handling history control

### DIFF
--- a/src/capability/display_agent.cc
+++ b/src/capability/display_agent.cc
@@ -316,7 +316,9 @@ void DisplayAgent::onDataChanged(const std::string& ps_id, std::pair<void*, void
     render_helper->updateDisplay(extra_datas, playsync_manager->hasNextPlayStack());
 
     if (!history_control_stack.empty()) {
-        playsync_manager->releaseSync(ps_id, getName());
+        if (!hasMediaPlayStack())
+            playsync_manager->releaseSync(ps_id, getName());
+
         keep_history = false;
     }
 }
@@ -663,6 +665,17 @@ bool DisplayAgent::hasPlayStack()
 {
     auto playstacks = playsync_manager->getAllPlayStackItems();
     return std::find(playstacks.cbegin(), playstacks.cend(), playstackctl_ps_id) != playstacks.cend();
+}
+
+bool DisplayAgent::hasMediaPlayStack()
+{
+    auto playstacks = playsync_manager->getAllPlayStackItems();
+
+    for (const auto& playstack : playstacks)
+        if (playsync_manager->hasActivity(playstack, PlayStackActivity::Media))
+            return true;
+
+    return false;
 }
 
 DisplayRenderInfo* DisplayAgent::composeRenderInfo(const NuguDirective* ndir, const std::string& ps_id, const std::string& token)

--- a/src/capability/display_agent.hh
+++ b/src/capability/display_agent.hh
@@ -96,6 +96,7 @@ private:
     void deactiveSession();
     void startPlaySync(const NuguDirective* ndir, const Json::Value& root);
     bool hasPlayStack();
+    bool hasMediaPlayStack();
 
     const std::set<std::string> TEMPLATE_NAMES {
         "FullText1",


### PR DESCRIPTION
It fix not to release play sync when the media is stacked
when the display history control is progressing.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>