### PR TITLE
SpeechRecognizerAggregator: change setWakeupModel return type

### DIFF
--- a/include/clientkit/speech_recognizer_aggregator_interface.hh
+++ b/include/clientkit/speech_recognizer_aggregator_interface.hh
@@ -113,8 +113,9 @@ public:
     /**
      * @brief Set wakeup model file.
      * @param[in] model_file wakeup model file
+     * @return true if set success, otherwise false
      */
-    virtual void setWakeupModel(const WakeupModelFile& model_file) = 0;
+    virtual bool setWakeupModel(const WakeupModelFile& model_file) = 0;
 
     /**
      * @brief Start detecting wakeup and progress recognizing speech after wakeup detected.

--- a/src/clientkit/speech_recognizer_aggregator.cc
+++ b/src/clientkit/speech_recognizer_aggregator.cc
@@ -77,15 +77,17 @@ void SpeechRecognizerAggregator::removeListener(ISpeechRecognizerAggregatorListe
     pimpl->listeners.erase(listener);
 }
 
-void SpeechRecognizerAggregator::setWakeupModel(const WakeupModelFile& model_file)
+bool SpeechRecognizerAggregator::setWakeupModel(const WakeupModelFile& model_file)
 {
     if (model_file.net.empty() || model_file.search.empty() || pimpl->isInvalid()) {
         nugu_error("It's failed to change wakeup model.");
-        return;
+        return false;
     }
 
     pimpl->asr_handler->stopRecognition();
     pimpl->wakeup_handler->changeModel(model_file);
+
+    return true;
 }
 
 void SpeechRecognizerAggregator::startListeningWithTrigger()

--- a/src/clientkit/speech_recognizer_aggregator.hh
+++ b/src/clientkit/speech_recognizer_aggregator.hh
@@ -37,7 +37,7 @@ public:
     // implements ISpeechRecognizerAggregator
     void addListener(ISpeechRecognizerAggregatorListener* listener) override;
     void removeListener(ISpeechRecognizerAggregatorListener* listener) override;
-    void setWakeupModel(const WakeupModelFile& model_file) override;
+    bool setWakeupModel(const WakeupModelFile& model_file) override;
     void startListeningWithTrigger() override;
     void startListening(float power_noise = 0, float power_speech = 0, ASRInitiator initiator = ASRInitiator::TAP) override;
     void stopListening(bool cancel = false) override;

--- a/tests/clientkit/test_clientkit_speech_recognizer_aggregator.cc
+++ b/tests/clientkit/test_clientkit_speech_recognizer_aggregator.cc
@@ -383,16 +383,16 @@ static void test_speech_recognizer_aggregator_set_wakeup_model(TestFixture* fixt
     };
 
     test_model_file = { ARIA_NET, ARIA_SEARCH };
-    fixture->speech_recognizer_aggregator->setWakeupModel(test_model_file);
+    g_assert(fixture->speech_recognizer_aggregator->setWakeupModel(test_model_file));
     checkWakeupInfo();
 
     // validation check (maintain previous value)
-    fixture->speech_recognizer_aggregator->setWakeupModel({});
+    g_assert(!fixture->speech_recognizer_aggregator->setWakeupModel({}));
     checkWakeupInfo();
 
     // change model
     test_model_file = { TINKERBELL_NET, TINKERBELL_SEARCH };
-    fixture->speech_recognizer_aggregator->setWakeupModel(test_model_file);
+    g_assert(fixture->speech_recognizer_aggregator->setWakeupModel(test_model_file));
     checkWakeupInfo();
 }
 


### PR DESCRIPTION
As the setWakeupModel result is required in some situation,
it change the return type from void to bool.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>