### PR TITLE
base: set audio property's name

### DIFF
--- a/include/base/nugu_audio.h
+++ b/include/base/nugu_audio.h
@@ -25,6 +25,15 @@ extern "C" {
  * @file nugu_audio.h
  */
 
+#define NUGU_AUDIO_ATTRIBUTE_MUSIC_DEFAULT_STRING "MUSIC"
+#define NUGU_AUDIO_ATTRIBUTE_RINGTONE_DEFAULT_STRING "RINGTONE"
+#define NUGU_AUDIO_ATTRIBUTE_CALL_DEFAULT_STRING "CALL"
+#define NUGU_AUDIO_ATTRIBUTE_NOTIFICATION_DEFAULT_STRING "NOTIFICATION"
+#define NUGU_AUDIO_ATTRIBUTE_ALARM_DEFAULT_STRING "ALARM"
+#define NUGU_AUDIO_ATTRIBUTE_VOICE_COMMAND_DEFAULT_STRING "VOICE_COMMAND"
+#define NUGU_AUDIO_ATTRIBUTE_NAVIGATION_DEFAULT_STRING "NAVIGATION"
+#define NUGU_AUDIO_ATTRIBUTE_SYSTEM_SOUND_DEFAULT_STRING "SYSTEM_SOUND"
+
 /**
  * @brief audio sample rate
  */
@@ -93,6 +102,14 @@ typedef enum nugu_audio_attribute NuguAudioAttribute;
  * @brief NuguAudioProperty
  */
 typedef struct nugu_audio_property NuguAudioProperty;
+
+/**
+ * @brief Set audio attribute string
+ * @param[in] attribute audio attribute
+ * @param[in] str audio attribute's string
+ */
+void nugu_audio_set_attribute_str(const NuguAudioAttribute attribute,
+				  const char *str);
 
 /**
  * @brief Get audio attribute string

--- a/include/capability/speaker_interface.hh
+++ b/include/capability/speaker_interface.hh
@@ -35,6 +35,16 @@ using namespace NuguClientKit;
  * @{
  */
 
+#define NUGU_SPEAKER_NUGU_STRING "NUGU"
+#define NUGU_SPEAKER_MUSIC_STRING NUGU_AUDIO_ATTRIBUTE_MUSIC_DEFAULT_STRING
+#define NUGU_SPEAKER_RINGTONE_STRING NUGU_AUDIO_ATTRIBUTE_RINGTONE_DEFAULT_STRING
+#define NUGU_SPEAKER_CALL_STRING NUGU_AUDIO_ATTRIBUTE_CALL_DEFAULT_STRING
+#define NUGU_SPEAKER_NOTIFICATION_STRING NUGU_AUDIO_ATTRIBUTE_NOTIFICATION_DEFAULT_STRING
+#define NUGU_SPEAKER_ALARM_STRING NUGU_AUDIO_ATTRIBUTE_ALARM_DEFAULT_STRING
+#define NUGU_SPEAKER_VOICE_COMMAND_STRING NUGU_AUDIO_ATTRIBUTE_VOICE_COMMAND_DEFAULT_STRING
+#define NUGU_SPEAKER_NAVIGATION_STRING NUGU_AUDIO_ATTRIBUTE_NAVIGATION_DEFAULT_STRING
+#define NUGU_SPEAKER_SYSTEM_SOUND_STRING NUGU_AUDIO_ATTRIBUTE_SYSTEM_SOUND_DEFAULT_STRING
+
 #define NUGU_SPEAKER_MIN_VOLUME 0 /** @def Set speaker minimum volume to 0 */
 #define NUGU_SPEAKER_MAX_VOLUME 100 /** @def Set speaker maximum volume to 100 */
 #define NUGU_SPEAKER_DEFAULT_VOLUME 50 /** @def Set speaker default volume to 50 */
@@ -142,6 +152,21 @@ public:
      * @param[in] result result of SetMute
      */
     virtual void sendEventMuteChanged(const std::string& ps_id, bool result) = 0;
+
+    /**
+     * @brief Get speaker's name
+     * @param[in] type speaker type
+     * @return result speaker's name
+     */
+    virtual std::string getSpeakerName(const SpeakerType& type) = 0;
+
+    /**
+     * @brief Get speaker's type according speaker's name
+     * @param[in] name speaker name
+     * @param[out] type speaker type
+     * @return return true if the speaker type is found, otherwise false
+     */
+    virtual bool getSpeakerType(const std::string& name, SpeakerType& type) = 0;
 };
 
 /**

--- a/src/base/nugu_audio.c
+++ b/src/base/nugu_audio.c
@@ -14,31 +14,81 @@
  * limitations under the License.
  */
 
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
 #include "base/nugu_audio.h"
 #include "base/nugu_log.h"
+
+#define AUDIO_ATTR_NUM NUGU_AUDIO_ATTRIBUTE_SYSTEM_SOUND
+#define GET_AUDIO_ATTR_INDEX(audio_attr) (audio_attr - 1)
+
+static char *audio_attr_str[AUDIO_ATTR_NUM];
+
+static char *nugu_audio_get_default_attribute_str(NuguAudioAttribute attribute)
+{
+	char *attr_str;
+
+	switch (attribute) {
+	case NUGU_AUDIO_ATTRIBUTE_MUSIC:
+		attr_str = NUGU_AUDIO_ATTRIBUTE_MUSIC_DEFAULT_STRING;
+		break;
+	case NUGU_AUDIO_ATTRIBUTE_RINGTONE:
+		attr_str = NUGU_AUDIO_ATTRIBUTE_RINGTONE_DEFAULT_STRING;
+		break;
+	case NUGU_AUDIO_ATTRIBUTE_CALL:
+		attr_str = NUGU_AUDIO_ATTRIBUTE_CALL_DEFAULT_STRING;
+		break;
+	case NUGU_AUDIO_ATTRIBUTE_NOTIFICATION:
+		attr_str = NUGU_AUDIO_ATTRIBUTE_NOTIFICATION_DEFAULT_STRING;
+		break;
+	case NUGU_AUDIO_ATTRIBUTE_ALARM:
+		attr_str = NUGU_AUDIO_ATTRIBUTE_ALARM_DEFAULT_STRING;
+		break;
+	case NUGU_AUDIO_ATTRIBUTE_VOICE_COMMAND:
+		attr_str = NUGU_AUDIO_ATTRIBUTE_VOICE_COMMAND_DEFAULT_STRING;
+		break;
+	case NUGU_AUDIO_ATTRIBUTE_NAVIGATION:
+		attr_str = NUGU_AUDIO_ATTRIBUTE_NAVIGATION_DEFAULT_STRING;
+		break;
+	case NUGU_AUDIO_ATTRIBUTE_SYSTEM_SOUND:
+		attr_str = NUGU_AUDIO_ATTRIBUTE_SYSTEM_SOUND_DEFAULT_STRING;
+		break;
+	default:
+		nugu_warn("not implement yet!!");
+		attr_str = NUGU_AUDIO_ATTRIBUTE_MUSIC_DEFAULT_STRING;
+		break;
+	}
+	return attr_str;
+}
+
+EXPORT_API void nugu_audio_set_attribute_str(const NuguAudioAttribute attribute,
+					     const char *str)
+{
+	int index = GET_AUDIO_ATTR_INDEX(attribute);
+
+	if (!str || !strlen(str))
+		return;
+
+	if (audio_attr_str[index])
+		free(audio_attr_str[index]);
+
+	audio_attr_str[index] = (char *)calloc(1, strlen(str) + 1);
+	if (!audio_attr_str[index]) {
+		nugu_error_nomem();
+		return;
+	}
+	snprintf(audio_attr_str[index], strlen(str) + 1, "%s", str);
+}
 
 EXPORT_API const char *
 nugu_audio_get_attribute_str(const NuguAudioAttribute attribute)
 {
-	switch (attribute) {
-	case NUGU_AUDIO_ATTRIBUTE_MUSIC:
-		return "music";
-	case NUGU_AUDIO_ATTRIBUTE_RINGTONE:
-		return "ringtone";
-	case NUGU_AUDIO_ATTRIBUTE_CALL:
-		return "call";
-	case NUGU_AUDIO_ATTRIBUTE_NOTIFICATION:
-		return "notification";
-	case NUGU_AUDIO_ATTRIBUTE_ALARM:
-		return "alarm";
-	case NUGU_AUDIO_ATTRIBUTE_VOICE_COMMAND:
-		return "voice";
-	case NUGU_AUDIO_ATTRIBUTE_NAVIGATION:
-		return "navigation";
-	case NUGU_AUDIO_ATTRIBUTE_SYSTEM_SOUND:
-		return "system";
-	default:
-		nugu_warn("not implement yet!!");
-		return "music";
-	}
+	int index = GET_AUDIO_ATTR_INDEX(attribute);
+
+	if (index < AUDIO_ATTR_NUM && audio_attr_str[index])
+		return audio_attr_str[index];
+
+	return nugu_audio_get_default_attribute_str(attribute);
 }

--- a/src/capability/speaker_agent.cc
+++ b/src/capability/speaker_agent.cc
@@ -28,10 +28,6 @@ SpeakerAgent::SpeakerAgent()
     : Capability(CAPABILITY_NAME, CAPABILITY_VERSION)
     , speaker_listener(nullptr)
 {
-    std::for_each(SPEAKER_NAMES_FOR_TYPES.cbegin(), SPEAKER_NAMES_FOR_TYPES.cend(),
-        [&](const std::pair<SpeakerType, std::string>& element) {
-            speaker_types_for_names.emplace(element.second, element.first);
-        });
 }
 
 void SpeakerAgent::initialize()
@@ -201,23 +197,29 @@ void SpeakerAgent::updateSpeakerMute(SpeakerType type, bool mute)
     }
 }
 
-bool SpeakerAgent::getSpeakerType(const std::string& name, SpeakerType& type) noexcept
+bool SpeakerAgent::getSpeakerType(const std::string& name, SpeakerType& type)
 {
-    try {
-        type = speaker_types_for_names.at(name);
-        return true;
-    } catch (const std::out_of_range& oor) {
-        return false;
+    for (auto iter = SPEAKER_NAMES_FOR_TYPES.begin(); iter != SPEAKER_NAMES_FOR_TYPES.end(); ++iter){
+        if (name == iter->second) {
+            type = iter->first;
+            return true;
+        }
     }
+    return false;
 }
 
-std::string SpeakerAgent::getSpeakerName(const SpeakerType& type) noexcept
+std::string SpeakerAgent::getSpeakerName(const SpeakerType& type)
 {
-    try {
-        return SPEAKER_NAMES_FOR_TYPES.at(type);
-    } catch (const std::out_of_range& oor) {
-        return "NUGU";
+    std::string name = NUGU_SPEAKER_NUGU_STRING;
+
+    for (auto iter = SPEAKER_NAMES_FOR_TYPES.begin(); iter != SPEAKER_NAMES_FOR_TYPES.end(); ++iter){
+        if (type == iter->first) {
+            name = iter->second;
+            break;
+        }
     }
+
+    return name;
 }
 
 void SpeakerAgent::sendEventSetVolumeSucceeded(const std::string& ps_id, EventResultCallback cb)

--- a/src/capability/speaker_agent.hh
+++ b/src/capability/speaker_agent.hh
@@ -44,6 +44,9 @@ public:
     void sendEventVolumeChanged(const std::string& ps_id, bool result) override;
     void sendEventMuteChanged(const std::string& ps_id, bool result) override;
 
+    bool getSpeakerType(const std::string& name, SpeakerType& type) override;
+    std::string getSpeakerName(const SpeakerType& type) override;
+
 private:
     void sendEventCommon(const std::string& ps_id, const std::string& ename, EventResultCallback cb = nullptr);
     void sendEventSetVolumeSucceeded(const std::string& ps_id, EventResultCallback cb = nullptr);
@@ -56,23 +59,20 @@ private:
 
     void updateSpeakerVolume(SpeakerType type, int volume);
     void updateSpeakerMute(SpeakerType type, bool mute);
-    bool getSpeakerType(const std::string& name, SpeakerType& type) noexcept;
-    std::string getSpeakerName(const SpeakerType& type) noexcept;
 
     const std::map<SpeakerType, std::string> SPEAKER_NAMES_FOR_TYPES {
-        { SpeakerType::NUGU, "NUGU" },
-        { SpeakerType::MUSIC, "MUSIC" },
-        { SpeakerType::RINGTONE, "RINGTONE" },
-        { SpeakerType::CALL, "CALL" },
-        { SpeakerType::NOTIFICATION, "NOTIFICATION" },
-        { SpeakerType::ALARM, "ALARM" },
-        { SpeakerType::VOICE_COMMAND, "VOICE_COMMAND" },
-        { SpeakerType::NAVIGATION, "NAVIGATION" },
-        { SpeakerType::SYSTEM_SOUND, "SYSTEM_SOUND" },
+        { SpeakerType::NUGU, std::string(NUGU_SPEAKER_NUGU_STRING) },
+        { SpeakerType::MUSIC, std::string(NUGU_SPEAKER_MUSIC_STRING) },
+        { SpeakerType::RINGTONE, std::string(NUGU_SPEAKER_RINGTONE_STRING) },
+        { SpeakerType::CALL, std::string(NUGU_SPEAKER_CALL_STRING) },
+        { SpeakerType::NOTIFICATION, std::string(NUGU_SPEAKER_NOTIFICATION_STRING) },
+        { SpeakerType::ALARM, std::string(NUGU_SPEAKER_ALARM_STRING) },
+        { SpeakerType::VOICE_COMMAND, std::string(NUGU_SPEAKER_VOICE_COMMAND_STRING) },
+        { SpeakerType::NAVIGATION, std::string(NUGU_SPEAKER_NAVIGATION_STRING) },
+        { SpeakerType::SYSTEM_SOUND, std::string(NUGU_SPEAKER_SYSTEM_SOUND_STRING) },
     };
 
     std::map<SpeakerType, std::unique_ptr<SpeakerInfo>> speakers;
-    std::map<std::string, SpeakerType> speaker_types_for_names;
     ISpeakerListener* speaker_listener;
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ ADD_DEPENDENCIES(plugin_nugu_custom.so libnugu)
 
 # Unit tests
 SET(UNIT_TESTS
+	test_nugu_audio
 	test_nugu_buffer
 	test_nugu_plugin
 	test_nugu_recorder

--- a/tests/test_nugu_audio.c
+++ b/tests/test_nugu_audio.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <glib.h>
+
+#include "base/nugu_audio.h"
+
+static void test_audio_default(void)
+{
+	// read default audio attribute string
+	g_assert_cmpstr(
+		nugu_audio_get_attribute_str(NUGU_AUDIO_ATTRIBUTE_MUSIC), ==,
+		NUGU_AUDIO_ATTRIBUTE_MUSIC_DEFAULT_STRING);
+	g_assert_cmpstr(
+		nugu_audio_get_attribute_str(NUGU_AUDIO_ATTRIBUTE_RINGTONE), ==,
+		NUGU_AUDIO_ATTRIBUTE_RINGTONE_DEFAULT_STRING);
+	g_assert_cmpstr(nugu_audio_get_attribute_str(NUGU_AUDIO_ATTRIBUTE_CALL),
+			==, NUGU_AUDIO_ATTRIBUTE_CALL_DEFAULT_STRING);
+	g_assert_cmpstr(
+		nugu_audio_get_attribute_str(NUGU_AUDIO_ATTRIBUTE_NOTIFICATION),
+		==, NUGU_AUDIO_ATTRIBUTE_NOTIFICATION_DEFAULT_STRING);
+	g_assert_cmpstr(
+		nugu_audio_get_attribute_str(NUGU_AUDIO_ATTRIBUTE_ALARM), ==,
+		NUGU_AUDIO_ATTRIBUTE_ALARM_DEFAULT_STRING);
+	g_assert_cmpstr(nugu_audio_get_attribute_str(
+				NUGU_AUDIO_ATTRIBUTE_VOICE_COMMAND),
+			==, NUGU_AUDIO_ATTRIBUTE_VOICE_COMMAND_DEFAULT_STRING);
+	g_assert_cmpstr(
+		nugu_audio_get_attribute_str(NUGU_AUDIO_ATTRIBUTE_NAVIGATION),
+		==, NUGU_AUDIO_ATTRIBUTE_NAVIGATION_DEFAULT_STRING);
+	g_assert_cmpstr(
+		nugu_audio_get_attribute_str(NUGU_AUDIO_ATTRIBUTE_SYSTEM_SOUND),
+		==, NUGU_AUDIO_ATTRIBUTE_SYSTEM_SOUND_DEFAULT_STRING);
+}
+
+static void test_audio_attribute_str(void)
+{
+	// NULL
+	nugu_audio_set_attribute_str(NUGU_AUDIO_ATTRIBUTE_MUSIC, NULL);
+	g_assert_cmpstr(
+		nugu_audio_get_attribute_str(NUGU_AUDIO_ATTRIBUTE_MUSIC), ==,
+		NUGU_AUDIO_ATTRIBUTE_MUSIC_DEFAULT_STRING);
+
+	// Empty String
+	nugu_audio_set_attribute_str(NUGU_AUDIO_ATTRIBUTE_MUSIC, "");
+	g_assert_cmpstr(
+		nugu_audio_get_attribute_str(NUGU_AUDIO_ATTRIBUTE_MUSIC), ==,
+		NUGU_AUDIO_ATTRIBUTE_MUSIC_DEFAULT_STRING);
+
+	// Set Multimedia
+	nugu_audio_set_attribute_str(NUGU_AUDIO_ATTRIBUTE_MUSIC, "Multimedia");
+	g_assert_cmpstr(
+		nugu_audio_get_attribute_str(NUGU_AUDIO_ATTRIBUTE_MUSIC), ==,
+		"Multimedia");
+
+	// Can set Multimedia other audio attribute
+	nugu_audio_set_attribute_str(NUGU_AUDIO_ATTRIBUTE_VOICE_COMMAND,
+				     "Multimedia");
+	g_assert_cmpstr(nugu_audio_get_attribute_str(
+				NUGU_AUDIO_ATTRIBUTE_VOICE_COMMAND),
+			==, "Multimedia");
+}
+
+int main(int argc, char *argv[])
+{
+#if !GLIB_CHECK_VERSION(2, 36, 0)
+	g_type_init();
+#endif
+
+	g_test_init(&argc, &argv, NULL);
+	g_log_set_always_fatal((GLogLevelFlags)G_LOG_FATAL_MASK);
+
+	g_test_add_func("/audio/default", test_audio_default);
+	g_test_add_func("/audio/set_audio_attribute_str",
+			test_audio_attribute_str);
+
+	return g_test_run();
+}

--- a/tests/test_nugu_pcm.c
+++ b/tests/test_nugu_pcm.c
@@ -228,13 +228,15 @@ static void test_pcm_audio_attribute(void)
 	// default pcm audio attribute: voice command (string: voice)
 	g_assert(nugu_pcm_get_audio_attribute(pcm) ==
 		 NUGU_AUDIO_ATTRIBUTE_VOICE_COMMAND);
-	g_assert_cmpstr(nugu_pcm_get_audio_attribute_str(pcm), ==, "voice");
+	g_assert_cmpstr(nugu_pcm_get_audio_attribute_str(pcm), ==,
+			NUGU_AUDIO_ATTRIBUTE_VOICE_COMMAND_DEFAULT_STRING);
 
 	// change to music
 	nugu_pcm_set_audio_attribute(pcm, NUGU_AUDIO_ATTRIBUTE_MUSIC);
 	g_assert(nugu_pcm_get_audio_attribute(pcm) ==
 		 NUGU_AUDIO_ATTRIBUTE_MUSIC);
-	g_assert_cmpstr(nugu_pcm_get_audio_attribute_str(pcm), ==, "music");
+	g_assert_cmpstr(nugu_pcm_get_audio_attribute_str(pcm), ==,
+			NUGU_AUDIO_ATTRIBUTE_MUSIC_DEFAULT_STRING);
 
 	nugu_pcm_remove(pcm);
 	nugu_pcm_free(pcm);

--- a/tests/test_nugu_player.c
+++ b/tests/test_nugu_player.c
@@ -470,7 +470,7 @@ static void test_player_audio_attribute(void)
 	g_assert(nugu_player_get_audio_attribute(alarm_player) ==
 		 NUGU_AUDIO_ATTRIBUTE_MUSIC);
 	g_assert_cmpstr(nugu_player_get_audio_attribute_str(music_player), ==,
-			"music");
+			NUGU_AUDIO_ATTRIBUTE_MUSIC_DEFAULT_STRING);
 
 	// change to alarm
 	nugu_player_set_audio_attribute(alarm_player,
@@ -480,7 +480,7 @@ static void test_player_audio_attribute(void)
 	g_assert(nugu_player_get_audio_attribute(alarm_player) ==
 		 NUGU_AUDIO_ATTRIBUTE_ALARM);
 	g_assert_cmpstr(nugu_player_get_audio_attribute_str(alarm_player), ==,
-			"alarm");
+			NUGU_AUDIO_ATTRIBUTE_ALARM_DEFAULT_STRING);
 
 	nugu_player_remove(music_player);
 	nugu_player_remove(alarm_player);


### PR DESCRIPTION
The names of audio properties are framework-dependent. And the nugu
speaker synchronizes the name with the default audio properties.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>