### PR TITLE
upgrade clang-tidy-action to v1.2

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           submodules: true
       - name: Run clang-tidy review
-        uses: kimhyungrok/clang-tidy-action@v1
+        uses: kimhyungrok/clang-tidy-action@v1.2
         with:
           exclude: 'externals'
 


### PR DESCRIPTION
It upgrade the clang-tidy-action to v1.2 activating on ubuntu focal.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>