### PR TITLE
DialogUXStateAggregator: adjust chips info management

### DIFF
--- a/src/clientkit/dialog_ux_state_aggregator.cc
+++ b/src/clientkit/dialog_ux_state_aggregator.cc
@@ -185,10 +185,8 @@ void DialogUXStateAggregator::onModeChanged(bool multi_turn)
 
     pimpl->is_multi_turn = multi_turn;
 
-    if (!pimpl->is_multi_turn) {
-        pimpl->chips = {};
+    if (!pimpl->is_multi_turn)
         pimpl->setIdleState();
-    }
 }
 
 /*******************************************************************************


### PR DESCRIPTION
Even if the multi-turn is deactivated, the chips info may be required.

As the deletion timing of chips info is ambiguous, instead of explicitly
deleting it, it is used after checking dialog id validity.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>