### PR TITLE
Chips: fix ChipsInfo ODR issue

### DIFF
--- a/include/capability/chips_interface.hh
+++ b/include/capability/chips_interface.hh
@@ -56,7 +56,7 @@ enum class ChipsType {
  * @brief Model for holding chips Info.
  * @see IChipsListener::onReceiveRender
  */
-typedef struct {
+typedef struct _ChipsInfo {
     struct Content {
         ChipsType type; /**< chips type */
         std::string text; /**< text for voice command guide */


### PR DESCRIPTION
It fix not to be occurred ODR(one definition rule) warning in ChipsInfo
as declaring struct name explicitly when building in ubuntu 22.04(jammy).

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>