### PR TITLE
Display:fix condition to clear playStackControl

### DIFF
--- a/src/capability/display_agent.cc
+++ b/src/capability/display_agent.cc
@@ -322,7 +322,9 @@ void DisplayAgent::onSyncState(const std::string& ps_id, PlaySyncState state, vo
         }
 
         render_helper->clearDisplay(extra_data, playsync_manager->hasNextPlayStack());
-        playstackctl_ps_id.clear();
+
+        if (ps_id == playstackctl_ps_id)
+            playstackctl_ps_id.clear();
     }
 }
 


### PR DESCRIPTION
It fix to clear playStackControl when the released
playsync play service id is matched with this.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>