### PR TITLE
build: apply debian packaging default link option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,6 +249,9 @@ IF (CMAKE_COMPILER_IS_GNUCC)
 		# Non-executable stack
 		LINK_LIBRARIES(-Wl,-z,noexecstack)
 
+		# Debian packaging default link flags
+		LINK_LIBRARIES(-Wl,-Bsymbolic-functions -Wl,-z,relro)
+
 		# RPATH is useful only for testing without installation.
 		# Please use the '-DPACKAGING' option for debian packaging.
 		IF (NOT PACKAGING)


### PR DESCRIPTION
Apply the default link options used for debian packaging builds.
The link options can be checked with the `dpkg-buildflags` command,
and the options according to the distribution version are as follows.

    bionic
    LDFLAGS=-Wl,-Bsymbolic-functions -Wl,-z,relro

    focal
    LDFLAGS=-Wl,-Bsymbolic-functions -Wl,-z,relro

    jammy
    LDFLAGS=-Wl,-Bsymbolic-functions -flto=auto -ffat-lto-objects
            -flto=auto -Wl,-z,relro

Signed-off-by: Inho Oh <inho.oh@sk.com>