### PR TITLE
tests: remove test target source duplication

### DIFF
--- a/tests/clientkit/CMakeLists.txt
+++ b/tests/clientkit/CMakeLists.txt
@@ -6,18 +6,8 @@ SET(UNIT_TESTS
 	test_clientkit_dialog_ux_state_aggregator
 	test_clientkit_speech_recognizer_aggregator)
 
-# Add Compile Sources with Mock for test
-SET(test_clientkit_nugu_runner_srcs ../../src/clientkit/nugu_runner.cc)
-SET(test_clientkit_capability_srcs ../../src/clientkit/capability.cc)
-SET(test_clientkit_dialog_ux_state_aggregator_srcs ../../src/clientkit/dialog_ux_state_aggregator.cc)
-SET(test_clientkit_speech_recognizer_aggregator_srcs ../../src/clientkit/speech_recognizer_aggregator.cc)
-
 FOREACH(test ${UNIT_TESTS})
-	SET(SRC ${test}.cc)
-	IF (${test}_srcs)
-		LIST(APPEND SRC ${${test}_srcs})
-	ENDIF ()
-	ADD_EXECUTABLE(${test} ${SRC})
+	ADD_EXECUTABLE(${test} ${test}.cc)
 	TARGET_COMPILE_DEFINITIONS(${test} PRIVATE
 		-DRUNPATH="${CMAKE_CURRENT_BINARY_DIR}")
 	TARGET_INCLUDE_DIRECTORIES(${test} PRIVATE

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -9,15 +9,7 @@ SET(UNIT_TESTS
 	test_core_routine_manager)
 
 # Add Compile Sources with Mock for test
-SET(test_core_nugu_timer_srcs
-	test_core_nugu_timer_mock.cc ../../src/core/nugu_timer.cc)
-SET(test_core_focus_manager_srcs ../../src/core/focus_manager.cc)
-SET(test_core_directive_sequencer_srcs ../../src/core/directive_sequencer.cc)
-SET(test_core_session_manager_srcs ../../src/core/session_manager.cc)
-SET(test_core_playstack_manager_srcs ../../src/core/playstack_manager.cc)
-SET(test_core_playsync_manager_srcs ../../src/core/playsync_manager.cc)
-SET(test_core_interaction_control_manager_srcs ../../src/core/interaction_control_manager.cc)
-SET(test_core_routine_manager_srcs ../../src/core/routine_manager.cc)
+SET(test_core_nugu_timer_srcs test_core_nugu_timer_mock.cc)
 
 FOREACH(test ${UNIT_TESTS})
 	SET(SRC ${test}.cc)


### PR DESCRIPTION
It fix not to include the test target source duplicately
as it's already linked by lnugu.

It could prevent ODR issue which is occurred from ASAN.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>