### PR TITLE
Routine: apply Routine Interface v1.3

### DIFF
--- a/include/capability/routine_interface.hh
+++ b/include/capability/routine_interface.hh
@@ -58,6 +58,22 @@ public:
      * @return whether starting routine is success or not
      */
     virtual bool startRoutine(const std::string& dialog_id, const std::string& data) = 0;
+
+    /**
+     * @brief move to the next action and process.
+     * @return Result of operation
+     * @retval true succeed to move and process
+     * @retval false fail to move and process
+     */
+    virtual bool next() = 0;
+
+    /**
+     * @brief move to the previous action and process.
+     * @return Result of operation
+     * @retval true succeed to move and process
+     * @retval false fail to move and process
+     */
+    virtual bool prev() = 0;
 };
 
 /**

--- a/src/capability/asr_agent.hh
+++ b/src/capability/asr_agent.hh
@@ -145,6 +145,7 @@ private:
     bool asr_cancel;
     bool listen_timeout_fail_beep;
     bool is_progress_release_focus;
+    bool is_routine_mute_delayed;
     std::string listen_timeout_event_msg_id;
     std::function<void(bool)> pending_release_focus;
 

--- a/src/capability/tts_agent.cc
+++ b/src/capability/tts_agent.cc
@@ -143,6 +143,8 @@ void TTSAgent::preprocessDirective(NuguDirective* ndir)
             routine_manager->stop();
 
         playsync_manager->prepareSync(getPlayServiceIdInStackControl(message), ndir);
+    } else if (!strcmp(dname, "Stop")) {
+        routine_manager->setPendingStop(ndir);
     }
 }
 
@@ -210,7 +212,7 @@ void TTSAgent::stopTTS()
     MediaPlayerState pre_state = cur_state;
 
     sendClearNudgeCommand(speak_dir);
-    postProcessDirective(!is_finished && routine_manager->hasRoutineDirective(speak_dir));
+    postProcessDirective(!is_finished && routine_manager->isConditionToCancel(speak_dir));
 
     if (player)
         player->stop();


### PR DESCRIPTION
It apply the Routine Interface v1.3 in RoutineAgent and related agents.

It update the directive post-processing condition in TTSAgent.

It update the media foreground focus skip condition in AudioPlayerAgnet.

main features
* It could move to the previous and next action.
* It could handle the media in the middle actions.
* The media is played for the duration of the action timeout.
* The action type BREAK is added to hold routine during mute delay.

Signed-off-by: Hyungrok.Kim <hr97gdi@sk.com>