### PR TITLE
fix CodeQL action error

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -18,7 +18,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
ubuntu-latest now points to 22.04 instead of 20.04. However, the codeql action has an issue in 22.04, so it is changed to use 20.04.

Signed-off-by: Inho Oh <webispy@gmail.com>