### PR TITLE
wakeup: change handling wakeup stop state

### DIFF
--- a/src/core/wakeup_detector.hh
+++ b/src/core/wakeup_detector.hh
@@ -28,6 +28,7 @@ enum class WakeupState {
     FAIL,
     DETECTING,
     DETECTED,
+    STOPPED,
     DONE
 };
 

--- a/src/core/wakeup_handler.cc
+++ b/src/core/wakeup_handler.cc
@@ -72,6 +72,14 @@ void WakeupHandler::onWakeupState(WakeupState state, const std::string& id, floa
         if (listener)
             listener->onWakeupState(WakeupDetectState::WAKEUP_DETECTED, noise, speech);
         break;
+    case WakeupState::STOPPED:
+        nugu_dbg("[id: %s] WakeupState::STOPPED", id.c_str());
+
+        if (listener)
+            listener->onWakeupState(WakeupDetectState::WAKEUP_IDLE, noise, speech);
+
+        break;
+
     case WakeupState::DONE:
         nugu_dbg("[id: %s] WakeupState::DONE", id.c_str());
         break;


### PR DESCRIPTION
In previously, even if the wakeup is stopped by user explicitly,
the state is WakeupDetectState::WAKEUP_FAIL.

As it's judged unreasonable, it change to WakeupDetectState::WAKEUP_IDLE.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>