### PR TITLE
wakeup: add wakeup idle state

### DIFF
--- a/examples/standalone/clientkit/speech_recognizer_aggregator_listener.cc
+++ b/examples/standalone/clientkit/speech_recognizer_aggregator_listener.cc
@@ -73,6 +73,9 @@ SpeechRecognizerAggregatorListener::SpeechRecognizerAggregatorListener(const std
 void SpeechRecognizerAggregatorListener::onWakeupState(WakeupDetectState state, float power_noise, float power_speech)
 {
     switch (state) {
+    case WakeupDetectState::WAKEUP_IDLE:
+        msg::wakeup::state("wakeup idle");
+        break;
     case WakeupDetectState::WAKEUP_DETECTING:
         msg::wakeup::state("wakeup detecting (" + wakeup_word + ")...");
         break;

--- a/include/clientkit/wakeup_interface.hh
+++ b/include/clientkit/wakeup_interface.hh
@@ -34,6 +34,7 @@ namespace NuguClientKit {
  * @brief WakeupDetectState
  */
 enum class WakeupDetectState {
+    WAKEUP_IDLE, /**< Initial state */
     WAKEUP_DETECTING, /**< Wakeup word detecting */
     WAKEUP_DETECTED, /**< Wakeup word is detected */
     WAKEUP_FAIL /**< Failure */

--- a/tests/clientkit/test_clientkit_speech_recognizer_aggregator.cc
+++ b/tests/clientkit/test_clientkit_speech_recognizer_aggregator.cc
@@ -336,7 +336,7 @@ public:
     }
 
 private:
-    SpeechRecognizerAggregatorState aggregate_state { WakeupDetectState::WAKEUP_FAIL, ASRState::IDLE };
+    SpeechRecognizerAggregatorState aggregate_state { WakeupDetectState::WAKEUP_IDLE, ASRState::IDLE };
     RecognitionResult result {};
     std::string dialog_id;
 };
@@ -400,7 +400,7 @@ static void test_speech_recognizer_aggregator_start_listening_with_trigger(TestF
 {
     const auto& state = fixture->listener->getState();
 
-    g_assert(state.wakeup != WakeupDetectState::WAKEUP_DETECTING);
+    g_assert(state.wakeup == WakeupDetectState::WAKEUP_IDLE);
     g_assert(state.asr == ASRState::IDLE);
 
     fixture->speech_recognizer_aggregator->startListeningWithTrigger();
@@ -578,7 +578,7 @@ static void test_speech_recognizer_aggregator_no_wakeup_handler(TestFixture* fix
 
     const auto& state = fixture->listener->getState();
 
-    g_assert(state.wakeup != WakeupDetectState::WAKEUP_DETECTING);
+    g_assert(state.wakeup == WakeupDetectState::WAKEUP_IDLE);
     g_assert(state.asr == ASRState::IDLE);
 
     speech_recognizer_aggregator->startListening();


### PR DESCRIPTION
It add the WakeupDetectState WAKEUP_IDLE to indicate the initial state.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>