### PR TITLE
upgrade clang-tidy-action to v1.2

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           submodules: true
       - name: Run clang-tidy review
-        uses: kimhyungrok/clang-tidy-action@v1
+        uses: kimhyungrok/clang-tidy-action@v1.2
         with:
           exclude: 'externals'
 

--- a/examples/standalone/capability/tts_listener.cc
+++ b/examples/standalone/capability/tts_listener.cc
@@ -57,7 +57,7 @@ void TTSListener::onTTSCancel(const std::string& dialog_id)
     std::cout << "[TTS][id:" << dialog_id << "] CANCEL... " << std::endl;
 }
 
-std::string TTSListener::extractText(std::string raw_text)
+std::string TTSListener::extractText(const std::string& raw_text)
 {
     // remove '< ~ >' tag
     std::string extracted_text;

--- a/examples/standalone/capability/tts_listener.hh
+++ b/examples/standalone/capability/tts_listener.hh
@@ -30,7 +30,7 @@ public:
     void onTTSCancel(const std::string& dialog_id) override;
 
 private:
-    std::string extractText(std::string raw_text);
+    std::string extractText(const std::string& raw_text);
 
     const std::string WAKEUP_WORD_TAG = "{W}";
     const std::string WAKEUP_WORD = "아리아"; // It skip to get wakeup word from NuguCoreContainer

--- a/examples/standalone/nugu_sdk_manager.cc
+++ b/examples/standalone/nugu_sdk_manager.cc
@@ -312,7 +312,7 @@ void NuguSDKManager::setDefaultSoundLayerPolicy()
 void NuguSDKManager::setAdditionalExecutor()
 {
     nugu_sample_manager->setTextCommander(
-        [&](std::string text, bool include_dialog_attribute) {
+        [&](const std::string& text, bool include_dialog_attribute) {
             text_handler->requestTextInput(text, "", "USERINPUT", include_dialog_attribute);
         });
     nugu_sample_manager->setPlayStackRetriever([&]() {

--- a/src/capability/display_agent.cc
+++ b/src/capability/display_agent.cc
@@ -396,6 +396,7 @@ void DisplayAgent::sendEventControlFocusFailed(const std::string& ps_id, Control
 void DisplayAgent::sendEventControlScrollSucceeded(const std::string& ps_id, ControlDirection direction)
 {
     sendEventControl("ControlScrollSucceeded", ps_id, direction,
+        // NOLINTNEXTLINE(cert-dcl50-cpp)
         [&](...) {
             interaction_control_manager->finish(interaction_mode, getName());
         });

--- a/src/capability/display_render_helper.cc
+++ b/src/capability/display_render_helper.cc
@@ -239,7 +239,7 @@ void DisplayRenderHelper::removedRenderInfo(const std::string& id) noexcept
 
 void DisplayRenderHelper::clear()
 {
-    for (auto info : render_infos)
+    for (const auto& info : render_infos)
         delete info.second;
 
     render_infos.clear();

--- a/src/capability/message_agent.cc
+++ b/src/capability/message_agent.cc
@@ -154,9 +154,11 @@ void MessageAgent::candidatesListed(const std::string& context_template, const s
     }
 
     this->context_template = context_template;
-    sendEvent("CandidatesListed", capa_helper->makeAllContextInfo(), writer.write(root), [&](...) {
-        finishInteractionControl();
-    });
+    sendEvent("CandidatesListed", capa_helper->makeAllContextInfo(), writer.write(root),
+        // NOLINTNEXTLINE(cert-dcl50-cpp)
+        [&](...) {
+            finishInteractionControl();
+        });
 }
 
 void MessageAgent::sendMessageSucceeded(const std::string& payload)
@@ -319,9 +321,11 @@ void MessageAgent::sendEventGetMessage(std::string&& event_name, const std::stri
         interaction_control_payloads.second.clear();
     }
 
-    sendEvent(event_name, getContextInfo(), writer.write(root), [&](...) {
-        finishInteractionControl();
-    });
+    sendEvent(event_name, getContextInfo(), writer.write(root),
+        // NOLINTNEXTLINE(cert-dcl50-cpp)
+        [&](...) {
+            finishInteractionControl();
+        });
 }
 
 void MessageAgent::sendEventReadMessageFinished(EventResultCallback cb)

--- a/src/core/audio_recorder_manager.cc
+++ b/src/core/audio_recorder_manager.cc
@@ -95,7 +95,7 @@ AudioRecorderManager::~AudioRecorderManager()
 {
     std::lock_guard<std::mutex> lock(mutex);
 
-    for (auto container : nugu_recorders)
+    for (const auto& container : nugu_recorders)
         nugu_recorder_free(container.second);
     nugu_recorders.clear();
 }
@@ -204,7 +204,7 @@ bool AudioRecorderManager::setMute(bool mute)
     muted = mute;
 
     if (muted == false) {
-        for (auto container : nugu_recorders)
+        for (const auto& container : nugu_recorders)
             nugu_recorder_clear(container.second);
     }
 

--- a/src/core/focus_manager.cc
+++ b/src/core/focus_manager.cc
@@ -269,10 +269,10 @@ void FocusManager::setConfigurations(std::vector<FocusConfiguration>& request, s
     request_configuration_map.clear();
     release_configuration_map.clear();
 
-    for (auto configuration : request)
+    for (const auto& configuration : request)
         request_configuration_map[configuration.type] = configuration.priority;
 
-    for (auto configuration : release)
+    for (const auto& configuration : release)
         release_configuration_map[configuration.type] = configuration.priority;
 
     printConfigurations();
@@ -379,10 +379,10 @@ void FocusManager::onFocusChanged(const std::string& type, const std::string& na
 void FocusManager::printConfigurations()
 {
     nugu_info("Focus Resource Configurtaion  =================");
-    for (auto configuration : request_configuration_map)
+    for (const auto& configuration : request_configuration_map)
         nugu_info("Request - priority:%4d, type: %s", configuration.second, configuration.first.c_str());
     nugu_info("-----------------------------------------------");
-    for (auto configuration : release_configuration_map)
+    for (const auto& configuration : release_configuration_map)
         nugu_info("Release - priority:%4d, type: %s", configuration.second, configuration.first.c_str());
     nugu_info("===============================================");
 }

--- a/tests/core/test_core_playsync_manager.cc
+++ b/tests/core/test_core_playsync_manager.cc
@@ -638,7 +638,7 @@ static void test_playsync_manager_implicit_release_sync_later(TestFixture* fixtu
 
 static void test_playsync_manager_release_sync_later_in_stack_condition(TestFixture* fixture, gconstpointer ignored)
 {
-    auto execMediaStackedSync = [&](std::function<void()> case_checker) {
+    auto execMediaStackedSync = [&](std::function<void()>&& case_checker) {
         fixture->playsync_manager->prepareSync("ps_id_1", fixture->ndir_media);
         fixture->playsync_manager->startSync("ps_id_1", "TTS");
         fixture->playsync_manager->startSync("ps_id_1", "AudioPlayer");

--- a/tests/core/test_core_routine_manager.cc
+++ b/tests/core/test_core_routine_manager.cc
@@ -110,7 +110,7 @@ private:
 
 class RoutineTestHelper {
 public:
-    void composeActions(std::vector<RoutineTestData> test_datas)
+    void composeActions(std::vector<RoutineTestData>&& test_datas)
     {
         actions.clear();
 


### PR DESCRIPTION
It upgrade the clang-tidy-action to v1.2 activating on ubuntu 20.04.

It fix to use const/universal reference for copied value usage detection.
* performance-for-range-copy
* performance-unnecessary-value-param

It suppress the C-style variadic function usage because it seems fair use.
(It would upgrade clang-tidy-action to be able to handle this properly.)
* cert-dcl50-cpp

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>