### PR TITLE
packaging: fix libasan version in 20.04(focal)

### DIFF
--- a/packaging/focal/control
+++ b/packaging/focal/control
@@ -17,7 +17,7 @@ Build-Depends: debhelper (>=10),
 	libgstreamer-plugins-base1.0-dev,
 	libgstreamer1.0-dev,
 	ca-certificates,
-	libasan4
+	libasan5
 Standards-Version: 4.1.4
 
 Package: libnugu


### PR DESCRIPTION
Ubuntu 20.04(focal) version uses gcc 9.4.0. Therefore, libasan5
should be used, but libasan4 (for gcc v7) was set incorrectly.

Signed-off-by: GitHub <noreply@github.com>