### PR TITLE
clientkit: fix nugu_runner wait blocking issue

### DIFF
--- a/src/clientkit/nugu_runner.cc
+++ b/src/clientkit/nugu_runner.cc
@@ -162,7 +162,8 @@ bool NuguRunner::invokeMethod(const std::string& tag, request_method method, Exe
         std::unique_lock<std::mutex> lk(mtx);
 
         if (timeout <= 0) {
-            d->cv.wait(lk);
+            if (d->done == 0)
+                d->cv.wait(lk);
             return true;
         }
 


### PR DESCRIPTION
add `d->done` value check before blocking-wait to avoid waiting if
the runner-job is already done.

Signed-off-by: Inho Oh <webispy@gmail.com>