### PR TITLE
fix time and random API to portable

### DIFF
--- a/examples/profiling/main_prof.cc
+++ b/examples/profiling/main_prof.cc
@@ -102,7 +102,7 @@ static void test_finished(void)
 
     /* CSV data, NOLINTNEXTLINE(cert-err33-c) */
     fprintf(fp_out, "%s,%d,%ld,%d,%d,%d,%d,%d,%s\n",
-        test_name.c_str(), test_iteration, tmp->timestamp.tv_sec,
+        test_name.c_str(), test_iteration, (long int)(tmp->timestamp / 1000000),
         nugu_prof_get_diff_msec_type(NUGU_PROF_TYPE_ASR_LISTENING_STARTED, NUGU_PROF_TYPE_ASR_END_POINT_DETECTED),
         nugu_prof_get_diff_msec_type(NUGU_PROF_TYPE_ASR_END_POINT_DETECTED, NUGU_PROF_TYPE_ASR_RESULT),
         nugu_prof_get_diff_msec_type(NUGU_PROF_TYPE_ASR_RESULT, NUGU_PROF_TYPE_TTS_SPEAK_DIRECTIVE),

--- a/include/base/nugu_prof.h
+++ b/include/base/nugu_prof.h
@@ -19,6 +19,7 @@
 
 #include <nugu.h>
 #include <base/nugu_uuid.h>
+#include <glib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -202,7 +203,7 @@ struct nugu_prof_data {
 	enum nugu_prof_type type; /**< profiling type */
 	char dialog_id[NUGU_MAX_UUID_STRING_SIZE + 1]; /* dialog request id */
 	char msg_id[NUGU_MAX_UUID_STRING_SIZE + 1]; /* message id */
-	struct timespec timestamp; /* timestamp */
+	gint64 timestamp; /* timestamp(microseconds) */
 	char *contents; /* additional contents */
 };
 

--- a/include/base/nugu_uuid.h
+++ b/include/base/nugu_uuid.h
@@ -19,6 +19,7 @@
 
 #include <time.h>
 #include <nugu.h>
+#include <glib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -92,14 +93,13 @@ NUGU_API int nugu_uuid_convert_base16(const unsigned char *bytes,
  * @brief Convert byte array to base16-encoded string
  * @param[in] bytes byte array
  * @param[in] bytes_len length
- * @param[out] out_time memory allocated structure
+ * @param[out] msec milliseconds
  * @return Result of conversion success or failure
  * @retval 0 Success
  * @retval -1 Failure
  */
-NUGU_API int nugu_uuid_convert_timespec(const unsigned char *bytes,
-					size_t bytes_len,
-					struct timespec *out_time);
+NUGU_API int nugu_uuid_convert_msec(const unsigned char *bytes,
+				    size_t bytes_len, gint64 *msec);
 
 /**
  * @brief Generate random bytes and fill to destination buffer
@@ -113,7 +113,7 @@ NUGU_API int nugu_uuid_fill_random(unsigned char *dest, size_t dest_len);
 
 /**
  * @brief Fill to output buffer with NUGU UUID format using parameters
- * @param[in] time timestamp information
+ * @param[in] msec milliseconds
  * @param[in] hash hash value(e.g. SHA1(token))
  * @param[in] hash_len length of hash value
  * @param[out] out memory allocated output buffer
@@ -122,9 +122,9 @@ NUGU_API int nugu_uuid_fill_random(unsigned char *dest, size_t dest_len);
  * @retval 0 Success
  * @retval -1 Failure
  */
-NUGU_API int nugu_uuid_fill(const struct timespec *time,
-			    const unsigned char *hash, size_t hash_len,
-			    unsigned char *out, size_t out_len);
+NUGU_API int nugu_uuid_fill(gint64 msec, const unsigned char *hash,
+			    size_t hash_len, unsigned char *out,
+			    size_t out_len);
 /**
  * @}
  */

--- a/plugins/filedump.c
+++ b/plugins/filedump.c
@@ -70,7 +70,11 @@ static int _dumpfile_open(const char *path, const char *prefix)
 	int fd;
 
 	now = time(NULL);
+#ifdef _WIN32
+	localtime_s(&now_tm, &now);
+#else
 	localtime_r(&now, &now_tm);
+#endif
 
 	snprintf(ymd, sizeof(ymd), "%04d%02d%02d", now_tm.tm_year + 1900,
 		 now_tm.tm_mon + 1, now_tm.tm_mday);

--- a/plugins/filereader.c
+++ b/plugins/filereader.c
@@ -84,7 +84,11 @@ static int _dumpfile_open(const char *path, const char *prefix)
 		return -1;
 
 	now = time(NULL);
+#ifdef _WIN32
+	localtime_s(&now_tm, &now);
+#else
 	localtime_r(&now, &now_tm);
+#endif
 
 	snprintf(ymd, sizeof(ymd), "%04d%02d%02d", now_tm.tm_year + 1900,
 		 now_tm.tm_mon + 1, now_tm.tm_mday);

--- a/plugins/gstreamer_pcm.c
+++ b/plugins/gstreamer_pcm.c
@@ -139,7 +139,11 @@ static int _dumpfile_open(const char *path, const char *prefix)
 		return -1;
 
 	now = time(NULL);
+#ifdef _WIN32
+	localtime_s(&now_tm, &now);
+#else
 	localtime_r(&now, &now_tm);
+#endif
 
 	snprintf(ymd, sizeof(ymd), "%04d%02d%02d", now_tm.tm_year + 1900,
 		 now_tm.tm_mon + 1, now_tm.tm_mday);

--- a/plugins/gstreamer_recorder.c
+++ b/plugins/gstreamer_recorder.c
@@ -110,7 +110,11 @@ static int _dumpfile_open(const char *path, const char *prefix)
 		return -1;
 
 	now = time(NULL);
+#ifdef _WIN32
+	localtime_s(&now_tm, &now);
+#else
 	localtime_r(&now, &now_tm);
+#endif
 
 	snprintf(ymd, sizeof(ymd), "%04d%02d%02d", now_tm.tm_year + 1900,
 		 now_tm.tm_mon + 1, now_tm.tm_mday);

--- a/plugins/opus.c
+++ b/plugins/opus.c
@@ -103,7 +103,11 @@ static int _dumpfile_open(const char *path, const char *prefix)
 		return -1;
 
 	now = time(NULL);
+#ifdef _WIN32
+	localtime_s(&now_tm, &now);
+#else
 	localtime_r(&now, &now_tm);
+#endif
 
 	snprintf(ymd, sizeof(ymd), "%04d%02d%02d", now_tm.tm_year + 1900,
 		 now_tm.tm_mon + 1, now_tm.tm_mday);

--- a/plugins/opus_encoder.c
+++ b/plugins/opus_encoder.c
@@ -77,7 +77,11 @@ static int _dumpfile_open(const char *path, const char *prefix)
 		return -1;
 
 	now = time(NULL);
+#ifdef _WIN32
+	localtime_s(&now_tm, &now);
+#else
 	localtime_r(&now, &now_tm);
+#endif
 
 	snprintf(ymd, sizeof(ymd), "%04d%02d%02d", now_tm.tm_year + 1900,
 		 now_tm.tm_mon + 1, now_tm.tm_mday);

--- a/plugins/portaudio_pcm_async.c
+++ b/plugins/portaudio_pcm_async.c
@@ -105,7 +105,11 @@ static int _dumpfile_open(const char *path, const char *prefix)
 		return -1;
 
 	now = time(NULL);
+#ifdef _WIN32
+	localtime_s(&now_tm, &now);
+#else
 	localtime_r(&now, &now_tm);
+#endif
 
 	snprintf(ymd, sizeof(ymd), "%04d%02d%02d", now_tm.tm_year + 1900,
 		 now_tm.tm_mon + 1, now_tm.tm_mday);

--- a/plugins/portaudio_pcm_sync.c
+++ b/plugins/portaudio_pcm_sync.c
@@ -114,7 +114,11 @@ static int _dumpfile_open(const char *path, const char *prefix)
 		return -1;
 
 	now = time(NULL);
+#ifdef _WIN32
+	localtime_s(&now_tm, &now);
+#else
 	localtime_r(&now, &now_tm);
+#endif
 
 	snprintf(ymd, sizeof(ymd), "%04d%02d%02d", now_tm.tm_year + 1900,
 		 now_tm.tm_mon + 1, now_tm.tm_mday);

--- a/plugins/portaudio_recorder.c
+++ b/plugins/portaudio_recorder.c
@@ -100,7 +100,11 @@ static int _dumpfile_open(const char *path, const char *prefix)
 		return -1;
 
 	now = time(NULL);
+#ifdef _WIN32
+	localtime_s(&now_tm, &now);
+#else
 	localtime_r(&now, &now_tm);
+#endif
 
 	snprintf(ymd, sizeof(ymd), "%04d%02d%02d", now_tm.tm_year + 1900,
 		 now_tm.tm_mon + 1, now_tm.tm_mday);

--- a/plugins/speex.c
+++ b/plugins/speex.c
@@ -61,7 +61,11 @@ static int _dumpfile_open(const char *path, const char *prefix)
 		return -1;
 
 	now = time(NULL);
+#ifdef _WIN32
+	localtime_s(&now_tm, &now);
+#else
 	localtime_r(&now, &now_tm);
+#endif
 
 	snprintf(ymd, sizeof(ymd), "%04d%02d%02d", now_tm.tm_year + 1900,
 		 now_tm.tm_mon + 1, now_tm.tm_mday);

--- a/src/base/network/http2/threadsync.c
+++ b/src/base/network/http2/threadsync.c
@@ -66,11 +66,13 @@ enum thread_sync_result thread_sync_wait_secs(ThreadSync *s, unsigned int secs)
 {
 	struct timespec spec;
 	int status = 0;
+	gint64 microseconds;
 
 	g_return_val_if_fail(s != NULL, THREAD_SYNC_RESULT_FAILURE);
 
-	clock_gettime(CLOCK_REALTIME, &spec);
-	spec.tv_sec = spec.tv_sec + secs;
+	microseconds = g_get_real_time();
+	spec.tv_nsec = (microseconds % 1000000) * 1000;
+	spec.tv_sec = microseconds / 1000000 + secs;
 
 	pthread_mutex_lock(&s->lock);
 	if (s->flag == 0)

--- a/src/base/network/http2/v1_ping.c
+++ b/src/base/network/http2/v1_ping.c
@@ -75,7 +75,11 @@ static int _get_next_timeout(V1Ping *ping)
 	/**
 	 * max(ttl_max_ms * (0 < random() <= 1), retry_delay_ms)
 	 */
+#ifdef _WIN32
+	timeout = ping->policy.ttl_max_ms * (rand() / (float)RAND_MAX * 1.0f);
+#else
 	timeout = ping->policy.ttl_max_ms * (random() / (float)RAND_MAX * 1.0f);
+#endif
 	if (timeout < ping->policy.retry_delay_ms)
 		timeout = ping->policy.retry_delay_ms;
 

--- a/src/base/nugu_log.c
+++ b/src/base/nugu_log.c
@@ -292,15 +292,24 @@ static int _log_make_prefix(char *prefix, enum nugu_log_level level,
 	int len = 0;
 
 	if (_log_prefix_fields & NUGU_LOG_PREFIX_TIMESTAMP) {
-		struct timespec tp;
 		struct tm ti;
+		int msec;
+		gint64 microseconds;
+		time_t now;
 
-		clock_gettime(CLOCK_REALTIME, &tp);
-		localtime_r(&(tp.tv_sec), &ti);
+		microseconds = g_get_real_time();
+
+		msec = (int)((microseconds % 1000000) / 1000);
+		now = (time_t)(microseconds / 1000000);
+
+#ifdef _WIN32
+		localtime_s(&ti, &now);
+#else
+		localtime_r(&now, &ti);
+#endif
 
 		len += (int)strftime(prefix, 15, "%m-%d %H:%M:%S", &ti);
-		len += snprintf(prefix + len, 6, ".%03ld ",
-				tp.tv_nsec / 1000000);
+		len += snprintf(prefix + len, 6, ".%03d ", msec);
 	}
 
 	if (_log_prefix_fields & NUGU_LOG_PREFIX_PID ||

--- a/src/base/nugu_network_manager.c
+++ b/src/base/nugu_network_manager.c
@@ -90,7 +90,7 @@ struct _nugu_network {
 
 	/* Server */
 	DGServer *server;
-	struct timespec ts_connected;
+	time_t tsec_connected;
 
 	/* Handoff */
 	DGServer *handoff;
@@ -648,7 +648,7 @@ static void on_directives_closed(enum nugu_equeue_type type, void *data,
 				 void *userdata)
 {
 	NetworkManager *nm = userdata;
-	struct timespec spec;
+	time_t sec = 0;
 
 	nugu_prof_mark(NUGU_PROF_TYPE_NETWORK_DIRECTIVES_CLOSED);
 
@@ -657,9 +657,9 @@ static void on_directives_closed(enum nugu_equeue_type type, void *data,
 		return;
 	}
 
-	clock_gettime(CLOCK_REALTIME, &spec);
+	sec = time(NULL);
 
-	if (spec.tv_sec - nm->ts_connected.tv_sec == 0) {
+	if (sec - nm->tsec_connected == 0) {
 		nugu_error(
 			"Connection was finished immediately on the server.");
 
@@ -706,7 +706,7 @@ static void on_event(enum nugu_equeue_type type, void *data, void *userdata)
 		nugu_prof_mark(
 			NUGU_PROF_TYPE_NETWORK_SERVER_ESTABLISH_RESPONSE);
 		nugu_prof_mark(NUGU_PROF_TYPE_NETWORK_CONNECTED);
-		clock_gettime(CLOCK_REALTIME, &nm->ts_connected);
+		nm->tsec_connected = time(NULL);
 		_process_connecting(userdata, STEP_SERVER_CONNECTED);
 		break;
 	default:
@@ -798,7 +798,6 @@ static NetworkManager *_network;
 
 int nugu_network_manager_initialize(void)
 {
-	struct timespec spec;
 	curl_version_info_data *cinfo;
 
 	if (_network) {
@@ -823,9 +822,11 @@ int nugu_network_manager_initialize(void)
 		}
 	}
 
-	clock_gettime(CLOCK_REALTIME, &spec);
-	srandom(spec.tv_nsec ^ spec.tv_sec);
-
+#ifdef _WIN32
+	srand(g_get_real_time());
+#else
+	srandom(g_get_real_time());
+#endif
 	_network = nugu_network_manager_new();
 	if (!_network)
 		return -1;
@@ -1074,7 +1075,11 @@ int nugu_network_manager_send_event(NuguEvent *nev)
 		struct tm tm;
 
 		now = time(NULL);
+#ifdef _WIN32
+		gmtime_s(&tm, &now);
+#else
 		gmtime_r(&now, &tm);
+#endif
 		if (strftime(buf, sizeof(buf), "%a, %d %b %Y %H:%M:%S %Z",
 			     &tm) == 0) {
 			nugu_error("strftime() failed");

--- a/src/capability/display_agent.cc
+++ b/src/capability/display_agent.cc
@@ -15,7 +15,10 @@
  */
 
 #include <string.h>
+
+#ifndef _WIN32
 #include <sys/time.h>
+#endif
 
 #include "base/nugu_log.h"
 #include "display_agent.hh"

--- a/src/capability/display_render_helper.cc
+++ b/src/capability/display_render_helper.cc
@@ -15,7 +15,11 @@
  */
 
 #include <stdexcept>
+#include <glib.h>
+
+#ifndef _WIN32
 #include <sys/time.h>
+#endif
 
 #include "base/nugu_log.h"
 #include "display_render_helper.hh"
@@ -100,10 +104,7 @@ DisplayRenderInfo* DisplayRenderHelper::Builder::build()
 
 std::string DisplayRenderHelper::Builder::makeId()
 {
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-
-    return std::to_string(tv.tv_sec) + std::to_string(tv.tv_usec);
+    return std::to_string(g_get_real_time());
 }
 
 DisplayRenderHelper::DisplayRenderHelper()

--- a/tests/test_nugu_uuid.c
+++ b/tests/test_nugu_uuid.c
@@ -81,7 +81,8 @@ static void test_nugu_uuid_time(void)
 	unsigned char buf[NUGU_MAX_UUID_SIZE];
 	unsigned char outbuf[NUGU_MAX_UUID_SIZE];
 	struct tm t_tm;
-	struct timespec t_spec;
+	time_t t_sec;
+	gint64 msec;
 	char timestr[32];
 	unsigned char dummy_hash[6] = { '0', '0', '0', '0', '0', '0' };
 
@@ -89,45 +90,57 @@ static void test_nugu_uuid_time(void)
 	g_assert(nugu_uuid_convert_bytes(TEST1, strlen(TEST1), buf,
 					 sizeof(buf)) == 0);
 
-	g_assert(nugu_uuid_convert_timespec(buf, sizeof(buf), &t_spec) == 0);
-	g_assert(t_spec.tv_sec == 1579655759);
-	g_assert(t_spec.tv_nsec == 39000000);
-	gmtime_r(&t_spec.tv_sec, &t_tm);
+	g_assert(nugu_uuid_convert_msec(buf, sizeof(buf), &msec) == 0);
+	g_assert(msec == 1579655759039);
+	t_sec = msec / 1000;
+#ifdef _WIN32
+	gmtime_s(&t_tm, &t_sec);
+#else
+	gmtime_r(&t_sec, &t_tm);
+#endif
 	g_assert(strftime(timestr, sizeof(timestr), "%F %T", &t_tm) != 0);
 	g_assert_cmpstr(timestr, ==, "2020-01-22 01:15:59");
 
 	/* Convert timespec to 5 bytes */
-	g_assert(nugu_uuid_fill(&t_spec, dummy_hash, sizeof(dummy_hash) - 5,
+	g_assert(nugu_uuid_fill(msec, dummy_hash, sizeof(dummy_hash) - 5,
 				outbuf, sizeof(outbuf)) == 0);
 	g_assert_cmpmem(buf, 5, outbuf, 5);
 
 	/* Convert 5 bytes to integer from NUGU_BASE_TIMESTAMP_MSEC */
 	g_assert(nugu_uuid_convert_bytes(TEST2, strlen(TEST2), buf,
 					 sizeof(buf)) == 0);
-	g_assert(nugu_uuid_convert_timespec(buf, sizeof(buf), &t_spec) == 0);
-	g_assert(t_spec.tv_sec == 1579655809);
-	g_assert(t_spec.tv_nsec == 627000000);
-	gmtime_r(&t_spec.tv_sec, &t_tm);
+	g_assert(nugu_uuid_convert_msec(buf, sizeof(buf), &msec) == 0);
+	g_assert(msec == 1579655809627);
+	t_sec = msec / 1000;
+#ifdef _WIN32
+	gmtime_s(&t_tm, &t_sec);
+#else
+	gmtime_r(&t_sec, &t_tm);
+#endif
 	g_assert(strftime(timestr, sizeof(timestr), "%F %T", &t_tm) != 0);
 	g_assert_cmpstr(timestr, ==, "2020-01-22 01:16:49");
 
 	/* Convert timespec to 5 bytes */
-	g_assert(nugu_uuid_fill(&t_spec, dummy_hash, sizeof(dummy_hash) - 5,
+	g_assert(nugu_uuid_fill(msec, dummy_hash, sizeof(dummy_hash) - 5,
 				outbuf, sizeof(outbuf)) == 0);
 	g_assert_cmpmem(buf, 5, outbuf, 5);
 
 	/* Convert 5 bytes to integer from NUGU_BASE_TIMESTAMP_MSEC */
 	g_assert(nugu_uuid_convert_bytes(TEST3, strlen(TEST3), buf,
 					 sizeof(buf)) == 0);
-	g_assert(nugu_uuid_convert_timespec(buf, sizeof(buf), &t_spec) == 0);
-	g_assert(t_spec.tv_sec == 1579740221);
-	g_assert(t_spec.tv_nsec == 516000000);
-	gmtime_r(&t_spec.tv_sec, &t_tm);
+	g_assert(nugu_uuid_convert_msec(buf, sizeof(buf), &msec) == 0);
+	g_assert(msec == 1579740221516);
+	t_sec = msec / 1000;
+#ifdef _WIN32
+	gmtime_s(&t_tm, &t_sec);
+#else
+	gmtime_r(&t_sec, &t_tm);
+#endif
 	g_assert(strftime(timestr, sizeof(timestr), "%F %T", &t_tm) != 0);
 	g_assert_cmpstr(timestr, ==, "2020-01-23 00:43:41");
 
 	/* Convert timespec to 5 bytes */
-	g_assert(nugu_uuid_fill(&t_spec, dummy_hash, sizeof(dummy_hash) - 5,
+	g_assert(nugu_uuid_fill(msec, dummy_hash, sizeof(dummy_hash) - 5,
 				outbuf, sizeof(outbuf)) == 0);
 	g_assert_cmpmem(buf, 5, outbuf, 5);
 }


### PR DESCRIPTION
Fix following time API to support WIN32
- gettimeofday() -> g_get_real_time()
- clock_gettime() -> g_get_real_time()

Add ifdef macro to support WIN32
- gmtime_r / gmtime_s
- localtime_r / localtime_s
- srandom / srand
- random / rand
