### PR TITLE
add tag name to anonymous structure

### DIFF
--- a/include/capability/asr_interface.hh
+++ b/include/capability/asr_interface.hh
@@ -80,7 +80,7 @@ enum class ASRError {
  * @brief Attributes for setting ASR options.
  * @see IASRHandler::setAttribute
  */
-typedef struct {
+typedef struct _ASRAttribute {
     std::string model_path; /**< Epd model file path */
     std::string epd_type; /**< Epd type : CLIENT, SERVER */
     std::string asr_encoding; /**< Asr encoding type : PARTIAL, COMPLETE */

--- a/include/capability/battery_interface.hh
+++ b/include/capability/battery_interface.hh
@@ -37,7 +37,7 @@ using namespace NuguClientKit;
 /**
  * @brief Battery Information
  */
-typedef struct {
+typedef struct _BatteryInfo {
     int level = -1; /**< battery level (0 ~ 100) */
     bool charging = false; /**< whether the battery is charged */
     bool approximate_level = false; /**< approximate battery level */

--- a/include/capability/bluetooth_interface.hh
+++ b/include/capability/bluetooth_interface.hh
@@ -38,7 +38,7 @@ using namespace NuguClientKit;
  * @brief Bluetooth profiles information
  * @see BTDeviceInfo
  */
-typedef struct {
+typedef struct _BTProfile {
     std::string name; /**< profile name (reference by https://www.bluetooth.com/specifications/specs/) */
     bool enable; /**< profile usage */
 } BTProfile;
@@ -47,7 +47,7 @@ typedef struct {
  * @brief Bluetooth device information
  * @see IBluetoothListener::setDeviceInformation
  */
-typedef struct {
+typedef struct _BTDeviceInfo {
     std::string device_name; /**< bluetooth adaptor's name */
     bool power_on; /**< bluetooth adaptor's power on state */
     std::vector<BTProfile> profiles; /**< paired 2nd device's profiles */

--- a/include/capability/display_interface.hh
+++ b/include/capability/display_interface.hh
@@ -53,7 +53,7 @@ enum class TemplateControlType {
 /**
  * @brief Display Context Information
  */
-typedef struct {
+typedef struct _DisplayContextInfo {
     std::string focused_item_token; /**< a unique identifier to identify the focused item */
     std::vector<std::string> visible_token_list; /**< unique identifier list to identify the items being displayed */
 } DisplayContextInfo;

--- a/include/capability/location_interface.hh
+++ b/include/capability/location_interface.hh
@@ -37,7 +37,7 @@ using namespace NuguClientKit;
 /**
  * @brief Location Information
  */
-typedef struct {
+typedef struct _LocationInfo {
     std::string latitude; /**< latitude coordinates */
     std::string longitude; /**< longitude coordinates */
 } LocationInfo;

--- a/include/capability/text_interface.hh
+++ b/include/capability/text_interface.hh
@@ -54,7 +54,7 @@ enum class TextError {
 /**
  * @brief Attributes for setting Text options.
  */
-typedef struct {
+typedef struct _TextAttribute {
     int response_timeout; /**< Server response timeout about sent text */
 } TextAttribute;
 

--- a/include/capability/tts_interface.hh
+++ b/include/capability/tts_interface.hh
@@ -48,7 +48,7 @@ enum class TTSState {
 /**
  * @brief Attributes for setting TTS options.
  */
-typedef struct {
+typedef struct _TTSAttribute {
     std::string tts_engine; /**< TTS engine type */
 } TTSAttribute;
 

--- a/include/clientkit/capability_interface.hh
+++ b/include/clientkit/capability_interface.hh
@@ -42,7 +42,7 @@ namespace NuguClientKit {
 /**
  * @brief Policy about canceling directives which are belong to the specific dialog id.
  */
-typedef struct {
+typedef struct _DirectiveCancelPolicy {
     bool cancel_all; /**< cancel all directives or selections */
     std::set<std::string> dir_groups; /**< directive groups for canceling */
 } DirectiveCancelPolicy;

--- a/include/clientkit/directive_sequencer_interface.hh
+++ b/include/clientkit/directive_sequencer_interface.hh
@@ -48,7 +48,7 @@ enum class BlockingMedium {
 /**
  * @brief BlockingPolicy
  */
-typedef struct {
+typedef struct _BlockingPolicy {
     BlockingMedium medium; /**< BlockingMedium */
     bool isBlocking; /**< true: Blocking, false: Non-blocking */
 } BlockingPolicy;

--- a/include/clientkit/focus_manager_interface.hh
+++ b/include/clientkit/focus_manager_interface.hh
@@ -81,7 +81,7 @@ enum class FocusState {
 /**
  * @brief FocusConfiguration
  */
-typedef struct {
+typedef struct _FocusConfiguration {
     std::string type; /**< focus type */
     int priority; /**< focus priority */
 } FocusConfiguration;

--- a/include/clientkit/session_manager_interface.hh
+++ b/include/clientkit/session_manager_interface.hh
@@ -37,7 +37,7 @@ namespace NuguClientKit {
  * @brief Model for containing session info.
  * @see ISessionManager
  */
-typedef struct {
+typedef struct _Session {
     std::string session_id; /**< session id */
     std::string ps_id; /**< play service id */
 } Session;

--- a/include/clientkit/speech_recognizer_aggregator_interface.hh
+++ b/include/clientkit/speech_recognizer_aggregator_interface.hh
@@ -42,7 +42,7 @@ using namespace NuguCapability;
  * @brief Model for holding recognition result.
  * @see ISpeechRecognizerAggregatorListener::onResult
  */
-typedef struct {
+typedef struct _RecognitionResult {
     /**
      * @brief Result status
      */

--- a/include/clientkit/speech_recognizer_interface.hh
+++ b/include/clientkit/speech_recognizer_interface.hh
@@ -48,7 +48,7 @@ enum class ListeningState {
 /**
  * @brief Attributes about epd.
  */
-typedef struct {
+typedef struct _EpdAttribute {
     int epd_timeout; /**< epd timeout sec */
     int epd_max_duration; /**< epd max duration sec */
     long epd_pause_length; /**< epd pause length msec */

--- a/include/clientkit/wakeup_interface.hh
+++ b/include/clientkit/wakeup_interface.hh
@@ -46,7 +46,7 @@ enum class WakeupDetectState {
  * @brief Model for holding Wakeup model file info.
  * @see IWakeupHandler::changeModel
  */
-typedef struct {
+typedef struct _WakeupModelFile {
     std::string net; /**< model net file */
     std::string search; /**< model search file */
 } WakeupModelFile;

--- a/src/capability/display_agent.hh
+++ b/src/capability/display_agent.hh
@@ -58,7 +58,7 @@ public:
     void onDataChanged(const std::string& ps_id, std::pair<void*, void*> extra_datas) override;
 
 private:
-    using HistoryControl = struct {
+    using HistoryControl = struct _HistoryControl {
         bool parent = false;
         bool child = false;
         std::string parent_token;
@@ -67,7 +67,7 @@ private:
         bool is_render = false;
     };
 
-    using DisplayContextCollection = struct : DisplayContextInfo {
+    using DisplayContextCollection = struct _DisplayContextCollection: DisplayContextInfo {
         std::string ps_id;
         std::string token;
     };

--- a/src/capability/display_render_helper.hh
+++ b/src/capability/display_render_helper.hh
@@ -25,7 +25,7 @@
 
 namespace NuguCapability {
 
-typedef struct {
+typedef struct _DisplayRenderInfo {
     std::string id;
     std::string type;
     std::string view;

--- a/src/capability/text_agent.hh
+++ b/src/capability/text_agent.hh
@@ -49,7 +49,7 @@ public:
     void onStackChanged(const std::pair<std::string, std::string>& ps_ids) override;
 
 private:
-    using TextInputParam = struct {
+    using TextInputParam = struct _TextInputParam {
         std::string text;
         std::string token;
         std::string ps_id;
@@ -57,7 +57,7 @@ private:
         Json::Value interaction_control;
     };
 
-    using ExpectTypingInfo = struct {
+    using ExpectTypingInfo = struct _ExpectTypingInfo {
         bool is_handle = false;
         std::string playstack;
         Json::Value payload;

--- a/src/core/playstack_manager.hh
+++ b/src/core/playstack_manager.hh
@@ -50,7 +50,7 @@ public:
 class PlayStackManager {
 public:
     using PlayStack = std::pair<std::map<std::string, PlayStackActivity>, std::vector<std::string>>;
-    using PlayStackHoldTimes = struct {
+    using PlayStackHoldTimes = struct _PlayStackHoldTimes {
         unsigned int normal_time;
         unsigned int long_time;
     };

--- a/src/core/routine_manager.hh
+++ b/src/core/routine_manager.hh
@@ -32,7 +32,7 @@ using namespace NuguClientKit;
 
 class RoutineManager : public IRoutineManager {
 public:
-    using RoutineAction = struct {
+    using RoutineAction = struct _RoutineAction {
         std::string type;
         std::string play_service_id;
         std::string text;

--- a/src/core/speech_recognizer.hh
+++ b/src/core/speech_recognizer.hh
@@ -27,7 +27,7 @@ using namespace NuguClientKit;
 class SpeechRecognizer : public ISpeechRecognizer,
                          public AudioInputProcessor {
 public:
-    using Attribute = struct {
+    using Attribute = struct _Attribute {
         std::string sample;
         std::string format;
         std::string channel;

--- a/src/core/wakeup_detector.hh
+++ b/src/core/wakeup_detector.hh
@@ -42,7 +42,7 @@ public:
 
 class WakeupDetector : public AudioInputProcessor {
 public:
-    using Attribute = struct {
+    using Attribute = struct _Attribute {
         std::string model_net_file;
         std::string model_search_file;
         std::string sample;

--- a/tests/clientkit/test_clientkit_capability.cc
+++ b/tests/clientkit/test_clientkit_capability.cc
@@ -69,7 +69,7 @@ private:
     bool is_destroy_directive_by_agent = true;
 };
 
-using TestFixture = struct {
+using TestFixture = struct _TestFixture {
     std::unique_ptr<NuguClient> nugu_client;
     std::unique_ptr<FakeAgent> agent;
     IDirectiveSequencer* dir_seq;

--- a/tests/clientkit/test_clientkit_dialog_ux_state_aggregator.cc
+++ b/tests/clientkit/test_clientkit_dialog_ux_state_aggregator.cc
@@ -216,7 +216,7 @@ private:
     ChipsInfo chips;
 };
 
-using TestFixture = struct {
+using TestFixture = struct _TestFixture {
     std::shared_ptr<NuguClient> nugu_client;
     std::shared_ptr<DialogUXStateAggregator> dialog_ux_state_aggregator;
     std::shared_ptr<DialogUXStateAggregatorListener> listener;

--- a/tests/clientkit/test_clientkit_nugu_runner.cc
+++ b/tests/clientkit/test_clientkit_nugu_runner.cc
@@ -138,7 +138,7 @@ public:
     std::string ret_str;
 };
 
-typedef struct {
+typedef struct _nuguFixture {
     GMainLoop* loop;
 } nuguFixture;
 

--- a/tests/clientkit/test_clientkit_speech_recognizer_aggregator.cc
+++ b/tests/clientkit/test_clientkit_speech_recognizer_aggregator.cc
@@ -145,12 +145,12 @@ class FakeASRHandler : public IASRHandler,
                        public Capability,
                        public FakeExecutorListener {
 public:
-    using WakeupPower = struct {
+    using WakeupPower = struct _WakeupPower {
         float noise;
         float speech;
     };
 
-    using ASRResult = struct {
+    using ASRResult = struct _ASRResult {
         std::string text;
         ASRError error;
     };
@@ -284,7 +284,7 @@ private:
     int dialog_id_index = 0;
 };
 
-typedef struct {
+typedef struct _SpeechRecognizerAggregatorState {
     WakeupDetectState wakeup;
     ASRState asr;
 
@@ -295,7 +295,6 @@ typedef struct {
     };
 
     Extras extras;
-
 } SpeechRecognizerAggregatorState;
 
 class SpeechRecognizerAggregatorListener : public ISpeechRecognizerAggregatorListener {
@@ -340,7 +339,8 @@ private:
     RecognitionResult result {};
     std::string dialog_id;
 };
-using TestFixture = struct {
+
+using TestFixture = struct _TestFixture {
     std::shared_ptr<FakeWakeupHandler> wakeup_handler;
     std::shared_ptr<FakeASRHandler> asr_handler;
     std::shared_ptr<FakeExecutor> executor;

--- a/tests/core/test_core_focus_manager.cc
+++ b/tests/core/test_core_focus_manager.cc
@@ -148,7 +148,7 @@ private:
     std::string name;
 };
 
-typedef struct {
+typedef struct _nFocusFixture {
     FocusManager* focus_manager;
     FocusManagerObserver* focus_observer;
     TestFocusResource* asr_resource;

--- a/tests/core/test_core_interaction_control_manager.cc
+++ b/tests/core/test_core_interaction_control_manager.cc
@@ -62,7 +62,7 @@ private:
 
 using TestModeChecker = InteractionControlManagerListener::InteractionModeChecker;
 
-typedef struct {
+typedef struct _TestFixture {
     std::shared_ptr<InteractionControlManager> ic_manager;
     std::shared_ptr<InteractionControlManagerListener> ic_manager_listener;
     std::shared_ptr<InteractionControlManagerListener> ic_manager_listener_snd;

--- a/tests/core/test_core_media_player.cc
+++ b/tests/core/test_core_media_player.cc
@@ -36,7 +36,7 @@
 
 using namespace NuguCore;
 
-typedef struct {
+typedef struct _mplayerFixture {
     MediaPlayer* player;
 } mplayerFixture;
 

--- a/tests/core/test_core_nugu_timer.cc
+++ b/tests/core/test_core_nugu_timer.cc
@@ -34,7 +34,7 @@ using namespace NuguCore;
 
 #define TIMEOUT_UNIT_SEC (1 * NUGU_TIMER_UNIT_SEC)
 
-typedef struct {
+typedef struct _ntimerFixture {
     NUGUTimer* timer1;
     NUGUTimer* timer2;
 } ntimerFixture;

--- a/tests/core/test_core_playstack_manager.cc
+++ b/tests/core/test_core_playstack_manager.cc
@@ -76,7 +76,7 @@ static NuguDirective* createDirective(const std::string& name_space, const std::
         "ref_1", "{}", groups.c_str());
 }
 
-typedef struct {
+typedef struct _TestFixture {
     std::shared_ptr<PlayStackManager> playstack_manager;
     std::shared_ptr<PlayStackManagerListener> playstack_manager_listener;
     std::shared_ptr<PlayStackManagerListener> playstack_manager_listener_snd;

--- a/tests/core/test_core_playsync_manager.cc
+++ b/tests/core/test_core_playsync_manager.cc
@@ -220,7 +220,7 @@ static NuguDirective* createDirective(const std::string& name_space, const std::
         "ref_1", "{}", groups.c_str());
 }
 
-typedef struct {
+typedef struct _TestFixture {
     std::shared_ptr<PlaySyncManager> playsync_manager;
     std::shared_ptr<PlaySyncManagerListener> playsync_manager_listener;
     std::shared_ptr<PlaySyncManagerListener> playsync_manager_listener_snd;
@@ -238,7 +238,6 @@ typedef struct {
     NuguDirective* ndir_nudge;
     NuguDirective* ndir_alerts;
     NuguDirective* ndir_disp_expect_speech;
-
 } TestFixture;
 
 static void setup(TestFixture* fixture, gconstpointer user_data)

--- a/tests/core/test_core_routine_manager.cc
+++ b/tests/core/test_core_routine_manager.cc
@@ -31,7 +31,7 @@ const unsigned int TIMER_DOWNSCALE_FACTOR = 10;
 std::mutex mutex;
 std::condition_variable cv;
 
-using RoutineTestData = struct {
+using RoutineTestData = struct _RoutineTestData {
     Json::Value type;
     Json::Value play_service_id;
     Json::Value text;
@@ -39,7 +39,7 @@ using RoutineTestData = struct {
     Json::Value post_delay_msec;
 };
 
-using DirectiveElement = struct {
+using DirectiveElement = struct _DirectiveElement {
     std::string name_space;
     std::string name;
     std::string dialog_id;
@@ -185,7 +185,7 @@ static void changeDialogId(NuguDirective*& ndir, std::string&& dialog_id)
     ndir = createDirective({ name_space, name, dialog_id, groups });
 }
 
-typedef struct {
+typedef struct _TestFixture {
     std::shared_ptr<RoutineManager> routine_manager;
     std::shared_ptr<RoutineTestHelper> routine_helper;
     std::shared_ptr<RoutineManagerListener> routine_manager_listener;

--- a/tests/core/test_core_session_manager.cc
+++ b/tests/core/test_core_session_manager.cc
@@ -62,7 +62,7 @@ private:
     int call_count = 0;
 };
 
-typedef struct {
+typedef struct _TestFixture {
     std::shared_ptr<SessionManager> session_manager;
     std::shared_ptr<SessionManagerListener> session_manager_listener;
     std::shared_ptr<SessionManagerListener> session_manager_listener_snd;


### PR DESCRIPTION
Add `struct` tag name to anonymous structure like below to fix build
error on `clang` compiler.

error message:

    error: anonymous non-C-compatible type given name for linkage
    purposes by alias declaration; add a tag name here
    [-Werror,-Wnon-c-typedef-for-linkage]

original code: structure with default member initializer

    typedef struct {
        int a = 1;
        ...
    } StructName;

change with tag name:

    typedef struct _StructName {
        int a = 1;
        ...
    } StructName;

Signed-off-by: Inho Oh <webispy@gmail.com>