### PR TITLE
DialogUXStateAggregator: fix issues detected by cppcheck

### DIFF
--- a/src/clientkit/dialog_ux_state_aggregator.cc
+++ b/src/clientkit/dialog_ux_state_aggregator.cc
@@ -32,7 +32,7 @@ struct DialogUXStateAggregator::Impl {
     bool is_multi_turn = false;
     std::string cur_dialog_id;
     std::string chips_dialog_id;
-    ChipsInfo chips;
+    ChipsInfo chips {};
 
     explicit Impl(ISessionManager* session_manager);
     void setState(DialogUXState state);
@@ -207,7 +207,7 @@ void DialogUXStateAggregator::Impl::setState(DialogUXState state)
     dialog_ux_state = state;
     bool session_active = isSessionActive();
     bool multi_turn = false;
-    ChipsInfo chips_info;
+    ChipsInfo chips_info {};
 
     if (dialog_ux_state == DialogUXState::Listening && (asr_initiator == ASRInitiator::EXPECT_SPEECH || session_active)) {
         multi_turn = is_multi_turn;

--- a/tests/clientkit/test_clientkit_dialog_ux_state_aggregator.cc
+++ b/tests/clientkit/test_clientkit_dialog_ux_state_aggregator.cc
@@ -150,11 +150,11 @@ private:
         return chips_info;
     }
 
-    ISessionManager* session_manager;
-    IASRListener* asr_listener;
-    ITTSListener* tts_listener;
-    IChipsListener* chips_listener;
-    IInteractionControlManagerListener* ic_manager_listener;
+    ISessionManager* session_manager = nullptr;
+    IASRListener* asr_listener = nullptr;
+    ITTSListener* tts_listener = nullptr;
+    IChipsListener* chips_listener = nullptr;
+    IInteractionControlManagerListener* ic_manager_listener = nullptr;
     DialogType dialog_type = DialogType::General;
     TTSState tts_state = TTSState::TTS_SPEECH_FINISH;
     std::string dialog_id;


### PR DESCRIPTION
It fix the issues detected by cppcheck about variable initialization.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>