### PR TITLE
capability: skip foreground action

### DIFF
--- a/src/capability/bluetooth_agent.hh
+++ b/src/capability/bluetooth_agent.hh
@@ -75,6 +75,7 @@ private:
     void executeOnForegroundAction();
     void executeOnBackgroundAction();
     void executeOnNoneAction();
+    bool hasToSkipForegroundAction();
 
     void printDeviceInformation(const BTDeviceInfo& device_info);
 


### PR DESCRIPTION
The bluetooth focus should not acquire when processing the multi-turn and the routine situation.