### PR TITLE
build: apply -fanalyzer compile option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,7 +218,17 @@ ENDIF()
 # the library already installed on the system.
 LINK_LIBRARIES(-L${CMAKE_BINARY_DIR}/src)
 
-IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+IF (CMAKE_COMPILER_IS_GNUCC)
+	# Enable a new static analysis pass and associated warnings. (Introduced gcc v10.1)
+	# This option will not work if LTO is enabled.
+	IF (CMAKE_C_COMPILER_VERSION VERSION_GREATER 10.1)
+		# It is recommended to use only C language.
+		STRING(APPEND CMAKE_C_FLAGS " -fanalyzer")
+
+		# Not errors
+		STRING(APPEND CMAKE_C_FLAGS " -Wno-analyzer-possible-null-dereference")
+	ENDIF()
+
 	ADD_COMPILE_OPTIONS(
 		# Non-executable stack
 		-Wa,--execstack

--- a/include/base/nugu_plugin.h
+++ b/include/base/nugu_plugin.h
@@ -137,7 +137,8 @@ void nugu_plugin_free(NuguPlugin *p);
  * @param[in] p plugin object
  * @return result
  * @retval 0 success
- * @retval -1 failure
+ * @retval 1 success (plugin is already registered)
+ * @retval -1 failure (another plugin using the same file is already registered)
  * @see nugu_plugin_find()
  * @see nugu_plugin_remove()
  */

--- a/tests/test_nugu_plugin.c
+++ b/tests/test_nugu_plugin.c
@@ -150,6 +150,7 @@ static void test_plugin_init_fail(void)
 static void test_plugin_load(void)
 {
 	NuguPlugin *plugin;
+	NuguPlugin *plugin2;
 	int (*custom_add)(int a, int b);
 
 	/* File does not exist. */
@@ -168,6 +169,17 @@ static void test_plugin_load(void)
 	/* There is no 'custom_add' symbol in this plugin. */
 	g_assert(nugu_plugin_get_symbol(plugin, "custom_add") == NULL);
 
+	g_assert(nugu_plugin_add(plugin) == 0);
+	g_assert(nugu_plugin_add(plugin) == 1);
+
+	/* Attempt to add plugin with same file path */
+	plugin2 = nugu_plugin_new_from_file(PLUGIN_NUGU);
+	g_assert(plugin2 != NULL);
+
+	g_assert(nugu_plugin_add(plugin2) == -1);
+	nugu_plugin_free(plugin2);
+
+	g_assert(nugu_plugin_remove(plugin) == 0);
 	nugu_plugin_free(plugin);
 
 	/* nugu plugin with custom symbol */
@@ -214,12 +226,13 @@ static void test_plugin_default(void)
 	p = nugu_plugin_new(&test_plugin_desc);
 	g_assert(p != NULL);
 
+	nugu_plugin_initialize();
+
 	g_assert(nugu_plugin_find("test") == NULL);
 	g_assert(nugu_plugin_add(p) == 0);
+	g_assert(nugu_plugin_add(p) == 1);
 	g_assert(nugu_plugin_find("test") == p);
 
-	nugu_plugin_initialize();
-	g_assert(nugu_plugin_find("test") == p);
 	nugu_plugin_deinitialize();
 
 	g_assert(nugu_plugin_find("test") == NULL);


### PR DESCRIPTION
Apply the `-fanalyzer` compile option to enable static analyzer.
This option only works for C language (C++ is currently recommended)

https://gcc.gnu.org/onlinedocs/gcc-10.1.0/gcc/Static-Analyzer-Options.html

Signed-off-by: Inho Oh <webispy@gmail.com>