### PR TITLE
base: initialize mutex

### DIFF
--- a/src/base/nugu_equeue.c
+++ b/src/base/nugu_equeue.c
@@ -65,7 +65,7 @@ struct _econtainer {
 };
 
 static struct _equeue *_equeue;
-static pthread_mutex_t _lock;
+static pthread_mutex_t _lock = PTHREAD_MUTEX_INITIALIZER;
 
 static void on_item_destroy(gpointer data)
 {

--- a/src/base/nugu_prof.c
+++ b/src/base/nugu_prof.c
@@ -118,7 +118,7 @@ static struct nugu_prof_data _prof_data[NUGU_PROF_TYPE_MAX + 1];
 
 static NuguProfCallback _callback;
 static void *_callback_userdata;
-static pthread_mutex_t _lock;
+static pthread_mutex_t _lock = PTHREAD_MUTEX_INITIALIZER;
 static gboolean _trace;
 
 static void _fill_timestr(char *dest_buf, size_t bufsize, gint64 msec)


### PR DESCRIPTION
Fix a bug using pthead mutex without initializing it.