### PR TITLE
AudioPlayer: fix parsing UpdateMetadata directive

### DIFF
--- a/src/capability/audio_player_agent.cc
+++ b/src/capability/audio_player_agent.cc
@@ -1353,7 +1353,7 @@ void AudioPlayerAgent::parsingUpdateMetadata(const char* message)
 
     std::string dialog_id = nugu_directive_peek_dialog_id(getNuguDirective());
 
-    settings = root["metadata"]["template"]["settings"];
+    settings = root["metadata"]["template"]["content"]["settings"];
     if (!settings["repeat"].empty()) {
         std::string repeat = settings["repeat"].asString();
 


### PR DESCRIPTION
It fix to parse UpdateMetadata directive correctly.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>