### PR TITLE
Chips:change onReceiveRender argument type

### DIFF
--- a/examples/standalone/capability/chips_listener.cc
+++ b/examples/standalone/capability/chips_listener.cc
@@ -22,7 +22,7 @@ ChipsListener::ChipsListener()
 {
 }
 
-void ChipsListener::onReceiveRender(ChipsInfo&& chips_info)
+void ChipsListener::onReceiveRender(const ChipsInfo& chips_info)
 {
     if (!chips_info.contents.empty())
         std::cout << "[Chips] target:" << TARGET_TEXTS.at(chips_info.target) << std::endl;

--- a/examples/standalone/capability/chips_listener.hh
+++ b/examples/standalone/capability/chips_listener.hh
@@ -26,7 +26,7 @@ public:
     ChipsListener();
     virtual ~ChipsListener() = default;
 
-    void onReceiveRender(ChipsInfo&& chips_info) override;
+    void onReceiveRender(const ChipsInfo& chips_info) override;
 
 private:
     const std::map<ChipsTarget, std::string> TARGET_TEXTS {

--- a/include/capability/chips_interface.hh
+++ b/include/capability/chips_interface.hh
@@ -80,7 +80,7 @@ public:
      * @brief Notified when receiving Render directive from server.
      * @param[in] chips_info received datas for rendering voice command guide
      */
-    virtual void onReceiveRender(ChipsInfo&& chips_info) = 0;
+    virtual void onReceiveRender(const ChipsInfo& chips_info) = 0;
 };
 
 /**

--- a/src/capability/chips_agent.cc
+++ b/src/capability/chips_agent.cc
@@ -94,7 +94,7 @@ void ChipsAgent::parsingRender(const char* message)
         }
 
         if (chips_listener)
-            chips_listener->onReceiveRender(std::move(chips_info));
+            chips_listener->onReceiveRender(chips_info);
     } catch (std::out_of_range& e) {
         nugu_error("The target or chip.type is invalid");
     } catch (std::logic_error& e) {


### PR DESCRIPTION
When the onReceiveRender call is propagated in several times,
as the argument is moved by universal reference, it can only be used once.

So, it change the argument type to const reference for multiple usages.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>