### PR TITLE
clientkit: add async API to auth discovery

### DIFF
--- a/include/clientkit/nugu_auth.hh
+++ b/include/clientkit/nugu_auth.hh
@@ -94,6 +94,15 @@ public:
     bool discovery();
 
     /**
+     * @brief Async OAuth2 discovery to get OAuth2 end-point and server url
+     * @param[in] cb callback function to receive response
+     * @return result
+     * @retval true success
+     * @retval false failure
+     */
+    bool discovery(const std::function<void(bool success)> &cb);
+
+    /**
      * @brief Check whether the requested grant type is supported for the client
      * @param[in] gtype grant type
      * @return result

--- a/tests/clientkit/test_clientkit_auth.cc
+++ b/tests/clientkit/test_clientkit_auth.cc
@@ -67,6 +67,26 @@ static void test_nugu_auth_discovery()
     g_assert(auth->discovery() == true);
     g_assert(auth->getGatewayRegistryUri().size() != 0);
     g_assert(auth->getTemplateServerUri().size() != 0);
+
+    /* Async request */
+    GMainLoop* loop;
+    loop = g_main_loop_new(NULL, FALSE);
+    int check_value = 0;
+
+    g_assert(auth->discovery([&](bool success) {
+        g_assert(success == true);
+        g_assert(check_value == 0);
+
+        check_value = 1;
+        g_main_loop_quit(loop);
+    }) == true);
+
+    g_main_loop_run(loop);
+    g_main_loop_unref(loop);
+
+    g_assert(check_value == 1);
+    g_assert(auth->getGatewayRegistryUri().size() != 0);
+    g_assert(auth->getTemplateServerUri().size() != 0);
 }
 
 static void test_nugu_auth_url()


### PR DESCRIPTION
Add `discovery(callback)` API to support async requests to the
auth module. The response callback can get the result of discovery
success or failure just like the sync API.

Signed-off-by: Inho Oh <webispy@gmail.com>