### PR TITLE
audio: add audio attribute

### DIFF
--- a/include/base/nugu_audio.h
+++ b/include/base/nugu_audio.h
@@ -59,6 +59,22 @@ enum nugu_audio_format {
 };
 
 /**
+ * @brief audio attribute
+ */
+enum nugu_audio_attribute {
+	NUGU_AUDIO_ATTRIBUTE_MUSIC, /**< audio attribute for music */
+	NUGU_AUDIO_ATTRIBUTE_RINGTONE, /**< audio attribute for ringtone */
+	NUGU_AUDIO_ATTRIBUTE_CALL, /**< audio attribute for call */
+	NUGU_AUDIO_ATTRIBUTE_NOTIFICATION,
+	/**< audio attribute for notification */
+	NUGU_AUDIO_ATTRIBUTE_ALARM, /**< audio attribute for alarm */
+	NUGU_AUDIO_ATTRIBUTE_VOICE_COMMAND,
+	/**< audio attribute for voice command like tts */
+	NUGU_AUDIO_ATTRIBUTE_NAVIGATION, /**< audio attribute for navigation */
+	NUGU_AUDIO_ATTRIBUTE_SYSTEM /**< audio attribute for system */
+};
+
+/**
  * @brief audio property
  */
 struct nugu_audio_property {
@@ -68,9 +84,21 @@ struct nugu_audio_property {
 };
 
 /**
+ * @brief NuguAudioAttribute
+ */
+typedef enum nugu_audio_attribute NuguAudioAttribute;
+
+/**
  * @brief NuguAudioProperty
  */
 typedef struct nugu_audio_property NuguAudioProperty;
+
+/**
+ * @brief Get audio attribute string
+ * @param[in] attribute audio attribute
+ * @return audio attribute string
+ */
+const char *nugu_audio_get_attribute_str(const NuguAudioAttribute attribute);
 
 #ifdef __cplusplus
 }

--- a/include/base/nugu_pcm.h
+++ b/include/base/nugu_pcm.h
@@ -102,6 +102,32 @@ int nugu_pcm_remove(NuguPcm *pcm);
 NuguPcm *nugu_pcm_find(const char *name);
 
 /**
+ * @brief Set audio attribute
+ * @param[in] pcm pcm object
+ * @param[in] attr audio attribute
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ */
+int nugu_pcm_set_audio_attribute(NuguPcm *pcm, NuguAudioAttribute attr);
+
+/**
+ * @brief Get audio attribute
+ * @param[in] pcm pcm object
+ * @return audio attribute
+ * @retval -1 failure
+ */
+int nugu_pcm_get_audio_attribute(NuguPcm *pcm);
+
+/**
+ * @brief Get audio attribute
+ * @param[in] pcm pcm object
+ * @return audio attribute string
+ * @retval NULL failure
+ */
+const char *nugu_pcm_get_audio_attribute_str(NuguPcm *pcm);
+
+/**
  * @brief Start pcm playback
  * @param[in] pcm pcm object
  * @return result
@@ -319,7 +345,7 @@ struct nugu_pcm_driver_ops {
 	 * @see nugu_pcm_new()
 	 */
 	int (*create)(NuguPcmDriver *driver, NuguPcm *pcm,
-		NuguAudioProperty property);
+		      NuguAudioProperty property);
 
 	/**
 	 * @brief Called when pcm is destroyed

--- a/include/base/nugu_player.h
+++ b/include/base/nugu_player.h
@@ -98,6 +98,33 @@ int nugu_player_remove(NuguPlayer *player);
 NuguPlayer *nugu_player_find(const char *name);
 
 /**
+ * @brief Set audio attribute
+ * @param[in] player player object
+ * @param[in] attr audio attribute
+ * @return result
+ * @retval 0 success
+ * @retval -1 failure
+ */
+int nugu_player_set_audio_attribute(NuguPlayer *player,
+				    NuguAudioAttribute attr);
+
+/**
+ * @brief Get audio attribute
+ * @param[in] player player object
+ * @return audio attribute
+ * @retval NULL -1
+ */
+int nugu_player_get_audio_attribute(NuguPlayer *player);
+
+/**
+ * @brief Get audio attribute
+ * @param[in] player player object
+ * @return audio attribute string
+ * @retval NULL failure
+ */
+const char *nugu_player_get_audio_attribute_str(NuguPlayer *player);
+
+/**
  * @brief Set source url
  * @param[in] player player object
  * @param[in] url source url
@@ -237,7 +264,6 @@ void nugu_player_set_event_callback(NuguPlayer *player,
  * @param[in] event player event
  */
 void nugu_player_emit_event(NuguPlayer *player, enum nugu_media_event event);
-
 
 /**
  * @brief Set custom data for driver

--- a/include/clientkit/media_player_interface.hh
+++ b/include/clientkit/media_player_interface.hh
@@ -17,6 +17,7 @@
 #ifndef __NUGU_MEDIA_PLAYER_INTERFACE_H__
 #define __NUGU_MEDIA_PLAYER_INTERFACE_H__
 
+#include <base/nugu_audio.h>
 #include <string>
 
 namespace NuguClientKit {
@@ -52,7 +53,7 @@ enum class MediaPlayerEvent {
     LOADING_MEDIA_FAILED, /**< Loading of media content failed */
     LOADING_MEDIA_SUCCESS, /**< Loading of media content success */
     PLAYING_MEDIA_FINISHED, /**< Playing media content to the end */
-    PLAYING_MEDIA_UNDERRUN  /**< Playing media content underrun */
+    PLAYING_MEDIA_UNDERRUN /**< Playing media content underrun */
 };
 
 /**
@@ -125,6 +126,12 @@ public:
      * @param[in] listener listener object
      */
     virtual void removeListener(IMediaPlayerListener* listener) = 0;
+
+    /**
+     * @brief Sets the audio attribute in the media player.
+     * @param[in] attr audio attribute
+     */
+    virtual void setAudioAttribute(NuguAudioAttribute attr) = 0;
 
     /**
      * @brief Sets the playurl of the media content to play in the media player.
@@ -264,7 +271,8 @@ public:
      * @param[in] size data size
      * @return success or not
      */
-    virtual bool write_audio(const char *data, int size) = 0;
+    virtual bool write_audio(const char* data, int size) = 0;
+
     /**
      * @brief Notify to write done to the tts player.
      */

--- a/src/base/nugu_audio.c
+++ b/src/base/nugu_audio.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "base/nugu_audio.h"
+#include "base/nugu_log.h"
+
+const char *nugu_audio_get_attribute_str(const NuguAudioAttribute attribute)
+{
+	switch (attribute) {
+	case NUGU_AUDIO_ATTRIBUTE_MUSIC:
+		return "music";
+	case NUGU_AUDIO_ATTRIBUTE_RINGTONE:
+		return "ringtone";
+	case NUGU_AUDIO_ATTRIBUTE_CALL:
+		return "call";
+	case NUGU_AUDIO_ATTRIBUTE_NOTIFICATION:
+		return "notification";
+	case NUGU_AUDIO_ATTRIBUTE_ALARM:
+		return "alarm";
+	case NUGU_AUDIO_ATTRIBUTE_VOICE_COMMAND:
+		return "voice";
+	case NUGU_AUDIO_ATTRIBUTE_NAVIGATION:
+		return "navigation";
+	case NUGU_AUDIO_ATTRIBUTE_SYSTEM:
+		return "system";
+	default:
+		nugu_warn("not implement yet!!");
+		return "music";
+	}
+}

--- a/src/base/nugu_pcm.c
+++ b/src/base/nugu_pcm.c
@@ -36,6 +36,7 @@ struct _nugu_pcm {
 	void *driver_data;
 
 	enum nugu_media_status status;
+	enum nugu_audio_attribute attr;
 	NuguAudioProperty property;
 	NuguMediaEventCallback ecb;
 	NuguMediaStatusCallback scb;
@@ -205,6 +206,7 @@ EXPORT_API NuguPcm *nugu_pcm_new(const char *name, NuguPcmDriver *driver,
 	pcm->eud = NULL;
 	pcm->driver_data = NULL;
 	pcm->status = NUGU_MEDIA_STATUS_STOPPED;
+	pcm->attr = NUGU_AUDIO_ATTRIBUTE_VOICE_COMMAND;
 	pcm->volume = NUGU_SET_VOLUME_MAX;
 	pcm->total_size = 0;
 	memcpy(&pcm->property, &property, sizeof(NuguAudioProperty));
@@ -292,6 +294,29 @@ EXPORT_API NuguPcm *nugu_pcm_find(const char *name)
 	}
 
 	return NULL;
+}
+
+EXPORT_API int nugu_pcm_set_audio_attribute(NuguPcm *pcm,
+					    NuguAudioAttribute attr)
+{
+	g_return_val_if_fail(pcm != NULL, -1);
+
+	pcm->attr = attr;
+	return 0;
+}
+
+EXPORT_API int nugu_pcm_get_audio_attribute(NuguPcm *pcm)
+{
+	g_return_val_if_fail(pcm != NULL, -1);
+
+	return pcm->attr;
+}
+
+EXPORT_API const char *nugu_pcm_get_audio_attribute_str(NuguPcm *pcm)
+{
+	g_return_val_if_fail(pcm != NULL, NULL);
+
+	return nugu_audio_get_attribute_str(pcm->attr);
 }
 
 EXPORT_API int nugu_pcm_start(NuguPcm *pcm)

--- a/src/base/nugu_player.c
+++ b/src/base/nugu_player.c
@@ -35,6 +35,7 @@ struct _nugu_player {
 	void *driver_data;
 
 	enum nugu_media_status status;
+	enum nugu_audio_attribute attr;
 	char *playurl;
 	int volume;
 	NuguMediaEventCallback ecb;
@@ -173,6 +174,7 @@ EXPORT_API NuguPlayer *nugu_player_new(const char *name,
 	player->driver = driver;
 	player->volume = NUGU_SET_VOLUME_DEFAULT;
 	player->status = NUGU_MEDIA_STATUS_STOPPED;
+	player->attr = NUGU_AUDIO_ATTRIBUTE_MUSIC;
 
 	if (driver == NULL || driver->ops == NULL ||
 	    driver->ops->create == NULL) {
@@ -252,6 +254,29 @@ EXPORT_API NuguPlayer *nugu_player_find(const char *name)
 	}
 
 	return NULL;
+}
+
+EXPORT_API int nugu_player_set_audio_attribute(NuguPlayer *player,
+					       NuguAudioAttribute attr)
+{
+	g_return_val_if_fail(player != NULL, -1);
+
+	player->attr = attr;
+	return 0;
+}
+
+EXPORT_API int nugu_player_get_audio_attribute(NuguPlayer *player)
+{
+	g_return_val_if_fail(player != NULL, -1);
+
+	return player->attr;
+}
+
+EXPORT_API const char *nugu_player_get_audio_attribute_str(NuguPlayer *player)
+{
+	g_return_val_if_fail(player != NULL, NULL);
+
+	return nugu_audio_get_attribute_str(player->attr);
 }
 
 EXPORT_API int nugu_player_set_source(NuguPlayer *player, const char *url)

--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -96,10 +96,12 @@ void AudioPlayerAgent::initialize()
     media_player = core_container->createMediaPlayer();
     media_player->addListener(this);
     media_player->setVolume(volume);
+    media_player->setAudioAttribute(NUGU_AUDIO_ATTRIBUTE_MUSIC);
 
     tts_player = core_container->createTTSPlayer();
     tts_player->addListener(this);
     tts_player->setVolume(volume);
+    tts_player->setAudioAttribute(NUGU_AUDIO_ATTRIBUTE_MUSIC);
 
     cur_player = media_player;
 

--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -86,6 +86,7 @@ void TTSAgent::initialize()
     player = core_container->createTTSPlayer();
     player->addListener(this);
     player->setVolume(volume);
+    player->setAudioAttribute(NUGU_AUDIO_ATTRIBUTE_VOICE_COMMAND);
 
     addReferrerEvents("SpeechStarted", "Speak");
     addReferrerEvents("SpeechFinished", "Speak");

--- a/src/core/media_player.cc
+++ b/src/core/media_player.cc
@@ -211,6 +211,11 @@ void MediaPlayer::removeListener(IMediaPlayerListener* listener)
     d->listeners.remove(listener);
 }
 
+void MediaPlayer::setAudioAttribute(NuguAudioAttribute attr)
+{
+    nugu_player_set_audio_attribute(d->player, attr);
+}
+
 bool MediaPlayer::setSource(const std::string& url)
 {
     if (url.size() == 0) {

--- a/src/core/media_player.hh
+++ b/src/core/media_player.hh
@@ -35,6 +35,7 @@ public:
     void addListener(IMediaPlayerListener* listener) override;
     void removeListener(IMediaPlayerListener* listener) override;
 
+    void setAudioAttribute(NuguAudioAttribute attr) override;
     bool setSource(const std::string& url) override;
     bool play() override;
     bool stop() override;

--- a/src/core/tts_player.cc
+++ b/src/core/tts_player.cc
@@ -204,6 +204,11 @@ void TTSPlayer::removeListener(IMediaPlayerListener* listener)
     d->listeners.remove(listener);
 }
 
+void TTSPlayer::setAudioAttribute(NuguAudioAttribute attr)
+{
+    nugu_pcm_set_audio_attribute(d->player, attr);
+}
+
 bool TTSPlayer::write_audio(const char* data, int size)
 {
     unsigned char* dbuf;

--- a/src/core/tts_player.hh
+++ b/src/core/tts_player.hh
@@ -38,6 +38,7 @@ public:
     bool write_audio(const char *data, int size) override;
     void write_done() override;
 
+    void setAudioAttribute(NuguAudioAttribute attr) override;
     bool setSource(const std::string& url) override;
     bool play() override;
     bool stop() override;

--- a/tests/test_nugu_pcm.c
+++ b/tests/test_nugu_pcm.c
@@ -46,7 +46,7 @@ static enum nugu_media_event _event2;
 	}
 
 static int dummy_create(NuguPcmDriver *driver, NuguPcm *pcm,
-		      NuguAudioProperty prop)
+			NuguAudioProperty prop)
 {
 	return 0;
 }
@@ -208,6 +208,39 @@ static void test_pcm_multiple(void)
 	nugu_pcm_driver_remove(driver);
 }
 
+static void test_pcm_audio_attribute(void)
+{
+	NuguPcmDriver *driver;
+	NuguPcm *pcm;
+	NuguAudioProperty prop;
+
+	driver = nugu_pcm_driver_new("dummy", &dummy_driver_ops);
+	g_assert(driver != NULL);
+	g_assert(nugu_pcm_driver_register(driver) == 0);
+
+	prop.samplerate = NUGU_AUDIO_SAMPLE_RATE_22K;
+	prop.format = NUGU_AUDIO_FORMAT_S16_LE;
+	prop.channel = 1;
+
+	pcm = nugu_pcm_new("pcm", driver, prop);
+	g_assert(nugu_pcm_add(pcm) == 0);
+
+	// default pcm audio attribute: voice command (string: voice)
+	g_assert(nugu_pcm_get_audio_attribute(pcm) ==
+		 NUGU_AUDIO_ATTRIBUTE_VOICE_COMMAND);
+	g_assert_cmpstr(nugu_pcm_get_audio_attribute_str(pcm), ==, "voice");
+
+	// change to music
+	nugu_pcm_set_audio_attribute(pcm, NUGU_AUDIO_ATTRIBUTE_MUSIC);
+	g_assert(nugu_pcm_get_audio_attribute(pcm) ==
+		 NUGU_AUDIO_ATTRIBUTE_MUSIC);
+	g_assert_cmpstr(nugu_pcm_get_audio_attribute_str(pcm), ==, "music");
+
+	nugu_pcm_remove(pcm);
+	nugu_pcm_free(pcm);
+	nugu_pcm_driver_remove(driver);
+}
+
 int main(int argc, char *argv[])
 {
 #if !GLIB_CHECK_VERSION(2, 36, 0)
@@ -219,6 +252,7 @@ int main(int argc, char *argv[])
 
 	g_test_add_func("/pcm/default", test_pcm_default);
 	g_test_add_func("/pcm/driver", test_pcm_multiple);
+	g_test_add_func("/pcm/audio_attribute", test_pcm_audio_attribute);
 
 	return g_test_run();
 }

--- a/tests/test_nugu_player.c
+++ b/tests/test_nugu_player.c
@@ -450,6 +450,47 @@ static void test_player_volume(void)
 	nugu_player_driver_remove(driver);
 }
 
+static void test_player_audio_attribute(void)
+{
+	NuguPlayerDriver *driver;
+	NuguPlayer *music_player, *alarm_player;
+
+	driver = nugu_player_driver_new("dummy", &dummy_driver_ops);
+	g_assert(driver != NULL);
+	g_assert(nugu_player_driver_register(driver) == 0);
+
+	music_player = nugu_player_new("music_player", driver);
+	alarm_player = nugu_player_new("alarm_player", driver);
+	g_assert(nugu_player_add(music_player) == 0);
+	g_assert(nugu_player_add(alarm_player) == 0);
+
+	// default player audio attribute: music (string: music)
+	g_assert(nugu_player_get_audio_attribute(music_player) ==
+		 NUGU_AUDIO_ATTRIBUTE_MUSIC);
+	g_assert(nugu_player_get_audio_attribute(alarm_player) ==
+		 NUGU_AUDIO_ATTRIBUTE_MUSIC);
+	g_assert_cmpstr(nugu_player_get_audio_attribute_str(music_player), ==,
+			"music");
+
+	// change to alarm
+	nugu_player_set_audio_attribute(alarm_player,
+					NUGU_AUDIO_ATTRIBUTE_ALARM);
+	g_assert(nugu_player_get_audio_attribute(music_player) ==
+		 NUGU_AUDIO_ATTRIBUTE_MUSIC);
+	g_assert(nugu_player_get_audio_attribute(alarm_player) ==
+		 NUGU_AUDIO_ATTRIBUTE_ALARM);
+	g_assert_cmpstr(nugu_player_get_audio_attribute_str(alarm_player), ==,
+			"alarm");
+
+	nugu_player_remove(music_player);
+	nugu_player_remove(alarm_player);
+
+	nugu_player_free(music_player);
+	nugu_player_free(alarm_player);
+
+	nugu_player_driver_remove(driver);
+}
+
 int main(int argc, char *argv[])
 {
 #if !GLIB_CHECK_VERSION(2, 36, 0)
@@ -464,6 +505,7 @@ int main(int argc, char *argv[])
 	g_test_add_func("/player/probe", test_player_probe);
 	g_test_add_func("/player/seek", test_nugu_player_seek);
 	g_test_add_func("/player/volume", test_player_volume);
+	g_test_add_func("/pcm/audio_attribute", test_player_audio_attribute);
 
 	return g_test_run();
 }


### PR DESCRIPTION
The audio volume is controlled by speaker's interface via audio
attribute. Categorized with reference to Android audio attribute.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>