### PR TITLE
base: add byte buffer manipulation to nugu_buffer

### DIFF
--- a/include/base/nugu_buffer.h
+++ b/include/base/nugu_buffer.h
@@ -73,9 +73,28 @@ void *nugu_buffer_free(NuguBuffer *buf, int is_data_free);
  * @param[in] buf buffer object
  * @param[in] data The data to add to the buffer.
  * @param[in] data_len Length of the data
- * @return added length
+ * @return added length (0 = failure)
  */
 size_t nugu_buffer_add(NuguBuffer *buf, const void *data, size_t data_len);
+
+/**
+ * @brief Append the data to buffer object
+ * @param[in] buf buffer object
+ * @param[in] byte The data to add to the buffer.
+ * @return added length (0 = failure)
+ */
+size_t nugu_buffer_add_byte(NuguBuffer *buf, unsigned char byte);
+
+/**
+ * @brief Append the data to buffer object
+ * @param[in] buf buffer object
+ * @param[in] pos position
+ * @param[in] byte The data to add to the buffer.
+ * @return Result
+ * @retval 0 success
+ * @retval -1 failure
+ */
+int nugu_buffer_set_byte(NuguBuffer *buf, size_t pos, unsigned char byte);
 
 /**
  * @brief Get the internal buffer

--- a/src/base/nugu_buffer.c
+++ b/src/base/nugu_buffer.c
@@ -105,19 +105,47 @@ static int _buffer_resize(NuguBuffer *buf, size_t needed)
 EXPORT_API size_t nugu_buffer_add(NuguBuffer *buf, const void *data,
 				  size_t data_len)
 {
-	g_return_val_if_fail(buf != NULL, -1);
-	g_return_val_if_fail(data != NULL, -1);
-	g_return_val_if_fail(data_len > 0, -1);
+	g_return_val_if_fail(buf != NULL, 0);
+	g_return_val_if_fail(data != NULL, 0);
+	g_return_val_if_fail(data_len > 0, 0);
 
 	if (buf->alloc_size - buf->index < data_len) {
 		if (_buffer_resize(buf, data_len) < 0)
-			return -1;
+			return 0;
 	}
 
 	memcpy(buf->data + buf->index, data, data_len);
 	buf->index += data_len;
 
 	return data_len;
+}
+
+EXPORT_API size_t nugu_buffer_add_byte(NuguBuffer *buf, unsigned char byte)
+{
+	g_return_val_if_fail(buf != NULL, 0);
+
+	if (buf->alloc_size - buf->index < 1) {
+		if (_buffer_resize(buf, 1) < 0)
+			return 0;
+	}
+
+	buf->data[buf->index] = byte;
+	buf->index += 1;
+
+	return 1;
+}
+
+EXPORT_API int nugu_buffer_set_byte(NuguBuffer *buf, size_t pos,
+				    unsigned char byte)
+{
+	g_return_val_if_fail(buf != NULL, -1);
+
+	if (pos > buf->index)
+		return -1;
+
+	buf->data[pos] = byte;
+
+	return 0;
 }
 
 EXPORT_API const void *nugu_buffer_peek(NuguBuffer *buf)

--- a/tests/test_nugu_buffer.c
+++ b/tests/test_nugu_buffer.c
@@ -44,11 +44,19 @@ static void test_buffer_default(void)
 
 	free(test);
 
+	g_assert(nugu_buffer_add(NULL, NULL, 0) == 0);
+	g_assert(nugu_buffer_add(NULL, "1234", 0) == 0);
+	g_assert(nugu_buffer_add(NULL, "1234", 4) == 0);
+	g_assert(nugu_buffer_add_byte(NULL, 0) == 0);
+	g_assert(nugu_buffer_set_byte(NULL, 0, 'A') == -1);
+
 	/* 10 bytes buffer */
 	buf = nugu_buffer_new(10);
 	g_assert(buf != NULL);
 	g_assert(nugu_buffer_get_size(buf) == 0);
 	g_assert(nugu_buffer_get_alloc_size(buf) == 10);
+	g_assert(nugu_buffer_add(buf, NULL, 0) == 0);
+	g_assert(nugu_buffer_add(buf, "1234", 0) == 0);
 
 	/* Fill 9 bytes */
 	g_assert(nugu_buffer_add(buf, "123456789", 9) == 9);
@@ -77,6 +85,14 @@ static void test_buffer_default(void)
 	peek_test = nugu_buffer_peek(buf);
 	g_assert(peek_test[44] == 'x');
 
+	g_assert(nugu_buffer_add_byte(buf, 'A') == 1);
+	peek_test = nugu_buffer_peek(buf);
+	g_assert(peek_test[45] == 'A');
+
+	g_assert(nugu_buffer_add_byte(buf, '\n') == 1);
+	peek_test = nugu_buffer_peek(buf);
+	g_assert(peek_test[46] == '\n');
+
 	g_assert(nugu_buffer_free(buf, 1) == NULL);
 }
 
@@ -84,9 +100,16 @@ static void test_buffer_byte(void)
 {
 	NuguBuffer *buf;
 	int pos;
+	const char *peek_test;
 
 	g_assert(nugu_buffer_find_byte(NULL, '0') == NUGU_BUFFER_NOT_FOUND);
 	g_assert(nugu_buffer_peek_byte(NULL, 0) == 0);
+
+	buf = nugu_buffer_new(1);
+	g_assert(buf != NULL);
+	g_assert(nugu_buffer_set_byte(buf, 0, 'a') == 0);
+	g_assert(nugu_buffer_set_byte(buf, 1, 'a') == -1);
+	g_assert(nugu_buffer_free(buf, 1) == NULL);
 
 	buf = nugu_buffer_new(0);
 	g_assert(buf != NULL);
@@ -106,6 +129,22 @@ static void test_buffer_byte(void)
 	g_assert(nugu_buffer_peek_byte(buf, 3) == 'd');
 	g_assert(nugu_buffer_peek_byte(buf, 4) == 'e');
 	g_assert(nugu_buffer_peek_byte(buf, 5) == 0);
+
+	g_assert(nugu_buffer_clear(buf) == 0);
+	g_assert(nugu_buffer_add_byte(buf, 'a') == 1);
+	g_assert(nugu_buffer_add_byte(buf, 'b') == 1);
+	g_assert(nugu_buffer_add_byte(buf, 'c') == 1);
+	g_assert(nugu_buffer_add_byte(buf, 'd') == 1);
+	g_assert(nugu_buffer_add_byte(buf, '\0') == 1);
+	g_assert(nugu_buffer_peek_byte(buf, 0) == 'a');
+	g_assert(nugu_buffer_peek_byte(buf, 1) == 'b');
+	g_assert(nugu_buffer_peek_byte(buf, 2) == 'c');
+	g_assert(nugu_buffer_peek_byte(buf, 3) == 'd');
+	g_assert(nugu_buffer_peek_byte(buf, 4) == '\0');
+	peek_test = nugu_buffer_peek(buf);
+	g_assert_cmpstr(peek_test, ==, "abcd");
+	g_assert(nugu_buffer_set_byte(buf, 1, 'B') == 0);
+	g_assert_cmpstr(peek_test, ==, "aBcd");
 
 	g_assert(nugu_buffer_free(buf, 1) == NULL);
 


### PR DESCRIPTION
Add `nugu_buffer_add_byte` and `nugu_buffer_set_byte` functions
to manipulate the nugu_buffer by byte.

Signed-off-by: Inho Oh <webispy@gmail.com>