### PR TITLE
fix issues detected by clang-tidy

### DIFF
--- a/examples/capability_injection/main_capability_injection.cc
+++ b/examples/capability_injection/main_capability_injection.cc
@@ -87,6 +87,14 @@ public:
 
 int main(int argc, char* argv[])
 {
+    const char *env_token;
+
+    env_token = getenv("NUGU_TOKEN");
+    if (env_token == NULL) {
+        std::cout << "Please set the token using the NUGU_TOKEN environment variable." << std::endl;
+        return -1;
+    }
+
     /* Turn off the SDK internal log */
     nugu_log_set_system(NUGU_LOG_SYSTEM_NONE);
 
@@ -114,7 +122,7 @@ int main(int argc, char* argv[])
     auto network_manager_listener(std::make_shared<MyNetwork>());
     auto network_manager(nugu_client->getNetworkManager());
     network_manager->addListener(network_manager_listener.get());
-    network_manager->setToken(getenv("NUGU_TOKEN"));
+    network_manager->setToken(env_token);
     network_manager->connect();
 
     /* Start GMainLoop */

--- a/examples/profiling/main_prof.cc
+++ b/examples/profiling/main_prof.cc
@@ -100,7 +100,7 @@ static void test_finished(void)
         return;
     }
 
-    /* CSV data */
+    /* CSV data, NOLINTNEXTLINE(cert-err33-c) */
     fprintf(fp_out, "%s,%d,%ld,%d,%d,%d,%d,%d,%s\n",
         test_name.c_str(), test_iteration, tmp->timestamp.tv_sec,
         nugu_prof_get_diff_msec_type(NUGU_PROF_TYPE_ASR_LISTENING_STARTED, NUGU_PROF_TYPE_ASR_END_POINT_DETECTED),
@@ -268,6 +268,7 @@ int main(int argc, char* argv[])
     std::string input_file;
     std::string output_file;
     std::string model_path = DEFAULT_MODEL_PATH;
+    const char* env_token;
 
     while ((c = getopt(argc, argv, "i:o:n:m:d:t:c:")) != -1) {
         switch (c) {
@@ -298,7 +299,8 @@ int main(int argc, char* argv[])
         }
     }
 
-    if (getenv("NUGU_TOKEN") == NULL) {
+    env_token = getenv("NUGU_TOKEN");
+    if (env_token == NULL) {
         printf("Please set the token using the NUGU_TOKEN environment variable.\n");
         return -1;
     }
@@ -313,7 +315,9 @@ int main(int argc, char* argv[])
         printf("Fail to open input file '%s'\n", input_file.c_str());
         return -1;
     }
-    fclose(fp_out);
+
+    if (fclose(fp_out))
+        printf("fclose() failed\n");
 
     if (test_name.size() == 0)
         test_name = input_file;
@@ -326,7 +330,7 @@ int main(int argc, char* argv[])
         return -1;
     }
 
-    /* CSV header */
+    /* CSV header, NOLINTNEXTLINE(cert-err33-c) */
     fprintf(fp_out, "Testcase,Num,timestamp,%s,%s,%s,%s,%s,Dialog_Request_ID\n",
         nugu_prof_get_type_name(NUGU_PROF_TYPE_ASR_END_POINT_DETECTED),
         nugu_prof_get_type_name(NUGU_PROF_TYPE_ASR_RESULT),
@@ -384,7 +388,7 @@ int main(int argc, char* argv[])
 
     auto network_manager(nugu_client->getNetworkManager());
     network_manager->addListener(network_manager_listener.get());
-    network_manager->setToken(getenv("NUGU_TOKEN"));
+    network_manager->setToken(env_token);
 
     network_timer_src = g_timeout_add_seconds(test_network_timeout, _network_timeout_cb, NULL);
     network_manager->connect();
@@ -400,8 +404,10 @@ int main(int argc, char* argv[])
 
     nugu_client->deInitialize();
 
-    if (fp_out)
-        fclose(fp_out);
+    if (fp_out) {
+        if (fclose(fp_out))
+            printf("fclose() failed\n");
+    }
 
     return 0;
 }

--- a/examples/response_filter/main.cc
+++ b/examples/response_filter/main.cc
@@ -177,7 +177,10 @@ public:
 
 int main(int argc, char* argv[])
 {
-    if (getenv("NUGU_TOKEN") == NULL) {
+    const char *env_token;
+
+    env_token = getenv("NUGU_TOKEN");
+    if (env_token == NULL) {
         std::cout << "Please set the token using the NUGU_TOKEN environment variable." << std::endl;
         return -1;
     }
@@ -238,7 +241,7 @@ int main(int argc, char* argv[])
 
     auto network_manager(nugu_client->getNetworkManager());
     network_manager->addListener(network_manager_listener.get());
-    network_manager->setToken(getenv("NUGU_TOKEN"));
+    network_manager->setToken(env_token);
     network_manager->connect();
 
     /* Start GMainLoop */

--- a/examples/simple_asr/main_asr.cc
+++ b/examples/simple_asr/main_asr.cc
@@ -156,7 +156,10 @@ public:
 
 int main()
 {
-    if (getenv("NUGU_TOKEN") == NULL) {
+    const char* env_token;
+
+    env_token = getenv("NUGU_TOKEN");
+    if (env_token == NULL) {
         std::cout << "Please set the token using the NUGU_TOKEN environment variable." << std::endl;
         return -1;
     }
@@ -206,7 +209,7 @@ int main()
 
     auto network_manager(nugu_client->getNetworkManager());
     network_manager->addListener(network_manager_listener.get());
-    network_manager->setToken(getenv("NUGU_TOKEN"));
+    network_manager->setToken(env_token);
     network_manager->connect();
 
     /* Start GMainLoop */

--- a/examples/simple_text/main_text.cc
+++ b/examples/simple_text/main_text.cc
@@ -83,12 +83,15 @@ public:
 
 int main(int argc, char* argv[])
 {
+    const char* env_token;
+
     if (argc != 2) {
         std::cout << "Usage: " << argv[0] << " Text-Command" << std::endl;
         return 0;
     }
 
-    if (getenv("NUGU_TOKEN") == NULL) {
+    env_token = getenv("NUGU_TOKEN");
+    if (env_token == NULL) {
         std::cout << "Please set the token using the NUGU_TOKEN environment variable." << std::endl;
         return -1;
     }
@@ -136,7 +139,7 @@ int main(int argc, char* argv[])
 
     auto network_manager(nugu_client->getNetworkManager());
     network_manager->addListener(network_manager_listener.get());
-    network_manager->setToken(getenv("NUGU_TOKEN"));
+    network_manager->setToken(env_token);
     network_manager->connect();
 
     /* Start GMainLoop */

--- a/examples/simple_tts/main_tts.cc
+++ b/examples/simple_tts/main_tts.cc
@@ -90,12 +90,15 @@ public:
 
 int main(int argc, char* argv[])
 {
+    const char* env_token;
+
     if (argc != 2) {
         std::cout << "Usage: " << argv[0] << " Text string" << std::endl;
         return 0;
     }
 
-    if (getenv("NUGU_TOKEN") == NULL) {
+    env_token = getenv("NUGU_TOKEN");
+    if (env_token == NULL) {
         std::cout << "Please set the token using the NUGU_TOKEN environment variable." << std::endl;
         return -1;
     }
@@ -135,7 +138,7 @@ int main(int argc, char* argv[])
 
     auto network_manager(nugu_client->getNetworkManager());
     network_manager->addListener(network_manager_listener.get());
-    network_manager->setToken(getenv("NUGU_TOKEN"));
+    network_manager->setToken(env_token);
     network_manager->connect();
 
     /* Start GMainLoop */

--- a/examples/standalone/nugu_sample_manager.cc
+++ b/examples/standalone/nugu_sample_manager.cc
@@ -246,6 +246,7 @@ void NuguSampleManager::showPrompt(void)
                   << C_RESET;
     }
 
+    // NOLINTNEXTLINE(cert-err33-c)
     fflush(stdout);
 }
 

--- a/examples/standalone/nugu_sdk_manager.cc
+++ b/examples/standalone/nugu_sdk_manager.cc
@@ -229,7 +229,11 @@ void NuguSDKManager::createInstance()
     setDefaultSoundLayerPolicy();
 
     network_manager->addListener(this);
-    network_manager->setToken(getenv("NUGU_TOKEN"));
+
+    const char* env_token = getenv("NUGU_TOKEN");
+    if (env_token)
+        network_manager->setToken(env_token);
+
     network_manager->setUserAgent("0.2.0");
 }
 

--- a/plugins/filereader.c
+++ b/plugins/filereader.c
@@ -256,6 +256,11 @@ static int _rec_start(NuguRecorderDriver *driver, NuguRecorder *rec,
 	}
 
 	rec_file = getenv(NUGU_ENV_RECORDING_FROM_FILE);
+	if (rec_file == NULL) {
+		nugu_error("can't get recording filename");
+		return -1;
+	}
+
 	src_fd = open(rec_file, O_RDONLY);
 	if (src_fd == -1) {
 		nugu_error("can't open the file: '%s'", rec_file);

--- a/plugins/gstreamer_recorder.c
+++ b/plugins/gstreamer_recorder.c
@@ -464,6 +464,9 @@ static int _rec_start(NuguRecorderDriver *driver, NuguRecorder *rec,
 	GstreamerHandle *gh = nugu_recorder_get_driver_data(rec);
 	int rec_5sec;
 	int rec_100ms;
+#ifdef NUGU_ENV_RECORDING_FROM_FILE
+	const char *env_filename;
+#endif
 
 	g_return_val_if_fail(rec != NULL, -1);
 
@@ -503,11 +506,10 @@ static int _rec_start(NuguRecorderDriver *driver, NuguRecorder *rec,
 #endif
 
 #ifdef NUGU_ENV_RECORDING_FROM_FILE
-	if (getenv(NUGU_ENV_RECORDING_FROM_FILE)) {
-		gh->src_fd =
-			open(getenv(NUGU_ENV_RECORDING_FROM_FILE), O_RDONLY);
-		nugu_dbg("recording from file: '%s'",
-			 getenv(NUGU_ENV_RECORDING_FROM_FILE));
+	env_filename = getenv(NUGU_ENV_RECORDING_FROM_FILE);
+	if (env_filename) {
+		gh->src_fd = open(env_filename, O_RDONLY);
+		nugu_dbg("recording from file: '%s'", env_filename);
 	} else {
 		gh->src_fd = -1;
 	}

--- a/plugins/portaudio_recorder.c
+++ b/plugins/portaudio_recorder.c
@@ -286,6 +286,9 @@ static int _rec_start(NuguRecorderDriver *driver, NuguRecorder *rec,
 	struct pa_audio_param *rec_param = nugu_recorder_get_driver_data(rec);
 	int rec_5sec;
 	int rec_100ms;
+#ifdef NUGU_ENV_RECORDING_FROM_FILE
+	const char *env_filename;
+#endif
 
 	if (rec_param) {
 		nugu_dbg("already start");
@@ -345,11 +348,10 @@ static int _rec_start(NuguRecorderDriver *driver, NuguRecorder *rec,
 #endif
 
 #ifdef NUGU_ENV_RECORDING_FROM_FILE
-	if (getenv(NUGU_ENV_RECORDING_FROM_FILE)) {
-		rec_param->src_fd =
-			open(getenv(NUGU_ENV_RECORDING_FROM_FILE), O_RDONLY);
-		nugu_dbg("recording from file: '%s'",
-			 getenv(NUGU_ENV_RECORDING_FROM_FILE));
+	env_filename = getenv(NUGU_ENV_RECORDING_FROM_FILE);
+	if (env_filename) {
+		rec_param->src_fd = open(env_filename, O_RDONLY);
+		nugu_dbg("recording from file: '%s'", env_filename);
 	} else {
 		rec_param->src_fd = -1;
 	}

--- a/src/base/network/http2/directives_parser.cc
+++ b/src/base/network/http2/directives_parser.cc
@@ -36,6 +36,7 @@
 #define FILTER_BODY_CONTENT_TYPE "Content-Type: "
 #define FILTER_JSON_TYPE "application/json"
 #define FILTER_OPUS_TYPE "audio/opus"
+#define MAX_GROUPNAME 32
 
 enum content_type {
     CONTENT_TYPE_UNKNOWN,
@@ -158,7 +159,7 @@ static void _body_json(DirParser* dp, const char* data, size_t length)
     NJson::Reader reader;
     NJson::StyledWriter writer;
     std::string group;
-    char group_buf[32];
+    char group_buf[MAX_GROUPNAME];
 
     if (!reader.parse(data, root)) {
         nugu_error("parsing error: '%s'", data);
@@ -206,8 +207,11 @@ static void _body_json(DirParser* dp, const char* data, size_t length)
         if (i > 0)
             group.append(",");
 
-        snprintf(group_buf, sizeof(group_buf), "\"%s.%s\"",
-            h["namespace"].asCString(), h["name"].asCString());
+        if (snprintf(group_buf, MAX_GROUPNAME, "\"%s.%s\"",
+                h["namespace"].asCString(), h["name"].asCString())
+            == 0)
+            group_buf[MAX_GROUPNAME - 1] = 0;
+
         group.append(group_buf);
     }
     group.append("] }");

--- a/src/base/nugu_log.c
+++ b/src/base/nugu_log.c
@@ -424,7 +424,10 @@ static void _log_formatted(enum nugu_log_module module,
 	else if (_log_system == NUGU_LOG_SYSTEM_CUSTOM && _log_handler) {
 		char msg[MAX_LOG_LENGTH];
 
-		vsnprintf(msg, MAX_LOG_LENGTH, format, arg);
+		if (vsnprintf(msg, MAX_LOG_LENGTH, format, arg) >=
+		    MAX_LOG_LENGTH)
+			msg[MAX_LOG_LENGTH - 1] = 0;
+
 		_log_handler(module, level, prefix, msg,
 			     _log_handler_user_data);
 
@@ -436,18 +439,28 @@ static void _log_formatted(enum nugu_log_module module,
 
 	pthread_mutex_lock(&_log_mutex);
 
+	/* NOLINTNEXTLINE(cert-err33-c) */
 	if (len > 0)
 		fprintf(fp, "%s ", prefix);
 
 	if (_log_level_map[level].color != NULL) {
+		/* NOLINTNEXTLINE(cert-err33-c) */
 		fputs(_log_level_map[level].color, fp);
+
+		/* NOLINTNEXTLINE(cert-err33-c) */
 		vfprintf(fp, format, arg);
+
+		/* NOLINTNEXTLINE(cert-err33-c) */
 		fputs(COLOR_OFF "\n", fp);
 	} else {
+		/* NOLINTNEXTLINE(cert-err33-c) */
 		vfprintf(fp, format, arg);
+
+		/* NOLINTNEXTLINE(cert-err33-c) */
 		fputc('\n', fp);
 	}
 
+	/* NOLINTNEXTLINE(cert-err33-c) */
 	fflush(fp);
 
 	pthread_mutex_unlock(&_log_mutex);
@@ -783,6 +796,7 @@ EXPORT_API void nugu_hexdump(enum nugu_log_module module, const uint8_t *data,
 	}
 
 	if (i % HEXDUMP_COLUMN_SIZE != 0)
+		/* NOLINTNEXTLINE(cert-err33-c) */
 		fputc('\n', fp);
 
 	if (footer)

--- a/src/base/nugu_network_manager.c
+++ b/src/base/nugu_network_manager.c
@@ -1075,7 +1075,11 @@ EXPORT_API int nugu_network_manager_send_event(NuguEvent *nev)
 
 		now = time(NULL);
 		gmtime_r(&now, &tm);
-		strftime(buf, sizeof(buf), "%a, %d %b %Y %H:%M:%S %Z", &tm);
+		if (strftime(buf, sizeof(buf), "%a, %d %b %Y %H:%M:%S %Z",
+			     &tm) == 0) {
+			nugu_error("strftime() failed");
+			buf[sizeof(buf) - 1] = 0;
+		}
 
 		if (_network->last_asr)
 			free(_network->last_asr);

--- a/src/base/nugu_plugin.c
+++ b/src/base/nugu_plugin.c
@@ -114,11 +114,12 @@ EXPORT_API void nugu_plugin_free(NuguPlugin *p)
 EXPORT_API int nugu_plugin_add(NuguPlugin *p)
 {
 	GList *cur;
-	NuguPlugin *tmp;
 
 	g_return_val_if_fail(p != NULL, -1);
 
 	for (cur = _plugin_list; cur; cur = cur->next) {
+		NuguPlugin *tmp;
+
 		tmp = cur->data;
 		if (!tmp)
 			continue;

--- a/src/base/nugu_prof.c
+++ b/src/base/nugu_prof.c
@@ -134,8 +134,12 @@ static void _fill_timestr(char *dest_buf, size_t bufsize,
 
 	localtime_r(&(ts->tv_sec), &tm_local);
 
-	strftime(dest_buf, 15, "%m-%d %H:%M:%S", &tm_local);
+	if (strftime(dest_buf, 15, "%m-%d %H:%M:%S", &tm_local) == 0) {
+		nugu_error("strftime() failed");
+		return;
+	}
 
+	/* NOLINTNEXTLINE(cert-err33-c) */
 	snprintf(dest_buf + 14, bufsize - 14, ".%03d",
 		 (int)(ts->tv_nsec / 1000000));
 }

--- a/src/capability/system_agent.cc
+++ b/src/capability/system_agent.cc
@@ -178,7 +178,11 @@ void SystemAgent::sendEventUserInactivityReport(int seconds, EventResultCallback
         return;
     }
 
-    snprintf(buf, 64, "{\"inactiveTimeInSeconds\": %d}", seconds);
+    if (snprintf(buf, 64, "{\"inactiveTimeInSeconds\": %d}", seconds) == 0) {
+        nugu_error("snprintf() failed");
+        buf[sizeof(buf) - 1] = 0;
+    }
+
     payload = buf;
 
     sendEvent(ename, getContextInfo(), payload, std::move(cb));

--- a/tests/test_nugu_uuid.c
+++ b/tests/test_nugu_uuid.c
@@ -93,7 +93,7 @@ static void test_nugu_uuid_time(void)
 	g_assert(t_spec.tv_sec == 1579655759);
 	g_assert(t_spec.tv_nsec == 39000000);
 	gmtime_r(&t_spec.tv_sec, &t_tm);
-	strftime(timestr, sizeof(timestr), "%F %T", &t_tm);
+	g_assert(strftime(timestr, sizeof(timestr), "%F %T", &t_tm) != 0);
 	g_assert_cmpstr(timestr, ==, "2020-01-22 01:15:59");
 
 	/* Convert timespec to 5 bytes */
@@ -108,7 +108,7 @@ static void test_nugu_uuid_time(void)
 	g_assert(t_spec.tv_sec == 1579655809);
 	g_assert(t_spec.tv_nsec == 627000000);
 	gmtime_r(&t_spec.tv_sec, &t_tm);
-	strftime(timestr, sizeof(timestr), "%F %T", &t_tm);
+	g_assert(strftime(timestr, sizeof(timestr), "%F %T", &t_tm) != 0);
 	g_assert_cmpstr(timestr, ==, "2020-01-22 01:16:49");
 
 	/* Convert timespec to 5 bytes */
@@ -123,7 +123,7 @@ static void test_nugu_uuid_time(void)
 	g_assert(t_spec.tv_sec == 1579740221);
 	g_assert(t_spec.tv_nsec == 516000000);
 	gmtime_r(&t_spec.tv_sec, &t_tm);
-	strftime(timestr, sizeof(timestr), "%F %T", &t_tm);
+	g_assert(strftime(timestr, sizeof(timestr), "%F %T", &t_tm) != 0);
 	g_assert_cmpstr(timestr, ==, "2020-01-23 00:43:41");
 
 	/* Convert timespec to 5 bytes */


### PR DESCRIPTION
Fix following issues
- the value returned by this function should be used [cert-err33-c]
- The parameter must not be null [clang-analyzer-cplusplus.StringChecker]