### PR TITLE
base: fix memory leak in http2 network module

### DIFF
--- a/src/base/network/http2/http2_network.c
+++ b/src/base/network/http2/http2_network.c
@@ -405,6 +405,7 @@ static void *_loop(void *data)
 			curl_easy_getinfo(easy, CURLINFO_EFFECTIVE_URL, &url);
 
 			nugu_dbg("remove incomplete req=%p (%s)", fake_p, url);
+			curl_multi_remove_handle(net->handle, easy);
 			http2_request_unref((HTTP2Request *)fake_p);
 			cur = cur->next;
 		}


### PR DESCRIPTION
Add missing `curl_multi_remove_handle()` call to cleanup logic for
incomplete HTTP/2 requests.

Signed-off-by: Inho Oh <webispy@gmail.com>