### PR TITLE
Routine: add/update RoutineManager API

### DIFF
--- a/include/clientkit/routine_manager_interface.hh
+++ b/include/clientkit/routine_manager_interface.hh
@@ -43,7 +43,8 @@ enum class RoutineActivity {
     PLAYING, /**< Routine is being executed. */
     INTERRUPTED, /**< Routine is interrupted. */
     FINISHED, /**< Routine execution is done. */
-    STOPPED /**< Routine is stopped before finish. */
+    STOPPED, /**< Routine is stopped before finish. */
+    SUSPENDED /**< Routine is suspended in the middle of actions. */
 };
 
 /**
@@ -59,6 +60,12 @@ public:
      * @param[in] activity current routine activity state
      */
     virtual void onActivity(RoutineActivity activity) = 0;
+
+    /**
+     * @brief Receive callback when the action timeout is ended.
+     * @param[in] last_action whether it was processed as the last action
+     */
+    virtual void onActionTimeout(bool last_action = false) = 0;
 };
 
 /**
@@ -120,15 +127,42 @@ public:
     virtual void resume() = 0;
 
     /**
+     * @brief Move to the specific action and process.
+     * @param[in] index action index
+     * @return Result of operation
+     * @retval true succeed to move and process
+     * @retval false fail to move and process
+     */
+    virtual bool move(unsigned int index) = 0;
+
+    /**
      * @brief Finish action.
      */
     virtual void finish() = 0;
 
     /**
+     * @brief Get token of current active action.
+     * @return token of current active action
+     */
+    virtual std::string getCurrentActionToken() = 0;
+
+    /**
      * @brief Get index of current active action.
      * @return index of current active action
      */
-    virtual int getCurrentActionIndex() = 0;
+    virtual unsigned int getCurrentActionIndex() = 0;
+
+    /**
+     * @brief Get size of countable actions.
+     * @return size of countable actions.
+     */
+    virtual unsigned int getCountableActionSize() = 0;
+
+    /**
+     * @brief Get index of current countable action.
+     * @return index of current active countable action
+     */
+    virtual unsigned int getCountableActionIndex() = 0;
 
     /**
      * @brief Check whether routine is in progress currently.
@@ -164,11 +198,46 @@ public:
     virtual bool isConditionToStop(const NuguDirective* ndir) = 0;
 
     /**
-     * @brief Check whether current condition is possible to finish progressing action
+     * @brief Check whether current condition is possible to finish progressing action.
      * @param[in] ndir NuguDirective object
      * @return true if satisfied, otherwise false
      */
     virtual bool isConditionToFinishAction(const NuguDirective* ndir) = 0;
+
+    /**
+     * @brief Check whether current condition is to cancel directive.
+     * @param[in] ndir NuguDirective object
+     * @return true if satisfied, otherwise false
+     */
+    virtual bool isConditionToCancel(const NuguDirective* ndir) = 0;
+
+    /**
+     * @brief Check whether mute delay is processed.
+     * @return Result of status
+     * @retval true in progress
+     * @retval false not in progress
+     */
+    virtual bool isMuteDelayed() = 0;
+
+    /**
+     * @brief Set default time (5 sec) when action timeout is not set.
+     */
+    virtual void presetActionTimeout() = 0;
+
+    /**
+     * @brief Set pending stop after checking whether Routine.Stop directive exists.
+     * @param[in] ndir NuguDirective object
+     */
+    virtual void setPendingStop(const NuguDirective* ndir) = 0;
+
+    /**
+     * @brief Check whether current condition should skip media play.
+     * @param[in] dialog_id dialog id
+     * @return Whether to skip media play
+     * @retval true skip
+     * @retval false not skip
+     */
+    virtual bool hasToSkipMedia(const std::string& dialog_id) = 0;
 };
 
 /**

--- a/src/capability/routine_agent.cc
+++ b/src/capability/routine_agent.cc
@@ -128,7 +128,13 @@ void RoutineAgent::onActivity(RoutineActivity activity)
         break;
     case RoutineActivity::IDLE:
         break;
+    case RoutineActivity::SUSPENDED:
+        break;
     }
+}
+
+void RoutineAgent::onActionTimeout(bool last_action)
+{
 }
 
 void RoutineAgent::handleInterrupted()

--- a/src/capability/routine_agent.hh
+++ b/src/capability/routine_agent.hh
@@ -42,6 +42,7 @@ public:
 private:
     // implements IRoutineManagerListener
     void onActivity(RoutineActivity activity) override;
+    void onActionTimeout(bool last_action = false) override;
 
     void handleInterrupted();
     void clearRoutineInfo();

--- a/src/core/routine_manager.cc
+++ b/src/core/routine_manager.cc
@@ -42,8 +42,12 @@ void RoutineManager::reset()
     data_requester = nullptr;
     activity = RoutineActivity::IDLE;
     token = "";
+
     is_interrupted = false;
+    is_mute_delayed = false;
+    is_action_timeout = false;
     has_post_delayed = false;
+    has_pending_stop = false;
 }
 
 void RoutineManager::addListener(IRoutineManagerListener* listener)
@@ -119,17 +123,30 @@ bool RoutineManager::start(const std::string& token, const Json::Value& actions)
 
 void RoutineManager::stop()
 {
+    has_pending_stop = false;
+
     clearContainer();
 
-    if (activity == RoutineActivity::PLAYING || activity == RoutineActivity::INTERRUPTED)
+    if (activity != RoutineActivity::FINISHED)
         setActivity(RoutineActivity::STOPPED);
 
     has_post_delayed = false;
     is_interrupted = false;
+
+    if (is_action_timeout || is_mute_delayed) {
+        timer->stop();
+        is_action_timeout = false;
+        is_mute_delayed = false;
+    }
 }
 
 void RoutineManager::interrupt()
 {
+    if (activity == RoutineActivity::SUSPENDED) {
+        nugu_warn("The routine is suspended.");
+        return;
+    }
+
     is_interrupted = true;
 
     if (has_post_delayed)
@@ -145,6 +162,42 @@ void RoutineManager::resume()
     has_post_delayed ? timer->restart() : finish();
 }
 
+bool RoutineManager::move(unsigned int index)
+{
+    if (activity == RoutineActivity::FINISHED || activity == RoutineActivity::STOPPED) {
+        nugu_warn("The routine is not alive");
+        return false;
+    }
+
+    if (index < 1 || index > action_queue.size()) {
+        nugu_warn("It's out of index.");
+        return false;
+    }
+
+    if (is_mute_delayed) {
+        nugu_warn("The routine is mute delayed.");
+        return false;
+    }
+
+    if (is_action_timeout)
+        timer->stop();
+
+    removePreviousActionDialog();
+
+    cur_action_index = index - 1;
+
+    // find executable action type (TEXT|DATA)
+    for (; cur_action_index < action_queue.size(); cur_action_index++)
+        if (action_queue[cur_action_index].type != ACTION_TYPE_BREAK)
+            break;
+
+    // skip processing next, if no executable action type exist until the end
+    if (!(is_last_action_processed = (cur_action_index == action_queue.size())))
+        next();
+
+    return true;
+}
+
 void RoutineManager::finish()
 {
     if (is_interrupted) {
@@ -152,26 +205,50 @@ void RoutineManager::finish()
         return;
     }
 
-    // remove previous progress action's dialog id
-    action_dialog_ids.erase(
-        std::find_if(action_dialog_ids.begin(), action_dialog_ids.end(),
-            [&](const std::pair<std::string, int>& element) {
-                return element.second == cur_action_index;
-            }));
+    if (is_action_timeout || is_mute_delayed) {
+        nugu_warn("The routine is action timeout or mute delayed.");
+        return;
+    }
+
+    removePreviousActionDialog();
 
     if (hasNext()) {
-        has_post_delayed ? postDelayed([&] { next(); }) : next();
+        has_post_delayed ? postHandle([&] { next(); }) : next();
     } else {
         cur_action_index = 0;
+        cur_countable_action_index = 0;
+        cur_action_token.clear();
+        has_pending_stop = false;
 
-        if (activity == RoutineActivity::PLAYING)
+        if (activity == RoutineActivity::PLAYING || activity == RoutineActivity::SUSPENDED)
             setActivity(RoutineActivity::FINISHED);
     }
 }
 
-int RoutineManager::getCurrentActionIndex()
+std::string RoutineManager::getCurrentActionToken()
+{
+    return cur_action_token;
+}
+
+unsigned int RoutineManager::getCurrentActionIndex()
 {
     return cur_action_index;
+}
+
+unsigned int RoutineManager::getCountableActionSize()
+{
+    unsigned int size = 0;
+
+    for (const auto& action : action_queue)
+        if (action.type != ACTION_TYPE_BREAK)
+            size++;
+
+    return size;
+}
+
+unsigned int RoutineManager::getCountableActionIndex()
+{
+    return cur_countable_action_index;
 }
 
 bool RoutineManager::isRoutineProgress()
@@ -181,7 +258,7 @@ bool RoutineManager::isRoutineProgress()
 
 bool RoutineManager::isRoutineAlive()
 {
-    return isRoutineProgress() || !action_queue.empty();
+    return isRoutineProgress() || (!action_queue.empty() && !is_last_action_processed);
 }
 
 bool RoutineManager::isActionProgress(const std::string& dialog_id)
@@ -207,7 +284,7 @@ bool RoutineManager::isConditionToStop(const NuguDirective* ndir)
         return false;
     }
 
-    if (!isRoutineAlive() || hasRoutineDirective(ndir))
+    if (!isRoutineAlive() || hasRoutineDirective(ndir) || activity == RoutineActivity::SUSPENDED)
         return false;
 
     if (isActionProgress(nugu_directive_peek_dialog_id(ndir))) {
@@ -234,12 +311,61 @@ bool RoutineManager::isConditionToFinishAction(const NuguDirective* ndir)
         && SKIP_FINISH_FILTER.find(nugu_directive_peek_namespace(ndir)) == SKIP_FINISH_FILTER.end();
 }
 
-const RoutineManager::RoutineActions& RoutineManager::getActionContainer()
+bool RoutineManager::isConditionToCancel(const NuguDirective* ndir)
+{
+    if (!ndir)
+        return false;
+
+    std::string dir_groups = nugu_directive_peek_groups(ndir);
+
+    if (dir_groups.find("Routine.Stop") != std::string::npos)
+        return false;
+    else if (dir_groups.find("Routine") != std::string::npos)
+        return true;
+
+    return false;
+}
+
+bool RoutineManager::isMuteDelayed()
+{
+    return is_mute_delayed;
+}
+
+void RoutineManager::presetActionTimeout()
+{
+    if (is_last_action_processed) {
+        nugu_warn("The all actions are processed");
+        return;
+    }
+
+    if (action_queue[cur_action_index - 1].action_timeout_msec == 0)
+        handleActionTimeout(DEFAULT_ACTION_TIME_OUT_MSEC);
+}
+
+void RoutineManager::setPendingStop(const NuguDirective* ndir)
+{
+    std::string dir_groups = nugu_directive_peek_groups(ndir);
+
+    has_pending_stop = dir_groups.find("Routine.Stop") != std::string::npos;
+}
+
+bool RoutineManager::hasToSkipMedia(const std::string& dialog_id)
+{
+    if (!isRoutineAlive() || has_pending_stop)
+        return false;
+
+    if (isActionProgress(dialog_id) || activity == RoutineActivity::SUSPENDED)
+        return false;
+
+    return true;
+}
+
+const RoutineManager::RoutineActions& RoutineManager::getActionContainer() const
 {
     return action_queue;
 }
 
-const RoutineManager::RoutineActionDialogs& RoutineManager::getActionDialogs()
+const RoutineManager::RoutineActionDialogs& RoutineManager::getActionDialogs() const
 {
     return action_dialog_ids;
 }
@@ -259,42 +385,85 @@ bool RoutineManager::isInterrupted()
     return is_interrupted;
 }
 
+bool RoutineManager::isActionTimeout()
+{
+    return is_action_timeout;
+}
+
+bool RoutineManager::isLastActionProcessed()
+{
+    return is_last_action_processed;
+}
+
 bool RoutineManager::hasPostDelayed()
 {
     return has_post_delayed;
 }
 
+bool RoutineManager::hasPendingStop()
+{
+    return has_pending_stop;
+}
+
 bool RoutineManager::hasNext()
 {
-    return !action_queue.empty();
+    return cur_action_index < action_queue.size();
 }
 
 void RoutineManager::next()
 {
-    if (action_queue.empty())
+    if (cur_action_index >= action_queue.size()) {
+        nugu_warn("The cur_action_index is invalid.");
         return;
+    }
 
-    const auto& action = action_queue.front();
+    const auto& action = action_queue[cur_action_index++];
     std::string dialog_id;
-    cur_action_index++;
+    cur_action_token = action.token;
+    is_last_action_processed = (cur_action_index == action_queue.size());
+    is_action_timeout = is_mute_delayed = has_post_delayed = false;
+    has_pending_stop = false;
 
-    setActivity(RoutineActivity::PLAYING);
+    setActivity((action.type == ACTION_TYPE_BREAK) ? RoutineActivity::SUSPENDED : RoutineActivity::PLAYING);
 
-    if (action.type == ACTION_TYPE_TEXT)
-        dialog_id = text_requester(token, action.text, action.play_service_id);
-    else if (action.type == ACTION_TYPE_DATA)
-        dialog_id = data_requester(action.play_service_id, action.data);
+    if (action.type == ACTION_TYPE_BREAK) {
+        if ((is_mute_delayed = (action.mute_delay_msec > 0)))
+            timer->setInterval(action.mute_delay_msec);
 
-    if (!dialog_id.empty())
-        action_dialog_ids.emplace(dialog_id, cur_action_index);
+        is_mute_delayed ? postHandle([&] { next(); }) : next();
+    } else {
+        if (action.type == ACTION_TYPE_TEXT)
+            dialog_id = text_requester(token, action.text, action.play_service_id);
+        else if (action.type == ACTION_TYPE_DATA)
+            dialog_id = data_requester(action.play_service_id, action.data);
 
-    if ((has_post_delayed = (action.post_delay_msec > 0)))
-        timer->setInterval(action.post_delay_msec);
+        if (!dialog_id.empty())
+            action_dialog_ids.emplace(dialog_id, cur_action_index);
 
-    action_queue.pop();
+        if (action.action_timeout_msec > 0)
+            handleActionTimeout(action.action_timeout_msec);
+        else if ((has_post_delayed = (action.post_delay_msec > 0)))
+            timer->setInterval(action.post_delay_msec);
+
+        cur_countable_action_index++;
+    }
 }
 
-void RoutineManager::postDelayed(TimerCallback&& func)
+void RoutineManager::handleActionTimeout(const long long action_time_msec)
+{
+    is_action_timeout = true;
+    setActivity(RoutineActivity::SUSPENDED);
+
+    timer->setInterval(action_time_msec);
+    postHandle([&] {
+        is_action_timeout = false;
+
+        for (const auto& listener : listeners)
+            listener->onActionTimeout(is_last_action_processed);
+    });
+}
+
+void RoutineManager::postHandle(TimerCallback&& func)
 {
     timer->setCallback(func);
     timer->start();
@@ -308,16 +477,18 @@ void RoutineManager::setActions(const Json::Value& actions)
         std::string type = action["type"].asString();
         std::string play_service_id = action["playServiceId"].asString();
 
-        if (type.empty() || (type == "DATA" && (play_service_id.empty() || action["data"].empty())))
+        if (type.empty() || (type == ACTION_TYPE_DATA && (play_service_id.empty() || action["data"].empty())))
             continue;
 
-        action_queue.push(RoutineAction {
+        action_queue.emplace_back(RoutineAction {
             type,
             play_service_id,
             action["text"].asString(),
             action["token"].asString(),
             action["data"],
-            action["postDelayInMilliseconds"].asLargestInt() });
+            action["postDelayInMilliseconds"].asLargestInt(),
+            action["muteDelayInMilliseconds"].asLargestInt(),
+            action["actionTimeoutInMilliseconds"].asLargestInt() });
     }
 }
 
@@ -332,13 +503,25 @@ void RoutineManager::setActivity(RoutineActivity activity)
         listener->onActivity(activity);
 }
 
+void RoutineManager::removePreviousActionDialog()
+{
+    auto cur_action_dialog_id = std::find_if(action_dialog_ids.begin(), action_dialog_ids.end(),
+        [&](const std::pair<std::string, unsigned int>& element) {
+            return element.second == cur_action_index;
+        });
+
+    if (cur_action_dialog_id != action_dialog_ids.end())
+        action_dialog_ids.erase(cur_action_dialog_id);
+}
+
 void RoutineManager::clearContainer()
 {
-    while (!action_queue.empty())
-        action_queue.pop();
-
+    action_queue.clear();
     action_dialog_ids.clear();
     cur_action_index = 0;
+    cur_countable_action_index = 0;
+    cur_action_token.clear();
+    is_last_action_processed = false;
 }
 
 } // NuguCore

--- a/tests/core/test_core_routine_manager.cc
+++ b/tests/core/test_core_routine_manager.cc
@@ -31,19 +31,21 @@ const unsigned int TIMER_DOWNSCALE_FACTOR = 10;
 std::mutex mutex;
 std::condition_variable cv;
 
-using RoutineTestData = struct _RoutineTestData {
-    Json::Value type;
-    Json::Value play_service_id;
-    Json::Value text;
-    Json::Value data;
-    Json::Value post_delay_msec;
-};
-
 using DirectiveElement = struct _DirectiveElement {
     std::string name_space;
     std::string name;
     std::string dialog_id;
     std::string groups;
+};
+
+enum class TestType {
+    Normal,
+    PostDelay,
+    ActionTimeout,
+    DefaultActionTimeout,
+    BreakAction,
+    CountableAction,
+    LastActionProcessed
 };
 
 class FakeTimer final : public NUGUTimer {
@@ -110,14 +112,17 @@ private:
 
 class RoutineTestHelper {
 public:
-    void composeActions(std::vector<RoutineTestData>&& test_datas)
+    void composeActions(std::vector<RoutineManager::RoutineAction>&& test_datas)
     {
         actions.clear();
 
-        for (auto& element : test_datas) {
+        for (const auto& element : test_datas) {
             Json::Value action;
             action["type"] = element.type;
             action["playServiceId"] = element.play_service_id;
+
+            if (!element.token.empty())
+                action["token"] = element.token;
 
             if (!element.text.empty())
                 action["text"] = element.text;
@@ -127,6 +132,12 @@ public:
 
             if (element.post_delay_msec > 0)
                 action["postDelayInMilliseconds"] = element.post_delay_msec;
+
+            if (element.mute_delay_msec > 0)
+                action["muteDelayInMilliseconds"] = element.mute_delay_msec;
+
+            if (element.action_timeout_msec > 0)
+                action["actionTimeoutInMilliseconds"] = element.action_timeout_msec;
 
             actions.append(action);
         }
@@ -147,6 +158,16 @@ public:
         return token;
     }
 
+    std::string getActionToken(unsigned int index)
+    {
+        for (Json::Value::ArrayIndex i = 0; i < actions.size(); i++) {
+            if (i == index - 1)
+                return actions[i]["token"].asString();
+        }
+
+        return "";
+    }
+
 private:
     Json::Value actions;
     std::string token = "token";
@@ -159,13 +180,37 @@ public:
         this->activity = activity;
     }
 
+    void onActionTimeout(bool last_action = false) override
+    {
+        is_action_timeout = true;
+        is_last_action = last_action;
+    }
+
     RoutineActivity getActivity()
     {
         return activity;
     }
 
+    bool isActionTimeout()
+    {
+        return is_action_timeout;
+    }
+
+    bool isProcessedInLastAction()
+    {
+        return is_last_action;
+    }
+
+    void reset()
+    {
+        is_action_timeout = false;
+        is_last_action = false;
+    }
+
 private:
     RoutineActivity activity = RoutineActivity::IDLE;
+    bool is_action_timeout = false;
+    bool is_last_action = false;
 };
 
 static NuguDirective* createDirective(DirectiveElement&& element)
@@ -195,7 +240,7 @@ typedef struct _TestFixture {
     NuguDirective* ndir_info_disp;
     NuguDirective* ndir_info_tts;
     NuguDirective* ndir_routine;
-    NuguDirective* ndir_media;
+    NuguDirective* ndir_routine_stop;
     NuguDirective* ndir_dm;
 } TestFixture;
 
@@ -208,20 +253,17 @@ static void setup(TestFixture* fixture, gconstpointer user_data)
     fixture->fake_timer = new FakeTimer(mutex, cv);
 
     fixture->routine_manager->setTimer(fixture->fake_timer);
-    fixture->routine_manager->setTextRequester(
-        [](const std::string& token, const std::string& text, const std::string& ps_id) {
-            return ps_id == "ps_id_1" ? "dialog_1" : "dialog_2";
-        });
-    fixture->routine_manager->setDataRequester(
-        [](const std::string& ps_id, const Json::Value& data) {
-            return "dialog_3";
-        });
-    fixture->routine_helper->composeActions(
-        {
-            { "TEXT", "ps_id_1", "text_1", Json::nullValue },
-            { "TEXT", "ps_id_2", "text_2", Json::nullValue },
-            { "DATA", "ps_id_3", "", Json::Value("DATA_VALUE") },
-        });
+    fixture->routine_manager->setTextRequester([](const std::string& token, const std::string& text, const std::string& ps_id) {
+        return ps_id == "ps_id_1" ? "dialog_1" : "dialog_2";
+    });
+    fixture->routine_manager->setDataRequester([](const std::string& ps_id, const Json::Value& data) {
+        return "dialog_3";
+    });
+    fixture->routine_helper->composeActions({
+        { "TEXT", "ps_id_1", "token_1", "text_1", Json::nullValue },
+        { "TEXT", "ps_id_2", "token_2", "text_2", Json::nullValue },
+        { "DATA", "ps_id_3", "token_3", "", Json::Value("DATA_VALUE") },
+    });
 
     fixture->ndir_info = createDirective({ "TTS", "Speak", "dialog_1",
         "{ \"directives\": [\"TTS.Speak\"] }" });
@@ -231,8 +273,8 @@ static void setup(TestFixture* fixture, gconstpointer user_data)
         "{ \"directives\": [\"Display.FullText2\", \"TTS.Speak\"] }" });
     fixture->ndir_routine = createDirective({ "Routine", "Continue", "dialog_1",
         "{ \"directives\": [\"TTS.Speak\", \"Routine.Continue\"] }" });
-    fixture->ndir_media = createDirective({ "AudioPlayer", "Play", "dialog_1",
-        "{ \"directives\": [\"TTS.Speak\", \"AudioPlayer.Play\"] }" });
+    fixture->ndir_routine_stop = createDirective({ "Routine", "Stop", "dialog_1",
+        "{ \"directives\": [\"TTS.Stop\", \"Routine.Stop\"] }" });
     fixture->ndir_dm = createDirective({ "ASR", "ExpectSpeech", "dialog_1",
         "{ \"directives\": [\"TTS.Speak\", \"ASR.ExpectSpeech\"] }" });
 }
@@ -243,7 +285,6 @@ static void teardown(TestFixture* fixture, gconstpointer user_data)
     nugu_directive_unref(fixture->ndir_info_disp);
     nugu_directive_unref(fixture->ndir_info_tts);
     nugu_directive_unref(fixture->ndir_routine);
-    nugu_directive_unref(fixture->ndir_media);
     nugu_directive_unref(fixture->ndir_dm);
 
     fixture->routine_manager_listener.reset();
@@ -269,7 +310,7 @@ static void test_routine_manager_listener(TestFixture* fixture, gconstpointer ig
     fixture->routine_manager->addListener(fixture->routine_manager_listener.get());
     g_assert(fixture->routine_manager->getListenerCount() == 1);
 
-    // check adding duplicately
+    // check duplicate addition
     fixture->routine_manager->addListener(fixture->routine_manager_listener.get());
     g_assert(fixture->routine_manager->getListenerCount() == 1);
     g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::IDLE);
@@ -304,28 +345,28 @@ static void test_routine_manager_validation(TestFixture* fixture, gconstpointer 
     // remove previous actions when calling start
     g_assert(fixture->routine_manager->start(fixture->routine_helper->getToken(), fixture->routine_helper->getActions()));
     g_assert(fixture->routine_manager->start(fixture->routine_helper->getToken(), fixture->routine_helper->getActions()));
-    g_assert(action_container.size() == 2);
+
+    g_assert(action_container.size() == 3);
 }
 
 static void test_routine_manager_compose_action_queue(TestFixture* fixture, gconstpointer ignored)
 {
-    fixture->routine_helper->composeActions(
-        {
-            { "", "ps_id_0", "text_0", Json::nullValue },
-            { Json::nullValue, "ps_id_0", "", Json::nullValue },
+    fixture->routine_helper->composeActions({
+        { "", "ps_id_0", "token_0", "text_0", Json::nullValue },
+        { "", "ps_id_0", "token_0", "", Json::nullValue },
 
-            { "TEXT", "ps_id_1", "text_1", Json::nullValue },
-            { "TEXT", "", "text_2", Json::nullValue },
-            { "TEXT", Json::nullValue, "text_3", Json::nullValue },
+        { "TEXT", "ps_id_1", "token_1", "text_1", Json::nullValue },
+        { "TEXT", "", "", "text_2", Json::nullValue },
+        { "TEXT", "", "", "text_3", Json::nullValue },
 
-            { "DATA", "ps_id_2", "", Json::Value("DATA_VALUE") },
-            { "DATA", "ps_id_2", "", Json::nullValue },
-            { "DATA", "", "", Json::Value("DATA_VALUE") },
-            { "DATA", Json::nullValue, "", Json::Value("DATA_VALUE") },
-        });
+        { "DATA", "ps_id_2", "token_2", "", Json::Value("DATA_VALUE") },
+        { "DATA", "ps_id_2", "token_2", "", Json::nullValue },
+        { "DATA", "", "", "", Json::Value("DATA_VALUE") },
+        { "DATA", "", "", "", Json::Value("DATA_VALUE") },
+    });
 
     g_assert(fixture->routine_manager->start(fixture->routine_helper->getToken(), fixture->routine_helper->getActions()));
-    g_assert(fixture->routine_manager->getActionContainer().size() == 3);
+    g_assert(fixture->routine_manager->getActionContainer().size() == 4);
 }
 
 static void test_routine_manager_normal(TestFixture* fixture, gconstpointer ignored)
@@ -360,22 +401,62 @@ static void test_routine_manager_normal(TestFixture* fixture, gconstpointer igno
     g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::PLAYING);
 }
 
-static void sub_test_routine_manager_preset_start(TestFixture* fixture, gconstpointer ignored)
+static void sub_test_routine_manager_start_routine(TestFixture* fixture, TestType test_type = TestType::Normal)
 {
-    const auto& action_container = fixture->routine_manager->getActionContainer();
+    std::vector<RoutineManager::RoutineAction> test_datas;
+
+    if (test_type == TestType::PostDelay)
+        test_datas = {
+            { "TEXT", "ps_id_1", "token_1", "text_1", Json::nullValue, 1000 },
+            { "TEXT", "ps_id_2", "token_2", "text_2", Json::nullValue, 2000 },
+            { "DATA", "ps_id_3", "token_3", "", Json::Value("DATA_VALUE") },
+            { "DATA", "ps_id_4", "token_4", "", Json::Value("DATA_VALUE") },
+        };
+    else if (test_type == TestType::ActionTimeout)
+        test_datas = {
+            { "TEXT", "ps_id_1", "token_1", "text_1", Json::nullValue },
+            { "DATA", "ps_id_2", "token_2", "", Json::Value("DATA_VALUE"), 0, 0, 2000 },
+            { "TEXT", "ps_id_3", "token_3", "text_3", Json::nullValue },
+            { "DATA", "ps_id_4", "token_4", "", Json::Value("DATA_VALUE"), 0, 0, 2000 },
+        };
+    else if (test_type == TestType::DefaultActionTimeout)
+        test_datas = {
+            { "TEXT", "ps_id_1", "token_1", "text_1", Json::nullValue },
+            { "DATA", "ps_id_2", "token_2", "", Json::Value("DATA_VALUE"), 0, 0, 2000 },
+            { "TEXT", "ps_id_3", "token_3", "text_3", Json::nullValue },
+        };
+    else if (test_type == TestType::BreakAction)
+        test_datas = {
+            { "TEXT", "ps_id_1", "token_1", "text_1", Json::nullValue },
+            { "BREAK", "ps_id_2", "token_2", "", Json::nullValue, 0, 1000 },
+            { "DATA", "ps_id_3", "token_3", "", Json::Value("DATA_VALUE") },
+            { "BREAK", "ps_id_4", "token_4", "", Json::nullValue, 0, 0 },
+            { "DATA", "ps_id_5", "token_5", "", Json::Value("DATA_VALUE") },
+        };
+    else if (test_type == TestType::CountableAction)
+        test_datas = {
+            { "TEXT", "ps_id_1", "token_1", "text_1", Json::nullValue },
+            { "BREAK", "ps_id_2", "token_2", "text_2", Json::nullValue, 0, 1000 },
+            { "DATA", "ps_id_3", "token_3", "", Json::Value("DATA_VALUE") },
+        };
+    else if (test_type == TestType::LastActionProcessed)
+        test_datas = {
+            { "TEXT", "ps_id_1", "token_1", "text_1", Json::nullValue },
+            { "TEXT", "ps_id_2", "token_2", "text_2", Json::nullValue },
+        };
+
+    if (!test_datas.empty())
+        fixture->routine_helper->composeActions(std::move(test_datas));
 
     fixture->routine_manager->addListener(fixture->routine_manager_listener.get());
-    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::IDLE);
-
     g_assert(fixture->routine_manager->start(fixture->routine_helper->getToken(), fixture->routine_helper->getActions()));
     g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::PLAYING);
     g_assert(fixture->routine_manager->getCurrentActionIndex() == 1);
-    g_assert(!action_container.empty());
 }
 
 static void test_routine_manager_interrupt(TestFixture* fixture, gconstpointer ignored)
 {
-    sub_test_routine_manager_preset_start(fixture, ignored);
+    sub_test_routine_manager_start_routine(fixture);
 
     g_assert(fixture->routine_manager->isRoutineProgress());
 
@@ -393,35 +474,113 @@ static void test_routine_manager_interrupt(TestFixture* fixture, gconstpointer i
     g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::STOPPED);
 }
 
+static void test_routine_manager_move(TestFixture* fixture, gconstpointer ignored)
+{
+    fixture->routine_manager->addListener(fixture->routine_manager_listener.get());
+
+    auto checkActionProgress = [&](const unsigned int& index, std::string&& cur_dialog_id = "", std::string&& prev_dialog_id = "") {
+        g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::PLAYING);
+        g_assert(fixture->routine_manager->getCurrentActionIndex() == index);
+
+        if (!cur_dialog_id.empty())
+            g_assert(fixture->routine_manager->isActionProgress(cur_dialog_id));
+
+        if (!prev_dialog_id.empty())
+            g_assert(!fixture->routine_manager->isActionProgress(prev_dialog_id));
+    };
+
+    auto checkRoutineActivity = [&](const RoutineActivity activity) {
+        g_assert(fixture->routine_manager_listener->getActivity() == activity);
+        g_assert(fixture->routine_manager->getCurrentActionIndex() == 0);
+    };
+
+    g_assert(fixture->routine_manager->start(fixture->routine_helper->getToken(), fixture->routine_helper->getActions()));
+    checkActionProgress(1, "dialog_1");
+
+    fixture->routine_manager->finish();
+    checkActionProgress(2, "dialog_2", "dialog_1");
+
+    fixture->routine_manager->finish();
+    checkActionProgress(3, "dialog_3", "dialog_2");
+
+    // move from action 3 to 2
+    g_assert(fixture->routine_manager->move(2));
+    checkActionProgress(2, "dialog_2", "dialog_3");
+
+    fixture->routine_manager->finish();
+    checkActionProgress(3, "dialog_3", "dialog_2");
+
+    // move from action 3 to 1
+    g_assert(fixture->routine_manager->move(1));
+    checkActionProgress(1, "dialog_1", "dialog_3");
+
+    fixture->routine_manager->finish();
+    checkActionProgress(2, "dialog_2", "dialog_1");
+
+    // move from action 2 to 3
+    g_assert(fixture->routine_manager->move(3));
+    checkActionProgress(3, "dialog_3", "dialog_2");
+
+    // move to index of greater than action count (maintain action: 3)
+    g_assert(!fixture->routine_manager->move(4));
+    checkActionProgress(3, "dialog_3");
+
+    // move to index of less than action count (maintain action: 3)
+    g_assert(!fixture->routine_manager->move(-1));
+    checkActionProgress(3, "dialog_3");
+
+    // try to move when routine is finished (not progress)
+    fixture->routine_manager->finish();
+    checkRoutineActivity(RoutineActivity::FINISHED);
+
+    g_assert(!fixture->routine_manager->move(1));
+    checkRoutineActivity(RoutineActivity::FINISHED);
+
+    // try to move when routine stopped (not progress)
+    g_assert(fixture->routine_manager->start(fixture->routine_helper->getToken(), fixture->routine_helper->getActions()));
+    checkActionProgress(1);
+
+    fixture->routine_manager->stop();
+    checkRoutineActivity(RoutineActivity::STOPPED);
+
+    g_assert(!fixture->routine_manager->move(1));
+    checkRoutineActivity(RoutineActivity::STOPPED);
+
+    // try to move when routine is interrupted (progress)
+    g_assert(fixture->routine_manager->start(fixture->routine_helper->getToken(), fixture->routine_helper->getActions()));
+    fixture->routine_manager->finish();
+    fixture->routine_manager->finish();
+    checkActionProgress(3, "dialog_3"); // handle last action but, routine is not finished yet.
+
+    g_assert(fixture->routine_manager->move(2));
+    checkActionProgress(2, "dialog_2", "dialog_3");
+
+    fixture->routine_manager->interrupt();
+    g_assert(fixture->routine_manager->isInterrupted());
+    g_assert(!fixture->routine_manager->isRoutineProgress());
+    g_assert(fixture->routine_manager->isRoutineAlive()); // It still alive because routine is not finished.
+    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::INTERRUPTED);
+
+    g_assert(fixture->routine_manager->move(3));
+    checkActionProgress(3, "dialog_3", "dialog_1");
+}
+
 static void test_routine_manager_stop(TestFixture* fixture, gconstpointer ignored)
 {
-    sub_test_routine_manager_preset_start(fixture, ignored);
+    sub_test_routine_manager_start_routine(fixture);
 
     const auto& action_container = fixture->routine_manager->getActionContainer();
 
     fixture->routine_manager->stop();
     g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::STOPPED);
     g_assert(fixture->routine_manager->getCurrentActionIndex() == 0);
+    g_assert(fixture->routine_manager->getCountableActionIndex() == 0);
     g_assert(action_container.empty());
-}
-
-static void sub_test_routine_manager_preset_post_delay_actions(TestFixture* fixture, gconstpointer ignored)
-{
-    fixture->routine_helper->composeActions(
-        {
-            { "TEXT", "ps_id_1", "text_1", Json::nullValue, 2000 },
-            { "TEXT", "ps_id_2", "text_2", Json::nullValue, 3000 },
-            { "DATA", "ps_id_3", "", Json::Value("DATA_VALUE") },
-            { "DATA", "ps_id_4", "", Json::Value("DATA_VALUE") },
-        });
-
-    g_assert(fixture->routine_manager->start(fixture->routine_helper->getToken(), fixture->routine_helper->getActions()));
-    g_assert(fixture->routine_manager->getCurrentActionIndex() == 1);
 }
 
 static void test_routine_manager_stop_in_post_delayed(TestFixture* fixture, gconstpointer ignored)
 {
-    sub_test_routine_manager_preset_post_delay_actions(fixture, ignored);
+    sub_test_routine_manager_start_routine(fixture, TestType::PostDelay);
 
     // hold by interrupt
     fixture->routine_manager->finish();
@@ -434,9 +593,46 @@ static void test_routine_manager_stop_in_post_delayed(TestFixture* fixture, gcon
     g_assert(!fixture->routine_manager->hasPostDelayed());
 }
 
+static void test_routine_manager_set_pending_stop(TestFixture* fixture, gconstpointer ignored)
+{
+    sub_test_routine_manager_start_routine(fixture);
+
+    fixture->routine_manager->setPendingStop(fixture->ndir_routine);
+    g_assert(!fixture->routine_manager->hasPendingStop());
+
+    // reset flag in next action progress
+    fixture->routine_manager->setPendingStop(fixture->ndir_routine_stop);
+    g_assert(fixture->routine_manager->hasPendingStop());
+    fixture->routine_manager->finish();
+    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::PLAYING);
+    g_assert(!fixture->routine_manager->hasPendingStop());
+
+    // reset flag in move
+    fixture->routine_manager->setPendingStop(fixture->ndir_routine_stop);
+    g_assert(fixture->routine_manager->hasPendingStop());
+    g_assert(fixture->routine_manager->move(3));
+    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::PLAYING);
+    g_assert(!fixture->routine_manager->hasPendingStop());
+
+    // reset flag in finish
+    fixture->routine_manager->setPendingStop(fixture->ndir_routine_stop);
+    g_assert(fixture->routine_manager->hasPendingStop());
+    fixture->routine_manager->finish();
+    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::FINISHED);
+    g_assert(!fixture->routine_manager->hasPendingStop());
+
+    // reset flag in stop
+    sub_test_routine_manager_start_routine(fixture);
+    fixture->routine_manager->setPendingStop(fixture->ndir_routine_stop);
+    g_assert(fixture->routine_manager->hasPendingStop());
+    fixture->routine_manager->stop();
+    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::STOPPED);
+    g_assert(!fixture->routine_manager->hasPendingStop());
+}
+
 static void test_routine_manager_continue(TestFixture* fixture, gconstpointer ignored)
 {
-    sub_test_routine_manager_preset_start(fixture, ignored);
+    sub_test_routine_manager_start_routine(fixture);
 
     // execute next second action
     fixture->routine_manager->finish();
@@ -457,7 +653,7 @@ static void test_routine_manager_continue(TestFixture* fixture, gconstpointer ig
 
 static void test_routine_manager_continue_in_post_delayed(TestFixture* fixture, gconstpointer ignored)
 {
-    sub_test_routine_manager_preset_post_delay_actions(fixture, ignored);
+    sub_test_routine_manager_start_routine(fixture, TestType::PostDelay);
 
     // hold by interrupt
     fixture->routine_manager->finish();
@@ -467,21 +663,22 @@ static void test_routine_manager_continue_in_post_delayed(TestFixture* fixture, 
 
     // resume
     fixture->routine_manager->resume();
+    g_assert(fixture->routine_manager->getCurrentActionIndex() == 1);
     onTimeElapsed(fixture);
     g_assert(fixture->routine_manager->getCurrentActionIndex() == 2);
 }
 
 static void test_routine_manager_post_delay_among_actions(TestFixture* fixture, gconstpointer ignored)
 {
-    sub_test_routine_manager_preset_post_delay_actions(fixture, ignored);
+    sub_test_routine_manager_start_routine(fixture, TestType::PostDelay);
 
-    // apply delay about 2000 msec
+    // apply delay about 1000 msec
     fixture->routine_manager->finish();
     g_assert(fixture->routine_manager->getCurrentActionIndex() == 1);
     onTimeElapsed(fixture);
     g_assert(fixture->routine_manager->getCurrentActionIndex() == 2);
 
-    // apply delay about 3000 msec
+    // apply delay about 2000 msec
     fixture->routine_manager->finish();
     g_assert(fixture->routine_manager->getCurrentActionIndex() == 2);
     onTimeElapsed(fixture);
@@ -490,6 +687,143 @@ static void test_routine_manager_post_delay_among_actions(TestFixture* fixture, 
     // no delay
     fixture->routine_manager->finish();
     g_assert(fixture->routine_manager->getCurrentActionIndex() == 4);
+}
+
+static void test_routine_manager_handle_action_timeout(TestFixture* fixture, gconstpointer ignored)
+{
+    sub_test_routine_manager_start_routine(fixture, TestType::ActionTimeout);
+
+    fixture->routine_manager->finish();
+    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::SUSPENDED);
+    g_assert(fixture->routine_manager->getCurrentActionIndex() == 2);
+    g_assert(fixture->routine_manager->isActionTimeout());
+
+    // interrupt not possible, if the routine is suspended.
+    fixture->routine_manager->interrupt();
+    g_assert(fixture->routine_manager_listener->getActivity() != RoutineActivity::INTERRUPTED);
+
+    // finish is prevented when handling action timeout
+    fixture->routine_manager->finish();
+    g_assert(fixture->routine_manager_listener->getActivity() != RoutineActivity::PLAYING);
+    g_assert(fixture->routine_manager->getCurrentActionIndex() == 2);
+    g_assert(fixture->routine_manager->isActionTimeout());
+
+    // move is possible when handling action timeout
+    g_assert(fixture->routine_manager->move(3));
+    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::PLAYING);
+    g_assert(fixture->routine_manager->getCurrentActionIndex() == 3);
+    g_assert(!fixture->routine_manager->isActionTimeout());
+    g_assert(!fixture->fake_timer->isStarted()); // timer stopped
+
+    // assume media start is notified and start action timeout timer
+    g_assert(fixture->routine_manager->move(2));
+    onTimeElapsed(fixture);
+    g_assert(fixture->routine_manager_listener->isActionTimeout());
+    g_assert(!fixture->routine_manager_listener->isProcessedInLastAction());
+    g_assert(fixture->routine_manager->move(3));
+    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::PLAYING);
+    g_assert(fixture->routine_manager->getCurrentActionIndex() == 3);
+
+    // process action timeout in last action
+    g_assert(fixture->routine_manager->move(4));
+    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::SUSPENDED);
+    g_assert(fixture->routine_manager->getCurrentActionIndex() == 4);
+    fixture->routine_manager_listener->reset();
+    onTimeElapsed(fixture);
+    g_assert(fixture->routine_manager_listener->isActionTimeout());
+    g_assert(fixture->routine_manager_listener->isProcessedInLastAction());
+
+    // stop in processing action timeout
+    g_assert(fixture->routine_manager->move(2));
+    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::SUSPENDED);
+    g_assert(fixture->routine_manager->getCurrentActionIndex() == 2);
+    g_assert(fixture->routine_manager->isActionTimeout());
+
+    fixture->routine_manager->stop();
+    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::STOPPED);
+    g_assert(fixture->routine_manager->getCurrentActionIndex() == 0);
+    g_assert(!fixture->routine_manager->isActionTimeout());
+}
+
+static void test_routine_manager_use_preset_action_timeout(TestFixture* fixture, gconstpointer ignored)
+{
+    sub_test_routine_manager_start_routine(fixture, TestType::DefaultActionTimeout);
+
+    // process media in middle action (no action timeout) -> use default
+    g_assert(!fixture->routine_manager->isActionTimeout());
+    fixture->routine_manager->presetActionTimeout();
+    g_assert(fixture->routine_manager->isActionTimeout());
+    g_assert(fixture->fake_timer->getInterval() == 5000); // set default (5ms)
+
+    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::SUSPENDED);
+    g_assert(fixture->routine_manager->getCurrentActionIndex() == 1);
+
+    onTimeElapsed(fixture);
+    g_assert(fixture->routine_manager->move(2));
+
+    // process media in middle action (has action timeout) -> use received data
+    g_assert(fixture->routine_manager->isActionTimeout());
+    fixture->routine_manager->presetActionTimeout();
+    g_assert(fixture->fake_timer->getInterval() == 2000);
+
+    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::SUSPENDED);
+    g_assert(fixture->routine_manager->getCurrentActionIndex() == 2);
+
+    onTimeElapsed(fixture);
+    g_assert(fixture->routine_manager->move(3));
+
+    // process media in last action (no action timeout) -> nothing
+    g_assert(!fixture->routine_manager->isActionTimeout());
+    fixture->routine_manager->presetActionTimeout();
+    g_assert(!fixture->routine_manager->isActionTimeout());
+    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::PLAYING);
+    g_assert(fixture->routine_manager->getCurrentActionIndex() == 3);
+}
+
+static void test_routine_manager_handle_break_action(TestFixture* fixture, gconstpointer ignored)
+{
+    sub_test_routine_manager_start_routine(fixture, TestType::BreakAction);
+
+    // SUSPENDED as handling BREAK action (activate mute delay timer)
+    fixture->routine_manager->finish();
+    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::SUSPENDED);
+    g_assert(fixture->routine_manager->getCurrentActionIndex() == 2);
+
+    // interrupt/finish/move is prevented when handling BREAK action
+    fixture->routine_manager->interrupt();
+    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::SUSPENDED);
+    g_assert(fixture->routine_manager->getCurrentActionIndex() == 2);
+    fixture->routine_manager->finish();
+    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::SUSPENDED);
+    g_assert(fixture->routine_manager->getCurrentActionIndex() == 2);
+    g_assert(!fixture->routine_manager->move(3));
+
+    // progress next action after mute delay timeout
+    onTimeElapsed(fixture);
+    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::PLAYING);
+    g_assert(fixture->routine_manager->getCurrentActionIndex() == 3);
+
+    // Because action-2 type is BREAK, it pass to action-3
+    g_assert(fixture->routine_manager->move(2));
+    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::PLAYING);
+    g_assert(fixture->routine_manager->getCurrentActionIndex() == 3);
+
+    // Because action-4 has no mute delay, it progress next action immediately
+    fixture->routine_manager->finish();
+    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::PLAYING);
+    g_assert(fixture->routine_manager->getCurrentActionIndex() == 5);
+
+    // stop routine in mute delay
+    g_assert(fixture->routine_manager->move(1));
+    fixture->routine_manager->finish();
+    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::SUSPENDED);
+    g_assert(fixture->routine_manager->getCurrentActionIndex() == 2);
+    g_assert(fixture->routine_manager->isMuteDelayed());
+
+    fixture->routine_manager->stop();
+    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::STOPPED);
+    g_assert(fixture->routine_manager->getCurrentActionIndex() == 0);
+    g_assert(!fixture->routine_manager->isMuteDelayed());
 }
 
 static void test_routine_manager_check_has_routine_directive(TestFixture* fixture, gconstpointer ignored)
@@ -503,7 +837,7 @@ static void test_routine_manager_check_routine_alive(TestFixture* fixture, gcons
 {
     g_assert(!fixture->routine_manager->isRoutineAlive());
 
-    sub_test_routine_manager_preset_start(fixture, ignored);
+    sub_test_routine_manager_start_routine(fixture);
     g_assert(fixture->routine_manager->isRoutineAlive());
 
     fixture->routine_manager->interrupt();
@@ -515,7 +849,7 @@ static void test_routine_manager_check_routine_alive(TestFixture* fixture, gcons
 
 static void test_routine_manager_check_condition_to_stop(TestFixture* fixture, gconstpointer ignored)
 {
-    sub_test_routine_manager_preset_start(fixture, ignored);
+    sub_test_routine_manager_start_routine(fixture);
 
     g_assert(!fixture->routine_manager->isConditionToStop(nullptr));
 
@@ -525,9 +859,8 @@ static void test_routine_manager_check_condition_to_stop(TestFixture* fixture, g
     g_assert(!fixture->routine_manager->isConditionToStop(fixture->ndir_info));
     g_assert(!fixture->routine_manager->isConditionToStop(fixture->ndir_routine));
 
-    // The received directive has ASR.ExpectSpeech or AudioPlayer.Play in progressing middle action. (stop)
+    // The received directive has ASR.ExpectSpeech in progressing middle action. (stop)
     g_assert(fixture->routine_manager->isConditionToStop(fixture->ndir_dm));
-    g_assert(fixture->routine_manager->isConditionToStop(fixture->ndir_media));
 
     // The received directive is for another play, not routine action. (stop if routine directive not exist)
     fixture->routine_manager->finish();
@@ -540,16 +873,25 @@ static void test_routine_manager_check_condition_to_stop(TestFixture* fixture, g
     g_assert(fixture->routine_manager->isRoutineAlive());
     g_assert(fixture->routine_manager->isActionProgress("dialog_3"));
 
-    // The received directive has ASR.ExpectSpeech or AudioPlayer.Play in progressing last action. (not stop)
+    // The received directive has ASR.ExpectSpeech in progressing last action. (not stop)
     changeDialogId(fixture->ndir_dm, "dialog_3");
-    changeDialogId(fixture->ndir_media, "dialog_3");
     g_assert(!fixture->routine_manager->isConditionToStop(fixture->ndir_dm));
-    g_assert(!fixture->routine_manager->isConditionToStop(fixture->ndir_media));
 
     // The routine is not activated. (not stop)
     fixture->routine_manager->stop();
     g_assert(!fixture->routine_manager->isRoutineAlive());
     g_assert(!fixture->routine_manager->isConditionToStop(fixture->ndir_info));
+
+    // check suspended case (not stop)
+    sub_test_routine_manager_start_routine(fixture, TestType::BreakAction);
+
+    fixture->routine_manager->finish();
+    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::SUSPENDED);
+    g_assert(!fixture->routine_manager->isConditionToStop(fixture->ndir_info));
+
+    onTimeElapsed(fixture);
+    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::PLAYING);
+    g_assert(fixture->routine_manager->isConditionToStop(fixture->ndir_info));
 }
 
 static void test_routine_manager_check_condition_to_finish_action(TestFixture* fixture, gconstpointer ignored)
@@ -583,23 +925,102 @@ static void test_routine_manager_check_condition_to_finish_action(TestFixture* f
     g_assert(!fixture->routine_manager->isConditionToFinishAction(fixture->ndir_info_tts));
 }
 
+static void test_routine_manager_check_condition_to_cancel(TestFixture* fixture, gconstpointer ignored)
+{
+    // condition to cancel (has Routine directive except Routine.Stop)
+    g_assert(fixture->routine_manager->isConditionToCancel(fixture->ndir_routine));
+
+    // condition not to cancel
+    g_assert(!fixture->routine_manager->isConditionToCancel(nullptr));
+    g_assert(!fixture->routine_manager->isConditionToCancel(fixture->ndir_routine_stop));
+    g_assert(!fixture->routine_manager->isConditionToCancel(fixture->ndir_info));
+}
+
+static void test_routine_manager_check_has_to_skip_media(TestFixture* fixture, gconstpointer ignored)
+{
+    // not skip in routine inactive
+    g_assert(!fixture->routine_manager->hasToSkipMedia("dialog_1"));
+
+    sub_test_routine_manager_start_routine(fixture, TestType::ActionTimeout);
+    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::PLAYING);
+
+    // not skip in current action progress
+    g_assert(!fixture->routine_manager->hasToSkipMedia("dialog_1"));
+    // skip in another dialog progress
+    g_assert(fixture->routine_manager->hasToSkipMedia("dialog_4"));
+
+    // not skip in routine suspended
+    fixture->routine_manager->finish();
+    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::SUSPENDED);
+    g_assert(!fixture->routine_manager->hasToSkipMedia("dialog_4"));
+    onTimeElapsed(fixture);
+
+    // not skip in pending stop
+    g_assert(fixture->routine_manager->move(3));
+    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::PLAYING);
+    fixture->routine_manager->setPendingStop(fixture->ndir_routine_stop);
+    g_assert(!fixture->routine_manager->hasToSkipMedia("dialog_4"));
+}
+
+static void test_routine_manager_get_current_action_token(TestFixture* fixture, gconstpointer ignored)
+{
+    g_assert(fixture->routine_manager->getCurrentActionToken().empty());
+
+    // start routine
+    g_assert(fixture->routine_manager->start(fixture->routine_helper->getToken(), fixture->routine_helper->getActions()));
+    g_assert(fixture->routine_manager->getCurrentActionIndex() == 1);
+    g_assert(fixture->routine_manager->getCurrentActionToken() == fixture->routine_helper->getActionToken(1));
+
+    // run next action
+    fixture->routine_manager->finish();
+    g_assert(fixture->routine_manager->getCurrentActionIndex() == 2);
+    g_assert(fixture->routine_manager->getCurrentActionToken() == fixture->routine_helper->getActionToken(2));
+
+    // stop routine
+    fixture->routine_manager->stop();
+    g_assert(fixture->routine_manager->getCurrentActionIndex() == 0);
+    g_assert(fixture->routine_manager->getCurrentActionToken().empty());
+}
+
+static void test_routine_manager_get_countable_action_info(TestFixture* fixture, gconstpointer ignored)
+{
+    sub_test_routine_manager_start_routine(fixture, TestType::CountableAction);
+
+    g_assert(fixture->routine_manager->getActionContainer().size() == 3);
+    g_assert(fixture->routine_manager->getCountableActionSize() == 2); // BREAK type excluded
+    g_assert(fixture->routine_manager->getCurrentActionIndex() == 1);
+    g_assert(fixture->routine_manager->getCountableActionIndex() == 1);
+
+    fixture->routine_manager->finish();
+    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::SUSPENDED);
+    g_assert(fixture->routine_manager->getCurrentActionIndex() == 2);
+    g_assert(fixture->routine_manager->getCountableActionIndex() == 1);
+
+    onTimeElapsed(fixture);
+    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::PLAYING);
+    g_assert(fixture->routine_manager->getCurrentActionIndex() == 3);
+    g_assert(fixture->routine_manager->getCountableActionIndex() == 2);
+
+    fixture->routine_manager->finish();
+    g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::FINISHED);
+    g_assert(fixture->routine_manager->getCurrentActionIndex() == 0);
+    g_assert(fixture->routine_manager->getCountableActionIndex() == 0);
+}
+
 static void test_routine_manager_reset(TestFixture* fixture, gconstpointer ignored)
 {
     const auto& action_container = fixture->routine_manager->getActionContainer();
     const auto& action_dialogs = fixture->routine_manager->getActionDialogs();
-    fixture->routine_manager->addListener(fixture->routine_manager_listener.get());
 
-    fixture->routine_helper->composeActions(
-        {
-            { "TEXT", "ps_id_1", "text_1", Json::nullValue, 2000 },
-            { "DATA", "ps_id_2", "", Json::Value("DATA_VALUE") },
-        });
+    sub_test_routine_manager_start_routine(fixture, TestType::PostDelay);
+    fixture->routine_manager->setPendingStop(fixture->ndir_routine_stop);
 
-    g_assert(fixture->routine_manager->start(fixture->routine_helper->getToken(), fixture->routine_helper->getActions()));
     g_assert(fixture->routine_manager_listener->getActivity() == RoutineActivity::PLAYING);
     g_assert(fixture->routine_manager->getCurrentActionIndex() == 1);
+    g_assert(fixture->routine_manager->getCountableActionIndex() == 1);
     g_assert(!fixture->routine_manager->getToken().empty());
     g_assert(fixture->routine_manager->hasPostDelayed());
+    g_assert(fixture->routine_manager->hasPendingStop());
     g_assert(!action_container.empty());
     g_assert(!action_dialogs.empty());
 
@@ -612,11 +1033,44 @@ static void test_routine_manager_reset(TestFixture* fixture, gconstpointer ignor
     g_assert(!fixture->routine_manager->getDataRequester());
     g_assert(fixture->routine_manager->getActivity() == RoutineActivity::IDLE);
     g_assert(fixture->routine_manager->getCurrentActionIndex() == 0);
+    g_assert(fixture->routine_manager->getCountableActionIndex() == 0);
     g_assert(fixture->routine_manager->getToken().empty());
     g_assert(!fixture->routine_manager->isInterrupted());
     g_assert(!fixture->routine_manager->hasPostDelayed());
+    g_assert(!fixture->routine_manager->hasPendingStop());
     g_assert(action_container.empty());
     g_assert(action_dialogs.empty());
+
+    // check last [action processed, mute delay, action timeout] flags reset
+    auto checkFlagReset = [&](TestType test_type, std::function<bool()>&& check_func) {
+        fixture->routine_manager->setTextRequester(
+            [](const std::string& token, const std::string& text, const std::string& ps_id) {
+                return "dialog_1";
+            });
+        fixture->routine_manager->setDataRequester(
+            [](const std::string& ps_id, const Json::Value& data) {
+                return "dialog_3";
+            });
+
+        sub_test_routine_manager_start_routine(fixture, test_type);
+        fixture->routine_manager->finish();
+
+        g_assert(check_func());
+        fixture->routine_manager->reset();
+        g_assert(!check_func());
+    };
+
+    checkFlagReset(TestType::LastActionProcessed, [&] {
+        return fixture->routine_manager->isLastActionProcessed();
+    });
+
+    checkFlagReset(TestType::BreakAction, [&] {
+        return fixture->routine_manager->isMuteDelayed();
+    });
+
+    checkFlagReset(TestType::ActionTimeout, [&] {
+        return fixture->routine_manager->isActionTimeout();
+    });
 }
 
 int main(int argc, char* argv[])
@@ -633,15 +1087,24 @@ int main(int argc, char* argv[])
     G_TEST_ADD_FUNC("/core/RoutineManager/composeActionQueue", test_routine_manager_compose_action_queue);
     G_TEST_ADD_FUNC("/core/RoutineManager/normal", test_routine_manager_normal);
     G_TEST_ADD_FUNC("/core/RoutineManager/interrupt", test_routine_manager_interrupt);
+    G_TEST_ADD_FUNC("/core/RoutineManager/move", test_routine_manager_move);
     G_TEST_ADD_FUNC("/core/RoutineManager/stop", test_routine_manager_stop);
     G_TEST_ADD_FUNC("/core/RoutineManager/stopInPostDelayed", test_routine_manager_stop_in_post_delayed);
+    G_TEST_ADD_FUNC("/core/RoutineManager/setPendingStop", test_routine_manager_set_pending_stop);
     G_TEST_ADD_FUNC("/core/RoutineManager/continue", test_routine_manager_continue);
     G_TEST_ADD_FUNC("/core/RoutineManager/continueInPostDelayed", test_routine_manager_continue_in_post_delayed);
     G_TEST_ADD_FUNC("/core/RoutineManager/postDelayAmongActions", test_routine_manager_post_delay_among_actions);
+    G_TEST_ADD_FUNC("/core/RoutineManager/handleActionTimeout", test_routine_manager_handle_action_timeout);
+    G_TEST_ADD_FUNC("/core/RoutineManager/usePresetActionTimeout", test_routine_manager_use_preset_action_timeout);
+    G_TEST_ADD_FUNC("/core/RoutineManager/handleBreakAction", test_routine_manager_handle_break_action);
     G_TEST_ADD_FUNC("/core/RoutineManager/checkHasRoutineDirective", test_routine_manager_check_has_routine_directive);
     G_TEST_ADD_FUNC("/core/RoutineManager/checkRoutineAlive", test_routine_manager_check_routine_alive);
     G_TEST_ADD_FUNC("/core/RoutineManager/checkConditionToStop", test_routine_manager_check_condition_to_stop);
     G_TEST_ADD_FUNC("/core/RoutineManager/checkConditionToFinishAction", test_routine_manager_check_condition_to_finish_action);
+    G_TEST_ADD_FUNC("/core/RoutineManager/checkConditionToCancel", test_routine_manager_check_condition_to_cancel);
+    G_TEST_ADD_FUNC("/core/RoutineManager/checkHasToSkipMedia", test_routine_manager_check_has_to_skip_media);
+    G_TEST_ADD_FUNC("/core/RoutineManager/getCurrentActionToken", test_routine_manager_get_current_action_token);
+    G_TEST_ADD_FUNC("/core/RoutineManager/getCountableActionInfo", test_routine_manager_get_countable_action_info);
     G_TEST_ADD_FUNC("/core/RoutineManager/reset", test_routine_manager_reset);
 
     return g_test_run();


### PR DESCRIPTION
It add/update the RoutineManager API to respond to routine interface 1.3.

It compose the RoutineManager test to implement API functions.

New Added API
* IRoutineManagerListener
	- onActionTimeout()
* IRoutineManager
	- move()
	- getCurrentActionToken()
	- getCountableActionSize()
	- getCountableActionIndex()
	- isConditionToCancel()
	- isMuteDelayed()
	- presetActionTimeout()
	- setPendingStop()
	- hasToSkipMedia()

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>