### PR TITLE
core: preload kwd model file

### DIFF
--- a/src/core/wakeup_detector.hh
+++ b/src/core/wakeup_detector.hh
@@ -67,6 +67,7 @@ private:
     void setPower(float power);
     void getPower(float& noise, float& speech);
     void setModelFile(const std::string& model_net_file, const std::string& model_search_file);
+    void preloadModelFile();
 
     IWakeupDetectorListener* listener = nullptr;
 


### PR DESCRIPTION
The event `WakeupState::DETECTED` is ignored when application requests stop and start repeatly during load kwd model file in `kwd_initialize`. Therefore, preload kwd model file in `WakeupDetector::initialize`.