### PR TITLE
build: add BUILTIN_NJSON feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,7 @@ DEFINE_FEATURE(PULSEAUDIO ${PULSEAUDIO_DEFAULT} "pulseaudio")
 DEFINE_FEATURE(VENDOR_LIBRARY ON "vendor specific library(nugu_wwd, nugu_epd)")
 DEFINE_FEATURE(VOICE_STREAMING OFF "voice streaming without epd")
 
+DEFINE_FEATURE(BUILTIN_NJSON ON "compile built-in njson library")
 DEFINE_FEATURE(BUILTIN_OPUS OFF "compile built-in OPUS library")
 DEFINE_FEATURE(BUILTIN_OPUS_FLOAT_API OFF "floating point to OPUS library")
 DEFINE_FEATURE(BUILTIN_CURL ${BUILTIN_CURL_DEFAULT} "compile built-in curl library")
@@ -278,6 +279,20 @@ ELSEIF(ENABLE_VENDOR_LIBRARY)
 		# The Speex plugin requires the speex API provided by nugu-epd
 		SET(VENDOR_PKGCONFIG nugu-epd)
 	ENDIF()
+ENDIF()
+
+# Built-in njson library
+IF (NOT ENABLE_BUILTIN_NJSON)
+	pkg_check_modules(njson_pkgs REQUIRED njson)
+	IF (MSVC)
+		INCLUDE_DIRECTORIES(${njson_pkgs_INCLUDE_DIRS})
+		SET(NJSON_LIBRARY ${njson_pkgs_LIBRARIES})
+	ELSE()
+		ADD_COMPILE_OPTIONS(${njson_pkgs_CFLAGS})
+		SET(NJSON_LIBRARY ${njson_pkgs_LDFLAGS})
+	ENDIF()
+
+	LINK_DIRECTORIES(${njson_pkgs_LIBRARY_DIRS})
 ENDIF()
 
 # Built-in curl library
@@ -413,7 +428,7 @@ IF (BUILD_LIBRARY)
 ENDIF()
 
 IF (NOT MSVC)
-	SET(COMMON_LDFLAGS ${COMMON_LDFLAGS} ${pkgs_LDFLAGS})
+	SET(COMMON_LDFLAGS ${COMMON_LDFLAGS} ${NJSON_LIBRARY} ${pkgs_LDFLAGS})
 ENDIF()
 
 # ----------------------------------------------------------------------------

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -2,29 +2,30 @@ include(ExternalProject)
 include(CheckIncludeFileCXX)
 
 # njson
-find_package(RapidJSON) # Provide RAPIDJSON_INCLUDE_DIRS variable
-IF(RapidJSON_FOUND)
-	SET(RAPIDJSON_INCLUDE ${RAPIDJSON_INCLUDE_DIRS})
-ELSE()
-	pkg_check_modules(rapidjson_pkgs RapidJSON)
-	IF(rapidjson_pkgs_FOUND)
-		SET(RAPIDJSON_INCLUDE ${rapidjson_pkgs_CFLAGS})
+IF(ENABLE_BUILTIN_NJSON)
+	find_package(RapidJSON) # Provide RAPIDJSON_INCLUDE_DIRS variable
+	IF(RapidJSON_FOUND)
+		SET(RAPIDJSON_INCLUDE ${RAPIDJSON_INCLUDE_DIRS})
 	ELSE()
-		CHECK_INCLUDE_FILE_CXX("rapidjson/rapidjson.h" HAVE_RAPIDJSON)
-		IF(NOT HAVE_RAPIDJSON)
-			MESSAGE(FATAL_ERROR "rapidjson.h file is not found")
+		pkg_check_modules(rapidjson_pkgs RapidJSON)
+		IF(rapidjson_pkgs_FOUND)
+			SET(RAPIDJSON_INCLUDE ${rapidjson_pkgs_CFLAGS})
+		ELSE()
+			CHECK_INCLUDE_FILE_CXX("rapidjson/rapidjson.h" HAVE_RAPIDJSON)
+			IF(NOT HAVE_RAPIDJSON)
+				MESSAGE(FATAL_ERROR "rapidjson.h file is not found")
+			ENDIF()
 		ENDIF()
 	ENDIF()
-ENDIF()
 
-FILE(GLOB_RECURSE njson_files njson/src/*.cpp)
-ADD_LIBRARY(njson STATIC ${njson_files})
-TARGET_INCLUDE_DIRECTORIES(njson PRIVATE njson/include ${RAPIDJSON_INCLUDE})
-IF(IS_MINGW)
-	TARGET_COMPILE_OPTIONS(njson PRIVATE -Wno-class-memaccess)
+	FILE(GLOB_RECURSE njson_files njson/src/*.cpp)
+	ADD_LIBRARY(njson STATIC ${njson_files})
+	TARGET_INCLUDE_DIRECTORIES(njson PRIVATE njson/include ${RAPIDJSON_INCLUDE})
+	IF(IS_MINGW)
+		TARGET_COMPILE_OPTIONS(njson PRIVATE -Wno-class-memaccess)
+	ENDIF()
+	INSTALL(DIRECTORY njson/include/njson DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/nugu/)
 ENDIF()
-INSTALL(DIRECTORY njson/include/njson
-		DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/nugu/)
 
 # In Bionic(18.04), the PKG_CONFIG_EXECUTABLE value with an absolute path is
 # passed from the debian package build script.


### PR DESCRIPTION
Add `ENABLE_BUILTIN_NJSON` feature option to provide `njson` library dependency option.

Default is ON (use sources from `externals/njson` submodule). And if option is OFF, use the `njson.pc` pkg-config file.