### PR TITLE
fix plugin architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ doc/latex
 
 # Auto-generated file
 include/nugu.h
+src/base/builtin.h
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,12 @@ SET(prefix ${CMAKE_INSTALL_PREFIX})
 SET(datadir ${CMAKE_INSTALL_FULL_DATAROOTDIR}/nugu)
 SET(bindir "${prefix}/${CMAKE_INSTALL_BINDIR}")
 SET(requires "")
+SET(builtin_decl "")
+SET(builtin_list "")
+
+SET(BUILTIN_PLUGIN_LIST "") # Array for built-in plugin
+SET(BUILTIN_PLUGIN_LIBS "") # TARGET_LINK_LIBRARIES for libnugu
+SET(BUILTIN_PLUGIN_DEPS "") # ADD_DEPENDENCIES for libnugu
 
 IF(PLUGIN_DIR)
 	SET(plugindir "${PLUGIN_DIR}")
@@ -108,6 +114,7 @@ DEFINE_FEATURE(VENDOR_LIBRARY ON "vendor specific library(nugu_wwd, nugu_epd)")
 DEFINE_FEATURE(BUILTIN_OPUS OFF "compile built-in OPUS library")
 DEFINE_FEATURE(BUILTIN_OPUS_FLOAT_API OFF "floating point to OPUS library")
 DEFINE_FEATURE(BUILTIN_CURL ${BUILTIN_CURL_DEFAULT} "compile built-in curl library")
+DEFINE_FEATURE(BUILTIN_PLUGIN "dummy,filedump" "List of plugins to be built-in in SDK")
 
 DEFINE_FEATURE(DL_LINKING ON "-ldl linking")
 DEFINE_FEATURE(SOCKET_LINKING OFF "-lsocket linking")
@@ -228,6 +235,11 @@ IF(ENABLE_EXAMPLES_ONLY)
 	SET(BUILD_EXAMPLES ON)
 ENDIF()
 
+IF(ENABLE_BUILTIN_PLUGIN)
+	# Change comma separated string to array
+	STRING(REPLACE "," ";" BUILTIN_PLUGIN_LIST ${ENABLE_BUILTIN_PLUGIN})
+ENDIF()
+
 IF(VENDOR_PKGCONFIG)
 	pkg_check_modules(vendor_pkgs REQUIRED ${VENDOR_PKGCONFIG})
 ENDIF()
@@ -257,10 +269,10 @@ ENDFOREACH()
 IF(ENABLE_GSTREAMER_PLUGIN)
 	pkg_check_modules(gstreamer_pkgs REQUIRED
 		gstreamer-1.0 gstreamer-app-1.0 gstreamer-pbutils-1.0)
-ENDIF()
 
-IF(ENABLE_GSTREAMER_PLUGIN_VOLUME)
-	ADD_DEFINITIONS(-DENABLE_GSTREAMER_PLUGIN_VOLUME)
+	IF(ENABLE_GSTREAMER_PLUGIN_VOLUME)
+		ADD_DEFINITIONS(-DENABLE_GSTREAMER_PLUGIN_VOLUME)
+	ENDIF()
 ENDIF()
 
 # Common compile options
@@ -406,13 +418,29 @@ ADD_DEFINITIONS(
 MESSAGE("")
 feature_summary(WHAT ALL)
 
-# External dependency modules - nghttp2, curl
 IF(BUILD_LIBRARY)
 	# Global include directories
 	INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/include)
 
-	# Install header files
+	FOREACH(item ${BUILTIN_PLUGIN_LIST})
+		SET(builtin_decl "${builtin_decl}extern struct nugu_plugin_desc _builtin_plugin_${item};\n")
+		SET(builtin_list "${builtin_list}&_builtin_plugin_${item},\n")
+	ENDFOREACH()
+
+	CONFIGURE_FILE(src/base/builtin.h.in ${PROJECT_SOURCE_DIR}/src/base/builtin.h @ONLY)
 	CONFIGURE_FILE(nugu.h.in ${PROJECT_SOURCE_DIR}/include/nugu.h @ONLY)
+ENDIF()
+
+# External dependency modules - nghttp2, curl
+ADD_SUBDIRECTORY(externals)
+
+# Plugins
+IF(BUILD_PLUGINS)
+	ADD_SUBDIRECTORY(plugins)
+ENDIF()
+
+IF(BUILD_LIBRARY)
+	# Install header files
 	INSTALL(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/nugu/)
 
 	# Install pkgconfig
@@ -424,8 +452,6 @@ IF(BUILD_LIBRARY)
 
 	ENABLE_TESTING()
 
-	ADD_SUBDIRECTORY(externals)
-
 	# NUGU SDK
 	ADD_SUBDIRECTORY(src)
 
@@ -433,12 +459,8 @@ IF(BUILD_LIBRARY)
 	ADD_SUBDIRECTORY(tests)
 ENDIF()
 
-# HAL Plugins
-IF(BUILD_PLUGINS)
-	ADD_SUBDIRECTORY(plugins)
-ENDIF()
-
 # Examples
 IF(BUILD_EXAMPLES)
 	ADD_SUBDIRECTORY(examples)
 ENDIF()
+

--- a/include/base/nugu_plugin.h
+++ b/include/base/nugu_plugin.h
@@ -58,14 +58,25 @@ extern "C" {
 /**
  * @brief Macros to easily define plugins
  */
+#ifdef NUGU_PLUGIN_BUILTIN
 #define NUGU_PLUGIN_DEFINE(p_name, p_prio, p_ver, p_load, p_unload, p_init)    \
 	__attribute__((visibility("default"))) struct nugu_plugin_desc         \
-		nugu_plugin_define_desc = { .name = p_name,                    \
+		_builtin_plugin_##p_name = { .name = #p_name,                  \
+					     .priority = p_prio,               \
+					     .version = p_ver,                 \
+					     .load = p_load,                   \
+					     .unload = p_unload,               \
+					     .init = p_init }
+#else
+#define NUGU_PLUGIN_DEFINE(p_name, p_prio, p_ver, p_load, p_unload, p_init)    \
+	__attribute__((visibility("default"))) struct nugu_plugin_desc         \
+		nugu_plugin_define_desc = { .name = #p_name,                   \
 					    .priority = p_prio,                \
 					    .version = p_ver,                  \
 					    .load = p_load,                    \
 					    .unload = p_unload,                \
 					    .init = p_init }
+#endif
 
 /**
  * @brief Plugin object
@@ -205,6 +216,13 @@ const struct nugu_plugin_desc *nugu_plugin_get_description(NuguPlugin *p);
  * @retval -1 failure
  */
 int nugu_plugin_load_directory(const char *dirpath);
+
+/**
+ * @brief Load all built-in plugins
+ * @return Number of plugins loaded
+ * @retval -1 failure
+ */
+int nugu_plugin_load_builtin(void);
 
 /**
  * @brief Initialize plugin

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,104 +1,162 @@
-ADD_LIBRARY(dummy SHARED dummy.c)
-TARGET_LINK_LIBRARIES(dummy -lnugu)
-SET_TARGET_PROPERTIES(dummy PROPERTIES PREFIX "" OUTPUT_NAME dummy)
-INSTALL(TARGETS dummy LIBRARY DESTINATION ${plugindir})
-ADD_DEPENDENCIES(dummy libnugu)
+# for TARGET_COMPILE_DEFINITIONS
+SET(BUILTIN_PLUGIN_DEFS "")
 
-ADD_LIBRARY(filedump SHARED filedump.c)
-TARGET_LINK_LIBRARIES(filedump ${pkgs_LDFLAGS} -lnugu)
-SET_TARGET_PROPERTIES(filedump PROPERTIES PREFIX "" OUTPUT_NAME filedump)
-INSTALL(TARGETS filedump LIBRARY DESTINATION ${plugindir} COMPONENT libnugu_component)
-ADD_DEPENDENCIES(filedump libnugu)
+# for TARGET_INCLUDE_DIRECTORIES
+SET(BUILTIN_PLUGIN_IDIR "")
 
-ADD_LIBRARY(filereader SHARED filereader.c)
-TARGET_LINK_LIBRARIES(filereader ${pkgs_LDFLAGS} -lnugu)
-SET_TARGET_PROPERTIES(filereader PROPERTIES PREFIX "" OUTPUT_NAME filereader)
-INSTALL(TARGETS filereader LIBRARY DESTINATION ${plugindir} COMPONENT libnugu_component)
-ADD_DEPENDENCIES(filereader libnugu)
+# for ADD_DEPENDENCIES
+SET(BUILTIN_PLUGIN_DEPS "")
 
-# OPUS plugin
-IF(ENABLE_OPUS_PLUGIN)
-	ADD_LIBRARY(opus SHARED opus.c)
+# for ADD_LIBRARY
+SET(BUILTIN_PLUGIN_SRCS "")
 
-	IF(ENABLE_BUILTIN_OPUS)
-		TARGET_INCLUDE_DIRECTORIES(opus PRIVATE
-			${PROJECT_BINARY_DIR}/opus/include/opus)
-		TARGET_LINK_LIBRARIES(opus ${pkgs_LDFLAGS}
-			${PROJECT_BINARY_DIR}/opus/lib/libopus.a
-			-lnugu -lm)
-		ADD_DEPENDENCIES(opus OPUSLIB)
+# for pkg_check_modules
+SET(BUILTIN_PLUGIN_PKGS "")
+
+# shared library plugin list
+SET(PLUGIN_LIST "")
+
+# Macro for plugin definition
+MACRO(DEFINE_PLUGIN name)
+	STRING(TOUPPER ${name} NAME_UPPER)
+	IF("${name}" IN_LIST BUILTIN_PLUGIN_LIST)
+		SET(BUILTIN_PLUGIN_DEFS ${BUILTIN_PLUGIN_DEFS}
+			-DNUGU_PLUGIN_BUILTIN_${NAME_UPPER})
+		LIST(APPEND BUILTIN_PLUGIN_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/${name}.c)
 	ELSE()
-		pkg_check_modules(opus REQUIRED opus)
-		TARGET_COMPILE_OPTIONS(opus PRIVATE ${opus_CFLAGS})
-		TARGET_LINK_LIBRARIES(opus ${pkgs_LDFLAGS} ${opus_LDFLAGS} -lnugu)
+		LIST(APPEND PLUGIN_LIST ${name})
+		ADD_LIBRARY(${name} SHARED ${name}.c)
+		TARGET_LINK_LIBRARIES(${name} ${pkgs_LDFLAGS} -lnugu)
+		SET_TARGET_PROPERTIES(${name} PROPERTIES PREFIX "" OUTPUT_NAME ${name})
+		INSTALL(TARGETS ${name} LIBRARY DESTINATION ${plugindir} COMPONENT libnugu_component)
+		ADD_DEPENDENCIES(${name} libnugu)
 	ENDIF()
+ENDMACRO(DEFINE_PLUGIN)
 
-	SET_TARGET_PROPERTIES(opus PROPERTIES PREFIX "" OUTPUT_NAME opus)
-	INSTALL(TARGETS opus LIBRARY DESTINATION ${plugindir} COMPONENT libnugu_component)
-	ADD_DEPENDENCIES(opus libnugu)
+DEFINE_PLUGIN(dummy)
+DEFINE_PLUGIN(filedump)
+DEFINE_PLUGIN(filereader)
+
+# OPUS decoder plugin
+IF(ENABLE_OPUS_PLUGIN)
+	DEFINE_PLUGIN(opus)
+
+	IF("opus" IN_LIST BUILTIN_PLUGIN_LIST)
+		IF(ENABLE_BUILTIN_OPUS)
+			# Use opus static library(externals/opus)
+			SET(BUILTIN_PLUGIN_IDIR ${BUILTIN_PLUGIN_IDIR}
+				${PROJECT_BINARY_DIR}/opus/include/opus)
+			SET(BUILTIN_PLUGIN_LIBS ${BUILTIN_PLUGIN_LIBS}
+				${PROJECT_BINARY_DIR}/opus/lib/libopus.a PARENT_SCOPE)
+			LIST(APPEND BUILTIN_PLUGIN_DEPS OPUSLIB)
+		ELSE()
+			# Use opus shared library
+			SET(BUILTIN_PLUGIN_PKGS ${BUILTIN_PLUGIN_PKGS} opus)
+		ENDIF()
+	ELSE()
+		IF(ENABLE_BUILTIN_OPUS)
+			# Use opus static library(externals/opus)
+			TARGET_INCLUDE_DIRECTORIES(opus PRIVATE
+				${PROJECT_BINARY_DIR}/opus/include/opus)
+			TARGET_LINK_LIBRARIES(opus ${pkgs_LDFLAGS}
+				${PROJECT_BINARY_DIR}/opus/lib/libopus.a
+				-lnugu -lm)
+			ADD_DEPENDENCIES(opus OPUSLIB)
+		ELSE()
+			# Use opus shared library
+			pkg_check_modules(opus REQUIRED opus)
+			TARGET_COMPILE_OPTIONS(opus PRIVATE ${opus_CFLAGS})
+			TARGET_LINK_LIBRARIES(opus ${pkgs_LDFLAGS} ${opus_LDFLAGS} -lnugu)
+		ENDIF()
+	ENDIF()
 ENDIF(ENABLE_OPUS_PLUGIN)
 
 # OPUS encoder plugin
 IF(ENABLE_OPUSENC_PLUGIN)
-	ADD_LIBRARY(opus_encoder SHARED opus_encoder.c)
-	pkg_check_modules(opus_encoder REQUIRED opus ogg)
-	TARGET_COMPILE_OPTIONS(opus_encoder PRIVATE ${opus_encoder_CFLAGS})
-	TARGET_LINK_LIBRARIES(opus_encoder ${pkgs_LDFLAGS} ${opus_encoder_LDFLAGS} -lnugu)
-	SET_TARGET_PROPERTIES(opus_encoder PROPERTIES PREFIX "" OUTPUT_NAME opus_encoder)
-	INSTALL(TARGETS opus_encoder LIBRARY DESTINATION ${plugindir} COMPONENT libnugu_component)
-	ADD_DEPENDENCIES(opus_encoder libnugu)
+	DEFINE_PLUGIN(opus_encoder)
+
+	IF("opus_encoder" IN_LIST BUILTIN_PLUGIN_LIST)
+		SET(BUILTIN_PLUGIN_PKGS ${BUILTIN_PLUGIN_PKGS} opus ogg)
+	ELSE()
+		pkg_check_modules(opus_encoder REQUIRED opus ogg)
+		TARGET_COMPILE_OPTIONS(opus_encoder PRIVATE ${opus_encoder_CFLAGS})
+		TARGET_LINK_LIBRARIES(opus_encoder ${pkgs_LDFLAGS} ${opus_encoder_LDFLAGS} -lnugu)
+	ENDIF()
 ENDIF(ENABLE_OPUSENC_PLUGIN)
 
-# PortAudio plugin
+# PortAudio plugin - recorder, pcm
 IF(ENABLE_PORTAUDIO_PLUGIN)
-	pkg_check_modules(portaudio REQUIRED portaudio-2.0 alsa)
-	SET(PORTAUDIO_PLUGINS
-		portaudio
-		portaudio_recorder
-		portaudio_pcm_sync
-		portaudio_pcm_async)
+	SET(PORTAUDIO_BUILTIN 0)
 
-	FOREACH(plugin ${PORTAUDIO_PLUGINS})
-		ADD_LIBRARY(${plugin} SHARED ${plugin}.c)
-		TARGET_COMPILE_OPTIONS(${plugin} PRIVATE ${portaudio_CFLAGS})
-		TARGET_LINK_LIBRARIES(${plugin} ${pkgs_LDFLAGS} ${portaudio_LDFLAGS} -lnugu)
-		SET_TARGET_PROPERTIES(${plugin} PROPERTIES PREFIX "" OUTPUT_NAME ${plugin})
-		INSTALL(TARGETS ${plugin} LIBRARY DESTINATION ${plugindir} COMPONENT libnugu_component)
-		ADD_DEPENDENCIES(${plugin} libnugu)
-	ENDFOREACH(plugin)
+	pkg_check_modules(portaudio REQUIRED portaudio-2.0 alsa)
+
+	FOREACH(item portaudio portaudio_recorder portaudio_pcm_sync portaudio_pcm_async)
+		DEFINE_PLUGIN(${item})
+		IF("${item}" IN_LIST BUILTIN_PLUGIN_LIST)
+			SET(PORTAUDIO_BUILTIN 1)
+		ELSE()
+			TARGET_COMPILE_OPTIONS(${item} PRIVATE ${portaudio_CFLAGS})
+			TARGET_LINK_LIBRARIES(${item} ${pkgs_LDFLAGS} ${portaudio_LDFLAGS} -lnugu)
+		ENDIF()
+	ENDFOREACH()
+
+	IF(PORTAUDIO_BUILTIN)
+		SET(BUILTIN_PLUGIN_PKGS ${BUILTIN_PLUGIN_PKGS} portaudio-2.0 alsa)
+	ENDIF()
 ENDIF(ENABLE_PORTAUDIO_PLUGIN)
 
-# gstreamer plugin
+# Gstreamer plugin - recorder, pcm, player
 IF(ENABLE_GSTREAMER_PLUGIN)
-	SET(GSTREAMER_PLUGINS
-		gstreamer
-		gstreamer_recorder
-		gstreamer_pcm)
+	SET(GSTREAMER_BUILTIN 0)
 
-	FOREACH(plugin ${GSTREAMER_PLUGINS})
-		ADD_LIBRARY(${plugin} SHARED ${plugin}.c)
-		TARGET_LINK_LIBRARIES(${plugin}
-			${pkgs_LDFLAGS}
-			${gstreamer_pkgs_LDFLAGS}
-			-lnugu)
-		FOREACH(flag ${gstreamer_pkgs_CFLAGS})
-			TARGET_COMPILE_OPTIONS(${plugin} PRIVATE ${flag})
-		ENDFOREACH(flag)
+	FOREACH(item gstreamer gstreamer_recorder gstreamer_pcm)
+		DEFINE_PLUGIN(${item})
+		IF("${item}" IN_LIST BUILTIN_PLUGIN_LIST)
+			SET(GSTREAMER_BUILTIN 1)
+		ELSE()
+			TARGET_LINK_LIBRARIES(${item} ${pkgs_LDFLAGS}
+				${gstreamer_pkgs_LDFLAGS} -lnugu)
+			TARGET_COMPILE_OPTIONS(${item} PRIVATE ${gstreamer_pkgs_CFLAGS})
+		ENDIF()
+	ENDFOREACH()
 
-		SET_TARGET_PROPERTIES(${plugin} PROPERTIES PREFIX "" OUTPUT_NAME ${plugin})
-		INSTALL(TARGETS ${plugin} LIBRARY DESTINATION ${plugindir} COMPONENT libnugu_component)
-		ADD_DEPENDENCIES(${plugin} libnugu)
-	ENDFOREACH(plugin)
+	IF(GSTREAMER_BUILTIN)
+		SET(BUILTIN_PLUGIN_PKGS ${BUILTIN_PLUGIN_PKGS}
+			gstreamer-1.0 gstreamer-app-1.0 gstreamer-pbutils-1.0)
+	ENDIF()
+
 ENDIF(ENABLE_GSTREAMER_PLUGIN)
 
-# Speex plugin
+# Speex encoder plugin
 IF(ENABLE_SPEEX_PLUGIN AND ENABLE_VENDOR_LIBRARY)
-	ADD_LIBRARY(speex SHARED speex.c)
-	FOREACH(flag ${vendor_pkgs_CFLAGS})
-		TARGET_COMPILE_OPTIONS(speex PRIVATE ${flag})
-	ENDFOREACH(flag)
-	TARGET_LINK_LIBRARIES(speex ${pkgs_LDFLAGS} ${vendor_pkgs_LDFLAGS} -lnugu)
-	SET_TARGET_PROPERTIES(speex PROPERTIES PREFIX "" OUTPUT_NAME speex)
-	INSTALL(TARGETS speex LIBRARY DESTINATION ${plugindir} COMPONENT libnugu_component)
-	ADD_DEPENDENCIES(speex libnugu)
+	DEFINE_PLUGIN(speex)
+
+	IF ("speex" IN_LIST BUILTIN_PLUGIN_LIST)
+	ELSE()
+		TARGET_COMPILE_OPTIONS(speex PRIVATE ${vendor_pkgs_CFLAGS})
+		TARGET_LINK_LIBRARIES(speex ${pkgs_LDFLAGS} ${vendor_pkgs_LDFLAGS} -lnugu)
+	ENDIF()
 ENDIF()
+
+# Plugins built into the SDK library.
+IF(BUILTIN_PLUGIN_SRCS)
+	ADD_LIBRARY(objbuiltin OBJECT ${BUILTIN_PLUGIN_SRCS})
+	TARGET_COMPILE_DEFINITIONS(objbuiltin PRIVATE ${BUILTIN_PLUGIN_DEFS})
+	TARGET_INCLUDE_DIRECTORIES(objbuiltin PRIVATE ${BUILTIN_PLUGIN_IDIR})
+
+	IF(BUILTIN_PLUGIN_PKGS)
+		# Get CFLAGS and LDFLAGS from pkg-config list
+		pkg_check_modules(builtin_plugin_pkgs REQUIRED ${BUILTIN_PLUGIN_PKGS})
+		TARGET_COMPILE_OPTIONS(objbuiltin PRIVATE ${builtin_plugin_pkgs_CFLAGS})
+	ENDIF()
+
+	FOREACH(lib ${BUILTIN_PLUGIN_DEPS})
+		ADD_DEPENDENCIES(objbuiltin ${lib})
+	ENDFOREACH()
+
+	SET(BUILTIN_PLUGIN_DEPS ${BUILTIN_PLUGIN_DEPS} PARENT_SCOPE)
+ENDIF()
+
+# output message
+MESSAGE("-- Built-in plugin list: ${BUILTIN_PLUGIN_LIST}")
+MESSAGE("-- Plugin list: ${PLUGIN_LIST}")

--- a/plugins/dummy.c
+++ b/plugins/dummy.c
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef NUGU_PLUGIN_BUILTIN_DUMMY
+#define NUGU_PLUGIN_BUILTIN
+#endif
+
 #include "base/nugu_log.h"
 #include "base/nugu_plugin.h"
 
@@ -36,7 +40,7 @@ static void unload(NuguPlugin *p)
 	nugu_dbg("plugin-unload '%s'", nugu_plugin_get_description(p)->name);
 }
 
-NUGU_PLUGIN_DEFINE("dummy",
+NUGU_PLUGIN_DEFINE(dummy,
 	NUGU_PLUGIN_PRIORITY_DEFAULT,
 	"0.0.1",
 	load,

--- a/plugins/filedump.c
+++ b/plugins/filedump.c
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef NUGU_PLUGIN_BUILTIN_FILEDUMP
+#define NUGU_PLUGIN_BUILTIN
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -240,6 +244,7 @@ static int init(NuguPlugin *p)
 
 	if (nugu_decoder_driver_register(decoder_driver) < 0) {
 		nugu_decoder_driver_free(decoder_driver);
+		decoder_driver = NULL;
 		return -1;
 	}
 
@@ -247,17 +252,21 @@ static int init(NuguPlugin *p)
 	if (!pcm_driver) {
 		nugu_decoder_driver_remove(decoder_driver);
 		nugu_decoder_driver_free(decoder_driver);
+		decoder_driver = NULL;
 		return -1;
 	}
 
 	if (nugu_pcm_driver_register(pcm_driver) != 0) {
 		nugu_pcm_driver_free(pcm_driver);
+		pcm_driver = NULL;
+
 		nugu_decoder_driver_remove(decoder_driver);
 		nugu_decoder_driver_free(decoder_driver);
+		decoder_driver = NULL;
 		return -1;
 	}
 
-	nugu_dbg("filedump decoder/pcm driver registered");
+	nugu_dbg("'%s' plugin initialized", desc->name);
 
 	return 0;
 }
@@ -284,9 +293,11 @@ static void unload(NuguPlugin *p)
 		nugu_pcm_driver_free(pcm_driver);
 		pcm_driver = NULL;
 	}
+
+	nugu_dbg("'%s' plugin unloaded", nugu_plugin_get_description(p)->name);
 }
 
-NUGU_PLUGIN_DEFINE("filedump",
+NUGU_PLUGIN_DEFINE(filedump,
 	NUGU_PLUGIN_PRIORITY_LOW,
 	"0.0.1",
 	load,

--- a/plugins/filereader.c
+++ b/plugins/filereader.c
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef NUGU_PLUGIN_BUILTIN_FILEREADER
+#define NUGU_PLUGIN_BUILTIN
+#endif
+
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -343,7 +347,7 @@ static int init(NuguPlugin *p)
 	const struct nugu_plugin_desc *desc;
 
 	desc = nugu_plugin_get_description(p);
-	nugu_dbg("'%s' plugin initialized", desc->name);
+	nugu_dbg("plugin-init '%s'", desc->name);
 
 	if (!getenv(NUGU_ENV_RECORDING_FROM_FILE)) {
 		nugu_error("must set environment => NUGU_RECORDING_FROM_FILE");
@@ -364,21 +368,21 @@ static int init(NuguPlugin *p)
 
 	pthread_mutex_init(&mutex, NULL);
 
-	nugu_dbg("'%s' plugin initialized done", desc->name);
+	nugu_dbg("'%s' plugin initialized", desc->name);
 
 	return 0;
 }
 
 static int load(void)
 {
-	nugu_dbg("plugin loaded");
+	nugu_dbg("plugin-load");
 
 	return 0;
 }
 
 static void unload(NuguPlugin *p)
 {
-	nugu_dbg("'%s' plugin unloaded", nugu_plugin_get_description(p)->name);
+	nugu_dbg("plugin-unload '%s'", nugu_plugin_get_description(p)->name);
 
 	if (rec_driver) {
 		nugu_recorder_driver_remove(rec_driver);
@@ -386,12 +390,11 @@ static void unload(NuguPlugin *p)
 		rec_driver = NULL;
 	}
 
-	nugu_dbg("'%s' plugin unloaded done",
-		 nugu_plugin_get_description(p)->name);
+	nugu_dbg("'%s' plugin unloaded", nugu_plugin_get_description(p)->name);
 }
 
 NUGU_PLUGIN_DEFINE(
-	"filereader",
+	filereader,
 	NUGU_PLUGIN_PRIORITY_LOW,
 	"0.0.1",
 	load,

--- a/plugins/gstreamer.c
+++ b/plugins/gstreamer.c
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef NUGU_PLUGIN_BUILTIN_GSTREAMER
+#define NUGU_PLUGIN_BUILTIN
+#endif
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -859,7 +863,7 @@ static int init(NuguPlugin *p)
 	const struct nugu_plugin_desc *desc;
 
 	desc = nugu_plugin_get_description(p);
-	nugu_dbg("'%s' plugin initialized", desc->name);
+	nugu_dbg("plugin-init '%s'", desc->name);
 
 	if (gst_is_initialized() == FALSE)
 		gst_init(NULL, NULL);
@@ -876,7 +880,7 @@ static int init(NuguPlugin *p)
 		return -1;
 	}
 
-	nugu_dbg("'%s' plugin initialized done", desc->name);
+	nugu_dbg("'%s' plugin initialized", desc->name);
 
 	return 0;
 }
@@ -889,7 +893,7 @@ static int load(void)
 
 static void unload(NuguPlugin *p)
 {
-	nugu_dbg("'%s' plugin unloaded", nugu_plugin_get_description(p)->name);
+	nugu_dbg("plugin-unload '%s'", nugu_plugin_get_description(p)->name);
 
 	if (driver) {
 		nugu_player_driver_remove(driver);
@@ -897,11 +901,10 @@ static void unload(NuguPlugin *p)
 		driver = NULL;
 	}
 
-	nugu_dbg("'%s' plugin unloaded done",
-		 nugu_plugin_get_description(p)->name);
+	nugu_dbg("'%s' plugin unloaded", nugu_plugin_get_description(p)->name);
 }
 
-NUGU_PLUGIN_DEFINE("gstreamer",
+NUGU_PLUGIN_DEFINE(gstreamer,
 	NUGU_PLUGIN_PRIORITY_DEFAULT,
 	"0.0.1",
 	load,

--- a/plugins/gstreamer_pcm.c
+++ b/plugins/gstreamer_pcm.c
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef NUGU_PLUGIN_BUILTIN_GSTREAMER_PCM
+#define NUGU_PLUGIN_BUILTIN
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -897,7 +901,7 @@ static int init(NuguPlugin *p)
 	const struct nugu_plugin_desc *desc;
 
 	desc = nugu_plugin_get_description(p);
-	nugu_dbg("'%s' plugin initialized", desc->name);
+	nugu_dbg("plugin-init '%s'", desc->name);
 
 	if (gst_is_initialized() == FALSE)
 		gst_init(NULL, NULL);
@@ -914,21 +918,21 @@ static int init(NuguPlugin *p)
 		return -1;
 	}
 
-	nugu_dbg("'%s' plugin initialized done", desc->name);
+	nugu_dbg("'%s' plugin initialized", desc->name);
 
 	return 0;
 }
 
 static int load(void)
 {
-	nugu_dbg("plugin loaded");
+	nugu_dbg("plugin-load");
 
 	return 0;
 }
 
 static void unload(NuguPlugin *p)
 {
-	nugu_dbg("'%s' plugin unloaded", nugu_plugin_get_description(p)->name);
+	nugu_dbg("plugin-unload '%s'", nugu_plugin_get_description(p)->name);
 
 	if (pcm_driver) {
 		nugu_pcm_driver_remove(pcm_driver);
@@ -936,13 +940,12 @@ static void unload(NuguPlugin *p)
 		pcm_driver = NULL;
 	}
 
-	nugu_dbg("'%s' plugin unloaded done",
-		 nugu_plugin_get_description(p)->name);
+	nugu_dbg("'%s' plugin unloaded", nugu_plugin_get_description(p)->name);
 }
 
 NUGU_PLUGIN_DEFINE(
 	/* NUGU SDK Plug-in description */
-	"gstreamer_pcm", /* Plugin name */
+	gstreamer_pcm, /* Plugin name */
 	NUGU_PLUGIN_PRIORITY_DEFAULT - 1, /* Plugin priority */
 	"0.0.1", /* Plugin version */
 	load, /* dlopen */

--- a/plugins/gstreamer_recorder.c
+++ b/plugins/gstreamer_recorder.c
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef NUGU_PLUGIN_BUILTIN_GSTREAMER_RECORDER
+#define NUGU_PLUGIN_BUILTIN
+#endif
+
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -575,7 +579,7 @@ static int init(NuguPlugin *p)
 	const struct nugu_plugin_desc *desc;
 
 	desc = nugu_plugin_get_description(p);
-	nugu_dbg("'%s' plugin initialized", desc->name);
+	nugu_dbg("plugin-init '%s'", desc->name);
 
 	if (gst_is_initialized() == FALSE)
 		gst_init(NULL, NULL);
@@ -594,21 +598,21 @@ static int init(NuguPlugin *p)
 
 	pthread_mutex_init(&lock, NULL);
 
-	nugu_dbg("'%s' plugin initialized done", desc->name);
+	nugu_dbg("'%s' plugin initialized", desc->name);
 
 	return 0;
 }
 
 static int load(void)
 {
-	nugu_dbg("plugin loaded");
+	nugu_dbg("plugin-load");
 
 	return 0;
 }
 
 static void unload(NuguPlugin *p)
 {
-	nugu_dbg("'%s' plugin unloaded", nugu_plugin_get_description(p)->name);
+	nugu_dbg("plugin-unload '%s'", nugu_plugin_get_description(p)->name);
 
 	if (rec_driver) {
 		nugu_recorder_driver_remove(rec_driver);
@@ -616,13 +620,12 @@ static void unload(NuguPlugin *p)
 		rec_driver = NULL;
 	}
 
-	nugu_dbg("'%s' plugin unloaded done",
-		 nugu_plugin_get_description(p)->name);
+	nugu_dbg("'%s' plugin unloaded", nugu_plugin_get_description(p)->name);
 }
 
 NUGU_PLUGIN_DEFINE(
 	/* NUGU SDK Plug-in description */
-	"gstreamer_recorder", /* Plugin name */
+	gstreamer_recorder, /* Plugin name */
 	NUGU_PLUGIN_PRIORITY_DEFAULT, /* Plugin priority */
 	"0.0.1", /* Plugin version */
 	load, /* dlopen */

--- a/plugins/opus.c
+++ b/plugins/opus.c
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef NUGU_PLUGIN_BUILTIN_OPUS
+#define NUGU_PLUGIN_BUILTIN
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -257,7 +261,7 @@ static int init(NuguPlugin *p)
 	const struct nugu_plugin_desc *desc;
 
 	desc = nugu_plugin_get_description(p);
-	nugu_dbg("'%s' plugin initialized", desc->name);
+	nugu_dbg("plugin-init '%s'", desc->name);
 
 	driver = nugu_decoder_driver_new(desc->name, NUGU_DECODER_TYPE_OPUS,
 					 &decoder_ops);
@@ -269,6 +273,8 @@ static int init(NuguPlugin *p)
 		driver = NULL;
 		return -1;
 	}
+
+	nugu_dbg("'%s' plugin initialized", desc->name);
 
 	return 0;
 }
@@ -289,9 +295,11 @@ static void unload(NuguPlugin *p)
 		nugu_decoder_driver_free(driver);
 		driver = NULL;
 	}
+
+	nugu_dbg("'%s' plugin unloaded", nugu_plugin_get_description(p)->name);
 }
 
-NUGU_PLUGIN_DEFINE("opus",
+NUGU_PLUGIN_DEFINE(opus,
 	NUGU_PLUGIN_PRIORITY_DEFAULT,
 	"0.0.1",
 	load,

--- a/plugins/opus_encoder.c
+++ b/plugins/opus_encoder.c
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef NUGU_PLUGIN_BUILTIN_OPUS_ENCODER
+#define NUGU_PLUGIN_BUILTIN
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -342,6 +346,8 @@ static int init(NuguPlugin *p)
 		return -1;
 	}
 
+	nugu_dbg("'%s' plugin initialized", desc->name);
+
 	return 0;
 }
 
@@ -355,11 +361,17 @@ static int load(void)
 static void unload(NuguPlugin *p)
 {
 	nugu_dbg("plugin-unload '%s'", nugu_plugin_get_description(p)->name);
-	nugu_encoder_driver_remove(enc_driver);
-	nugu_encoder_driver_free(enc_driver);
+
+	if (enc_driver) {
+		nugu_encoder_driver_remove(enc_driver);
+		nugu_encoder_driver_free(enc_driver);
+		enc_driver = NULL;
+	}
+
+	nugu_dbg("'%s' plugin unloaded", nugu_plugin_get_description(p)->name);
 }
 
-NUGU_PLUGIN_DEFINE("opus_encoder",
+NUGU_PLUGIN_DEFINE(opus_encoder,
 	NUGU_PLUGIN_PRIORITY_DEFAULT,
 	"0.0.1",
 	load,

--- a/plugins/portaudio.c
+++ b/plugins/portaudio.c
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef NUGU_PLUGIN_BUILTIN_PORTAUDIO
+#define NUGU_PLUGIN_BUILTIN
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
@@ -54,8 +58,7 @@ static void snd_error_log(const char *file, int line, const char *function,
 
 static int init(NuguPlugin *p)
 {
-	nugu_dbg("'%s' plugin initialized",
-		 nugu_plugin_get_description(p)->name);
+	nugu_dbg("plugin-init '%s'", nugu_plugin_get_description(p)->name);
 
 	if (Pa_Initialize() != paNoError) {
 		nugu_error("initialize is failed");
@@ -64,7 +67,7 @@ static int init(NuguPlugin *p)
 
 	nugu_info("version: %s", Pa_GetVersionText());
 
-	nugu_dbg("'%s' plugin initialized done",
+	nugu_dbg("'%s' plugin initialized",
 		 nugu_plugin_get_description(p)->name);
 
 	return 0;
@@ -72,7 +75,7 @@ static int init(NuguPlugin *p)
 
 static int load(void)
 {
-	nugu_dbg("plugin loaded");
+	nugu_dbg("plugin-load");
 	snd_lib_error_set_handler(snd_error_log);
 
 	return 0;
@@ -80,19 +83,18 @@ static int load(void)
 
 static void unload(NuguPlugin *p)
 {
-	nugu_dbg("'%s' plugin unloaded", nugu_plugin_get_description(p)->name);
+	nugu_dbg("plugin-unload '%s'", nugu_plugin_get_description(p)->name);
 
 	Pa_Terminate();
 
 	snd_lib_error_set_handler(NULL);
 
-	nugu_dbg("'%s' plugin unloaded done",
-		 nugu_plugin_get_description(p)->name);
+	nugu_dbg("'%s' plugin unloaded", nugu_plugin_get_description(p)->name);
 }
 
 NUGU_PLUGIN_DEFINE(
 	/* NUGU SDK Plug-in description */
-	"portaudio", /* Plugin name */
+	portaudio, /* Plugin name */
 	NUGU_PLUGIN_PRIORITY_DEFAULT + 1, /* Plugin priority */
 	"0.0.2", /* Plugin version */
 	load, /* dlopen */

--- a/plugins/portaudio_pcm_async.c
+++ b/plugins/portaudio_pcm_async.c
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef NUGU_PLUGIN_BUILTIN_PORTAUDIO_PCM_ASYNC
+#define NUGU_PLUGIN_BUILTIN
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -572,7 +576,7 @@ static int init(NuguPlugin *p)
 	const struct nugu_plugin_desc *desc;
 
 	desc = nugu_plugin_get_description(p);
-	nugu_dbg("'%s' plugin initialized", desc->name);
+	nugu_dbg("plugin-init '%s'", desc->name);
 
 	if (!nugu_plugin_find("portaudio")) {
 		nugu_error("portaudio plugin is not initialized");
@@ -592,21 +596,21 @@ static int init(NuguPlugin *p)
 		return -1;
 	}
 
-	nugu_dbg("'%s' plugin initialized done", desc->name);
+	nugu_dbg("'%s' plugin initialized", desc->name);
 
 	return 0;
 }
 
 static int load(void)
 {
-	nugu_dbg("plugin loaded");
+	nugu_dbg("plugin-load");
 
 	return 0;
 }
 
 static void unload(NuguPlugin *p)
 {
-	nugu_dbg("'%s' plugin unloaded", nugu_plugin_get_description(p)->name);
+	nugu_dbg("plugin-unload '%s'", nugu_plugin_get_description(p)->name);
 
 	if (pcm_driver) {
 		nugu_pcm_driver_remove(pcm_driver);
@@ -614,13 +618,12 @@ static void unload(NuguPlugin *p)
 		pcm_driver = NULL;
 	}
 
-	nugu_dbg("'%s' plugin unloaded done",
-		 nugu_plugin_get_description(p)->name);
+	nugu_dbg("'%s' plugin unloaded", nugu_plugin_get_description(p)->name);
 }
 
 NUGU_PLUGIN_DEFINE(
 	/* NUGU SDK Plug-in description */
-	"portaudio_pcm_async", /* Plugin name */
+	portaudio_pcm_async, /* Plugin name */
 	NUGU_PLUGIN_PRIORITY_DEFAULT + 2, /* Plugin priority */
 	"0.0.2", /* Plugin version */
 	load, /* dlopen */

--- a/plugins/portaudio_pcm_sync.c
+++ b/plugins/portaudio_pcm_sync.c
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef NUGU_PLUGIN_BUILTIN_PORTAUDIO_PCM_SYNC
+#define NUGU_PLUGIN_BUILTIN
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -611,7 +615,7 @@ static int init(NuguPlugin *p)
 	const struct nugu_plugin_desc *desc;
 
 	desc = nugu_plugin_get_description(p);
-	nugu_dbg("'%s' plugin initialized", desc->name);
+	nugu_dbg("plugin-init '%s'", desc->name);
 
 	if (!nugu_plugin_find("portaudio")) {
 		nugu_error("portaudio plugin is not initialized");
@@ -630,21 +634,21 @@ static int init(NuguPlugin *p)
 		return -1;
 	}
 
-	nugu_dbg("'%s' plugin initialized done", desc->name);
+	nugu_dbg("'%s' plugin initialized", desc->name);
 
 	return 0;
 }
 
 static int load(void)
 {
-	nugu_dbg("plugin loaded");
+	nugu_dbg("plugin-load");
 
 	return 0;
 }
 
 static void unload(NuguPlugin *p)
 {
-	nugu_dbg("'%s' plugin unloaded", nugu_plugin_get_description(p)->name);
+	nugu_dbg("plugin-unload '%s'", nugu_plugin_get_description(p)->name);
 
 	if (pcm_driver) {
 		nugu_pcm_driver_remove(pcm_driver);
@@ -652,13 +656,12 @@ static void unload(NuguPlugin *p)
 		pcm_driver = NULL;
 	}
 
-	nugu_dbg("'%s' plugin unloaded done",
-		 nugu_plugin_get_description(p)->name);
+	nugu_dbg("'%s' plugin unloaded", nugu_plugin_get_description(p)->name);
 }
 
 NUGU_PLUGIN_DEFINE(
 	/* NUGU SDK Plug-in description */
-	"portaudio_pcm_sync", /* Plugin name */
+	portaudio_pcm_sync, /* Plugin name */
 	NUGU_PLUGIN_PRIORITY_DEFAULT + 3, /* Plugin priority */
 	"0.0.2", /* Plugin version */
 	load, /* dlopen */

--- a/plugins/portaudio_recorder.c
+++ b/plugins/portaudio_recorder.c
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef NUGU_PLUGIN_BUILTIN_PORTAUDIO_RECORDER
+#define NUGU_PLUGIN_BUILTIN
+#endif
+
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -413,7 +417,7 @@ static int init(NuguPlugin *p)
 	const struct nugu_plugin_desc *desc;
 
 	desc = nugu_plugin_get_description(p);
-	nugu_dbg("'%s' plugin initialized", desc->name);
+	nugu_dbg("plugin-init '%s'", desc->name);
 
 	if (!nugu_plugin_find("portaudio")) {
 		nugu_error("portaudio plugin is not initialized");
@@ -432,21 +436,21 @@ static int init(NuguPlugin *p)
 		return -1;
 	}
 
-	nugu_dbg("'%s' plugin initialized done", desc->name);
+	nugu_dbg("'%s' plugin initialized", desc->name);
 
 	return 0;
 }
 
 static int load(void)
 {
-	nugu_dbg("plugin loaded");
+	nugu_dbg("plugin-load");
 
 	return 0;
 }
 
 static void unload(NuguPlugin *p)
 {
-	nugu_dbg("'%s' plugin unloaded", nugu_plugin_get_description(p)->name);
+	nugu_dbg("plugin-unload '%s'", nugu_plugin_get_description(p)->name);
 
 	if (rec_driver) {
 		nugu_recorder_driver_remove(rec_driver);
@@ -454,13 +458,12 @@ static void unload(NuguPlugin *p)
 		rec_driver = NULL;
 	}
 
-	nugu_dbg("'%s' plugin unloaded done",
-		 nugu_plugin_get_description(p)->name);
+	nugu_dbg("'%s' plugin unloaded", nugu_plugin_get_description(p)->name);
 }
 
 NUGU_PLUGIN_DEFINE(
 	/* NUGU SDK Plug-in description */
-	"portaudio_recorder", /* Plugin name */
+	portaudio_recorder, /* Plugin name */
 	NUGU_PLUGIN_PRIORITY_DEFAULT + 2, /* Plugin priority */
 	"0.0.2", /* Plugin version */
 	load, /* dlopen */

--- a/plugins/speex.c
+++ b/plugins/speex.c
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef NUGU_PLUGIN_BUILTIN_SPEEX
+#define NUGU_PLUGIN_BUILTIN
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -223,7 +227,7 @@ static int init(NuguPlugin *p)
 	const struct nugu_plugin_desc *desc;
 
 	desc = nugu_plugin_get_description(p);
-	nugu_dbg("'%s' plugin initialized", desc->name);
+	nugu_dbg("plugin-init '%s'", desc->name);
 
 	driver = nugu_encoder_driver_new(desc->name, NUGU_ENCODER_TYPE_SPEEX,
 					 &encoder_ops);
@@ -236,7 +240,7 @@ static int init(NuguPlugin *p)
 		return -1;
 	}
 
-	nugu_dbg("'%s' plugin initialized done", desc->name);
+	nugu_dbg("'%s' plugin initialized", desc->name);
 
 	return 0;
 }
@@ -257,9 +261,11 @@ static void unload(NuguPlugin *p)
 		nugu_encoder_driver_free(driver);
 		driver = NULL;
 	}
+
+	nugu_dbg("'%s' plugin unloaded", nugu_plugin_get_description(p)->name);
 }
 
-NUGU_PLUGIN_DEFINE("speex",
+NUGU_PLUGIN_DEFINE(speex,
 	NUGU_PLUGIN_PRIORITY_DEFAULT,
 	"0.0.1",
 	load,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,16 +5,33 @@ ADD_SUBDIRECTORY(capability)
 ADD_SUBDIRECTORY(clientkit)
 
 # NUGU SDK Library
-ADD_LIBRARY(libnugu SHARED
-	$<TARGET_OBJECTS:objhttp2>
-	$<TARGET_OBJECTS:objbase>
-	$<TARGET_OBJECTS:objcore>
-	$<TARGET_OBJECTS:objcapability>
-	$<TARGET_OBJECTS:objclientkit>)
+IF(BUILTIN_PLUGIN_LIST)
+	ADD_LIBRARY(libnugu SHARED
+		$<TARGET_OBJECTS:objhttp2>
+		$<TARGET_OBJECTS:objbase>
+		$<TARGET_OBJECTS:objcore>
+		$<TARGET_OBJECTS:objcapability>
+		$<TARGET_OBJECTS:objclientkit>
+		$<TARGET_OBJECTS:objbuiltin>)
+ELSE()
+	ADD_LIBRARY(libnugu SHARED
+		$<TARGET_OBJECTS:objhttp2>
+		$<TARGET_OBJECTS:objbase>
+		$<TARGET_OBJECTS:objcore>
+		$<TARGET_OBJECTS:objcapability>
+		$<TARGET_OBJECTS:objclientkit>)
+ENDIF()
 
 TARGET_LINK_LIBRARIES(libnugu PUBLIC
-	${CURL_LIBRARY} ${NJSON_LIBRARY}
-	${pkgs_LDFLAGS} ${LDFLAG_SOCKET} ${LDFLAG_DL})
+	${CURL_LIBRARY} njson
+	${pkgs_LDFLAGS}
+	${builtin_plugin_pkgs_LDFLAGS}
+	${BUILTIN_PLUGIN_LIBS}
+	${LDFLAG_SOCKET} ${LDFLAG_DL})
+
+FOREACH(lib ${BUILTIN_PLUGIN_DEPS})
+	ADD_DEPENDENCIES(libnugu ${lib})
+ENDFOREACH()
 
 # Gstreamer does not support dynamic loading/unloading of their libraries.
 # Therefore, add the library dependency to NUGU SDK instead of NUGU Plugin.

--- a/src/base/builtin.h.in
+++ b/src/base/builtin.h.in
@@ -1,0 +1,20 @@
+#ifndef __NUGU_PLUGIN_BUILT_IN_H__
+#define __NUGU_PLUGIN_BUILT_IN_H__
+
+#include "base/nugu_plugin.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+@builtin_decl@
+
+static struct nugu_plugin_desc *_builtin_list[] = {
+@builtin_list@
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/base/nugu_plugin.c
+++ b/src/base/nugu_plugin.c
@@ -23,6 +23,8 @@
 #include "base/nugu_log.h"
 #include "base/nugu_plugin.h"
 
+#include "builtin.h"
+
 struct _plugin {
 	const struct nugu_plugin_desc *desc;
 	void *data;
@@ -240,6 +242,29 @@ EXPORT_API int nugu_plugin_load_directory(const char *dirpath)
 		return 0;
 	else
 		return g_list_length(_plugin_list);
+}
+
+EXPORT_API int nugu_plugin_load_builtin(void)
+{
+	size_t length;
+	size_t i;
+	NuguPlugin *p;
+
+	length = sizeof(_builtin_list) / sizeof(struct nugu_plugin_desc *);
+	nugu_info("built-in plugin count: %d", length);
+
+	for (i = 0; i < length; i++) {
+		p = nugu_plugin_new(_builtin_list[i]);
+		if (!p) {
+			nugu_error("nugu_plugin_new() failed");
+			continue;
+		}
+
+		if (nugu_plugin_add(p) != 0)
+			nugu_plugin_free(p);
+	}
+
+	return g_list_length(_plugin_list);
 }
 
 static gint _sort_priority_cmp(gconstpointer a, gconstpointer b)

--- a/tests/plugin_nugu.c
+++ b/tests/plugin_nugu.c
@@ -14,5 +14,5 @@ static int on_init(NuguPlugin *p)
 	return 0;
 }
 
-NUGU_PLUGIN_DEFINE("test_nugu", NUGU_PLUGIN_PRIORITY_DEFAULT, "1.0", on_load,
+NUGU_PLUGIN_DEFINE(test_nugu, NUGU_PLUGIN_PRIORITY_DEFAULT, "1.0", on_load,
 		   on_unload, on_init);

--- a/tests/plugin_nugu_custom.c
+++ b/tests/plugin_nugu_custom.c
@@ -20,5 +20,5 @@ int custom_add(int a, int b)
 	return a + b;
 }
 
-NUGU_PLUGIN_DEFINE("test_nugu_custom", NUGU_PLUGIN_PRIORITY_DEFAULT, "1.0",
+NUGU_PLUGIN_DEFINE(test_nugu_custom, NUGU_PLUGIN_PRIORITY_DEFAULT, "1.0",
 		   on_load, on_unload, on_init);


### PR DESCRIPTION
Modified plugin architecture to support embedding(built-in) in SDK
library instead of separate shared library.

Just add build options to the built-in target plugins as shown below.

    cmake ... -DENABLE_BUILTIN_PLUGIN="opus,dummy,speex"

Signed-off-by: Inho Oh <webispy@gmail.com>