### PR TITLE
clientkit: expose focus manager interface

### DIFF
--- a/include/clientkit/nugu_client.hh
+++ b/include/clientkit/nugu_client.hh
@@ -127,6 +127,12 @@ public:
      */
     ICapabilityInterface* getCapabilityHandler(const std::string& cname);
 
+    /**
+     * @brief Get instance of FocusManager
+     * @return IFocusManager abstraction object of FocusManager
+     */
+    IFocusManager* getFocusManager();
+
 private:
     std::unique_ptr<NuguClientImpl> impl;
     CapabilityBuilder* cap_builder;

--- a/src/clientkit/nugu_client.cc
+++ b/src/clientkit/nugu_client.cc
@@ -96,4 +96,9 @@ ICapabilityInterface* NuguClient::getCapabilityHandler(const std::string& cname)
     return impl->getCapabilityHandler(cname);
 }
 
+IFocusManager* NuguClient::getFocusManager()
+{
+    return impl->getFocusManager();
+}
+
 } // NuguClientKit

--- a/src/clientkit/nugu_client_impl.cc
+++ b/src/clientkit/nugu_client_impl.cc
@@ -95,6 +95,16 @@ INuguCoreContainer* NuguClientImpl::getNuguCoreContainer()
     return nugu_core_container.get();
 }
 
+INetworkManager* NuguClientImpl::getNetworkManager()
+{
+    return network_manager.get();
+}
+
+IFocusManager* NuguClientImpl::getFocusManager()
+{
+    return nugu_core_container->getCapabilityHelper()->getFocusManager();
+}
+
 int NuguClientImpl::create(void)
 {
     if (createCapabilities() <= 0) {
@@ -227,11 +237,6 @@ void NuguClientImpl::deInitialize(void)
     nugu_dbg("NuguClientImpl deInitialize success.");
 
     initialized = false;
-}
-
-INetworkManager* NuguClientImpl::getNetworkManager()
-{
-    return network_manager.get();
 }
 
 } // NuguClientKit

--- a/src/clientkit/nugu_client_impl.hh
+++ b/src/clientkit/nugu_client_impl.hh
@@ -43,6 +43,7 @@ public:
     ICapabilityInterface* getCapabilityHandler(const std::string& cname);
     INuguCoreContainer* getNuguCoreContainer();
     INetworkManager* getNetworkManager();
+    IFocusManager* getFocusManager();
 
 private:
     int createCapabilities(void);


### PR DESCRIPTION
The audio resources is managed by framework and the focus is not
handled in capability agent all the time. For convenience usage, the focus
manager interface is exposed to the clientkit.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>