### PR TITLE
clientkit: replace map in nugu_http to struct

### DIFF
--- a/include/clientkit/nugu_http_rest.hh
+++ b/include/clientkit/nugu_http_rest.hh
@@ -18,7 +18,6 @@
 #define __NUGU_HTTP_REST_H__
 
 #include <functional>
-#include <map>
 #include <string>
 
 #include <base/nugu_http.h>
@@ -211,7 +210,9 @@ private:
 
     NuguHttpHost* host;
     NuguHttpHeader* common_header;
-    std::map<NuguHttpRequest*, ResponseCallback> pending_async_callback;
+    struct pending_async_data {
+        ResponseCallback cb;
+    };
 };
 
 /**

--- a/src/base/nugu_http.c
+++ b/src/base/nugu_http.c
@@ -377,7 +377,7 @@ static void _curl_perform(NuguHttpRequest *req)
 
 	ret = curl_easy_perform(req->curl);
 	if (ret != CURLE_OK) {
-		nugu_error("%s", curl_easy_strerror(ret));
+		nugu_error("curl_easy_perform failed: %s", curl_easy_strerror(ret));
 		req->resp->code = -1;
 		return;
 	}


### PR DESCRIPTION
When memory is allocated, freed, and re-allocated, the same address can be allocated, so change to use a structure instead of a map through an address.

Signed-off-by: Inho Oh <webispy@gmail.com>