### PR TITLE
plugins: fix memory leak of speex

### DIFF
--- a/plugins/speex.c
+++ b/plugins/speex.c
@@ -204,6 +204,7 @@ int _encoder_destroy(NuguEncoderDriver *driver, NuguEncoder *enc)
 			ed->dump_fd = -1;
 		}
 #endif
+		free(ed);
 	}
 
 	nugu_encoder_set_driver_data(enc, NULL);


### PR DESCRIPTION
The memory for encoder_data is allocated but not freed, resulting leak.
(It only free the buffer currently.)

So, it fix to free the allocated memory in destroyed time.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>