### PR TITLE
build: add nugu-epd dependency to plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,12 +223,21 @@ IF(ENABLE_PLUGINS_ONLY)
 	SET(BUILD_LIBRARY OFF)
 	SET(BUILD_PLUGINS ON)
 	SET(BUILD_EXAMPLES OFF)
+
+	# The SPEEX plugin requires nugu-epd.
+	IF(ENABLE_VENDOR_LIBRARY)
+		SET(VENDOR_PKGCONFIG nugu-epd)
+	ENDIF()
 ENDIF()
 
 IF(ENABLE_EXAMPLES_ONLY)
 	SET(BUILD_LIBRARY OFF)
 	SET(BUILD_PLUGINS OFF)
 	SET(BUILD_EXAMPLES ON)
+ENDIF()
+
+IF(VENDOR_PKGCONFIG)
+	pkg_check_modules(vendor_pkgs REQUIRED ${VENDOR_PKGCONFIG})
 ENDIF()
 
 IF(BUILD_LIBRARY)
@@ -242,6 +251,8 @@ IF(BUILD_LIBRARY)
 	LINK_LIBRARIES(-L${CMAKE_BINARY_DIR}/src)
 ELSE()
 	SET(DEFAULT_LIB_DEPENDENCY nugu)
+
+	# Dummy target
 	ADD_CUSTOM_TARGET(libnugu)
 ENDIF()
 
@@ -251,15 +262,9 @@ FOREACH(flag ${pkgs_CFLAGS})
 	ADD_COMPILE_OPTIONS(${flag})
 ENDFOREACH()
 
-# Gstreamer does not support dynamic loading/unloading of their libraries.
-# Therefore, add the library dependency to NUGU SDK instead of NUGU Plugin.
-IF(BUILD_PLUGINS)
-	IF(ENABLE_GSTREAMER_PLUGIN)
-		pkg_check_modules(force_pkgs REQUIRED gstreamer-1.0 gstreamer-app-1.0 gstreamer-pbutils-1.0 gstreamer-app-1.0)
-		FOREACH(flag ${force_pkgs_CFLAGS})
-			ADD_COMPILE_OPTIONS(${flag})
-		ENDFOREACH(flag)
-	ENDIF()
+IF(ENABLE_GSTREAMER_PLUGIN)
+	pkg_check_modules(gstreamer_pkgs REQUIRED
+		gstreamer-1.0 gstreamer-app-1.0 gstreamer-pbutils-1.0)
 ENDIF()
 
 # Common compile options
@@ -327,9 +332,6 @@ IF (CMAKE_COMPILER_IS_GNUCC)
 		-Wl,--gc-sections)
 
 	LINK_LIBRARIES(
-		# Link with force dependency libraries
-		-Wl,--no-as-needed ${force_pkgs_LDFLAGS}
-
 		# Link only needed libraries
 		-Wl,--as-needed
 
@@ -359,8 +361,6 @@ IF (CMAKE_COMPILER_IS_GNUCC)
 	ENDIF()
 ELSE()
 	ADD_COMPILE_OPTIONS(-fmacro-prefix-map=${CMAKE_SOURCE_DIR}/=)
-
-	LINK_LIBRARIES(${force_pkgs_LDFLAGS})
 
 	IF (NOT PACKAGING)
 		LINK_LIBRARIES(-Wl,-rpath,${CMAKE_BINARY_DIR}/src)
@@ -435,4 +435,3 @@ ENDIF()
 IF(BUILD_EXAMPLES)
 	ADD_SUBDIRECTORY(examples)
 ENDIF()
-

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,14 +1,14 @@
-SET(PLUGINS
-	filedump
-	dummy)
+ADD_LIBRARY(dummy SHARED dummy.c)
+TARGET_LINK_LIBRARIES(dummy -lnugu)
+SET_TARGET_PROPERTIES(dummy PROPERTIES PREFIX "" OUTPUT_NAME dummy)
+INSTALL(TARGETS dummy LIBRARY DESTINATION ${plugindir})
+ADD_DEPENDENCIES(dummy libnugu)
 
-FOREACH(plugin ${PLUGINS})
-	ADD_LIBRARY(${plugin} SHARED ${plugin}.c)
-	TARGET_LINK_LIBRARIES(${plugin} ${pkgs_LDFLAGS} -lnugu)
-	SET_TARGET_PROPERTIES(${plugin} PROPERTIES PREFIX "" OUTPUT_NAME ${plugin})
-	INSTALL(TARGETS ${plugin} LIBRARY DESTINATION ${plugindir})
-	ADD_DEPENDENCIES(${plugin} libnugu)
-ENDFOREACH(plugin)
+ADD_LIBRARY(filedump SHARED filedump.c)
+TARGET_LINK_LIBRARIES(filedump ${pkgs_LDFLAGS} -lnugu)
+SET_TARGET_PROPERTIES(filedump PROPERTIES PREFIX "" OUTPUT_NAME filedump)
+INSTALL(TARGETS filedump LIBRARY DESTINATION ${plugindir})
+ADD_DEPENDENCIES(filedump libnugu)
 
 # OPUS plugin
 IF(ENABLE_OPUS_PLUGIN)
@@ -71,7 +71,14 @@ IF(ENABLE_GSTREAMER_PLUGIN)
 
 	FOREACH(plugin ${GSTREAMER_PLUGINS})
 		ADD_LIBRARY(${plugin} SHARED ${plugin}.c)
-		TARGET_LINK_LIBRARIES(${plugin} ${pkgs_LDFLAGS} -lnugu)
+		TARGET_LINK_LIBRARIES(${plugin}
+			${pkgs_LDFLAGS}
+			${gstreamer_pkgs_LDFLAGS}
+			-lnugu)
+		FOREACH(flag ${gstreamer_pkgs_CFLAGS})
+			TARGET_COMPILE_OPTIONS(${plugin} PRIVATE ${flag})
+		ENDFOREACH(flag)
+
 		SET_TARGET_PROPERTIES(${plugin} PROPERTIES PREFIX "" OUTPUT_NAME ${plugin})
 		INSTALL(TARGETS ${plugin} LIBRARY DESTINATION ${plugindir})
 		ADD_DEPENDENCIES(${plugin} libnugu)
@@ -81,7 +88,10 @@ ENDIF(ENABLE_GSTREAMER_PLUGIN)
 # Speex plugin
 IF(ENABLE_SPEEX_PLUGIN AND ENABLE_VENDOR_LIBRARY)
 	ADD_LIBRARY(speex SHARED speex.c)
-	TARGET_LINK_LIBRARIES(speex ${pkgs_LDFLAGS} -lnugu)
+	FOREACH(flag ${vendor_pkgs_CFLAGS})
+		TARGET_COMPILE_OPTIONS(speex PRIVATE ${flag})
+	ENDFOREACH(flag)
+	TARGET_LINK_LIBRARIES(speex ${pkgs_LDFLAGS} ${vendor_pkgs_LDFLAGS} -lnugu)
 	SET_TARGET_PROPERTIES(speex PROPERTIES PREFIX "" OUTPUT_NAME speex)
 	INSTALL(TARGETS speex LIBRARY DESTINATION ${plugindir})
 	ADD_DEPENDENCIES(speex libnugu)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,18 @@ TARGET_LINK_LIBRARIES(libnugu PUBLIC
 	${CURL_LIBRARY} ${JSONCPP_LIBRARY}
 	${pkgs_LDFLAGS} ${LDFLAG_SOCKET} ${LDFLAG_DL})
 
+# Gstreamer does not support dynamic loading/unloading of their libraries.
+# Therefore, add the library dependency to NUGU SDK instead of NUGU Plugin.
+FOREACH(flag ${gstreamer_pkgs_CFLAGS})
+    TARGET_COMPILE_OPTIONS(libnugu PRIVATE ${flag})
+ENDFOREACH(flag)
+
+IF(CMAKE_COMPILER_IS_GNUCC)
+    TARGET_LINK_LIBRARIES(libnugu PUBLIC -Wl,--no-as-needed ${gstreamer_pkgs_LDFLAGS})
+ELSE()
+    TARGET_LINK_LIBRARIES(libnugu PUBLIC ${gstreamer_pkgs_LDFLAGS})
+ENDIF()
+
 SET_TARGET_PROPERTIES(libnugu
 	PROPERTIES VERSION ${VERSION} SOVERSION ${VERSION_MAJOR} OUTPUT_NAME nugu)
 


### PR DESCRIPTION
The speex plugin requires nugu-epd dependency.

Signed-off-by: Inho Oh <inho.oh@sk.com>