### PR TITLE
capability: add focus for bluetooth

### DIFF
--- a/examples/standalone/capability/bluetooth_listener.cc
+++ b/examples/standalone/capability/bluetooth_listener.cc
@@ -39,21 +39,21 @@ void BluetoothListener::finishDiscoverableMode()
         bt_handler->finishDiscoverableModeSucceeded();
 }
 
-void BluetoothListener::play()
+void BluetoothListener::play(bool by_focus)
 {
-    if (bt_handler)
+    if (bt_handler && !by_focus)
         bt_handler->mediaControlPlaySucceeded();
 }
 
-void BluetoothListener::stop()
+void BluetoothListener::stop(bool by_focus)
 {
-    if (bt_handler)
+    if (bt_handler && !by_focus)
         bt_handler->mediaControlStopSucceeded();
 }
 
-void BluetoothListener::pause()
+void BluetoothListener::pause(bool by_focus)
 {
-    if (bt_handler)
+    if (bt_handler && !by_focus)
         bt_handler->mediaControlPauseSucceeded();
 }
 

--- a/examples/standalone/capability/bluetooth_listener.hh
+++ b/examples/standalone/capability/bluetooth_listener.hh
@@ -29,9 +29,9 @@ public:
     void setCapabilityHandler(ICapabilityInterface* handler) override;
     void startDiscoverableMode(long duration_sec) override;
     void finishDiscoverableMode() override;
-    void play() override;
-    void stop() override;
-    void pause() override;
+    void play(bool by_focus) override;
+    void stop(bool by_focus) override;
+    void pause(bool by_focus) override;
     void next() override;
     void previous() override;
     void requestContext(BTDeviceInfo& device_info) override;

--- a/include/capability/bluetooth_interface.hh
+++ b/include/capability/bluetooth_interface.hh
@@ -79,18 +79,21 @@ public:
 
     /**
      * @brief Send command to play media to bluetooth adaptor
+     * @param by_focus request to play media to bluetooth adaptor by focus policy
      */
-    virtual void play() = 0;
+    virtual void play(bool by_focus = false) = 0;
 
     /**
      * @brief Send command to stop media to bluetooth adaptor
+     * @param by_focus request to stop media to bluetooth adaptor by focus policy
      */
-    virtual void stop() = 0;
+    virtual void stop(bool by_focus = false) = 0;
 
     /**
      * @brief Send command to pause media to bluetooth adaptor
+     * @param by_focus request to pause media to bluetooth adaptor by focus policy
      */
-    virtual void pause() = 0;
+    virtual void pause(bool by_focus = false) = 0;
 
     /**
      * @brief Send command to play next media to bluetooth adaptor
@@ -116,6 +119,12 @@ public:
 class IBluetoothHandler : virtual public ICapabilityInterface {
 public:
     virtual ~IBluetoothHandler() = default;
+
+    /**
+     * @brief Notify the audio player's state
+     * @param state audio player's state (INACTIVE / ACTIVE / PAUSED / UNUSABLE)
+     */
+    virtual void setAudioPlayerState(const std::string& state) = 0;
 
     /**
      * @brief Notify the success result of start discoverable mode

--- a/src/capability/bluetooth_agent.hh
+++ b/src/capability/bluetooth_agent.hh
@@ -23,6 +23,7 @@
 namespace NuguCapability {
 
 class BluetoothAgent final : public Capability,
+                             public IFocusResourceListener,
                              public IBluetoothHandler {
 public:
     BluetoothAgent();
@@ -35,6 +36,9 @@ public:
     void parsingDirective(const char* dname, const char* message) override;
     void updateInfoForContext(Json::Value& ctx) override;
 
+    void onFocusChanged(FocusState state) override;
+
+    void setAudioPlayerState(const std::string& state) override;
     void startDiscoverableModeSucceeded(bool has_paired_devices) override;
     void startDiscoverableModeFailed(bool has_paired_devices) override;
     void finishDiscoverableModeSucceeded() override;
@@ -68,11 +72,17 @@ private:
     void parsingNext(const char* message);
     void parsingPrevious(const char* message);
 
+    void executeOnForegroundAction();
+    void executeOnBackgroundAction();
+    void executeOnNoneAction();
+
     void printDeviceInformation(const BTDeviceInfo& device_info);
 
     IBluetoothListener* bt_listener = nullptr;
     std::string context_info;
     std::string ps_id;
+    FocusState focus_state = FocusState::NONE;
+    std::string player_state = "UNUSABLE";
 };
 } // NuguCapability
 


### PR DESCRIPTION
A2DP streaming is processed like audio player in the sdk. It is paused when keyword is detected and tts is played. It is also resumed when tts is playing finished. For this, add focus to the bluetooth.