### PR TITLE
plugins: fix memory leak of opus encoder

### DIFF
--- a/plugins/opus_encoder.c
+++ b/plugins/opus_encoder.c
@@ -121,6 +121,7 @@ static void setup_opus_head(struct opus_data *od)
 	p_head.packetno = od->packetno++;
 	ogg_stream_packetin(&(od->os), &p_head);
 
+	free(p_head.packet);
 	nugu_buffer_free(header, 1);
 }
 
@@ -145,6 +146,7 @@ static void setup_opus_tags(struct opus_data *od)
 	p_tags.packetno = od->packetno++;
 	ogg_stream_packetin(&(od->os), &p_tags);
 
+	free(p_tags.packet);
 	nugu_buffer_free(header, 1);
 }
 


### PR DESCRIPTION
The ogg_packet.packet which memory is allocated before calling
ogg_stream_packetin is not freed, so it result memory leak.

So, it fix to free the allocated memory after calling ogg_stream_packetin.

Because the ogg_packet data is copied in ogg_stream_packetin internally,
it's no problem manipulate ogg_packet after calling ogg_stream_packetin.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>