### PR TITLE
tests: fix http test case

### DIFF
--- a/tests/test_nugu_http.c
+++ b/tests/test_nugu_http.c
@@ -676,9 +676,6 @@ int main(int argc, char *argv[])
 	g_test_init(&argc, &argv, NULL);
 	g_log_set_always_fatal((GLogLevelFlags)G_LOG_FATAL_MASK);
 
-	nugu_http_init();
-	g_test_add_func("/http/download", test_nugu_http_download);
-
 	/*
 	 * If the "HTTP_TEST_SERVER" environment value is not set,
 	 * the HTTP test is skipped.
@@ -692,6 +689,8 @@ int main(int argc, char *argv[])
 
 	SERVER = getenv("HTTP_TEST_SERVER");
 
+	nugu_http_init();
+
 	g_test_add_func("/http/default", test_nugu_http_default);
 	g_test_add_func("/http/timeout", test_nugu_http_timeout);
 	g_test_add_func("/http/invalid_async", test_nugu_http_invalid_async);
@@ -704,6 +703,7 @@ int main(int argc, char *argv[])
 	g_test_add_func("/http/delete_sync", test_nugu_http_delete_sync);
 	g_test_add_func("/http/delete_async", test_nugu_http_delete_async);
 	g_test_add_func("/http/multiple_async", test_nugu_http_multiple_async);
+	g_test_add_func("/http/download", test_nugu_http_download);
 
 	return g_test_run();
 }


### PR DESCRIPTION
Fix the http test case to avoid external network connection when the
environment variable is not set.

Signed-off-by: Inho Oh <webispy@gmail.com>