### PR TITLE
update network connection oriented mode check

### DIFF
--- a/src/core/network_manager.hh
+++ b/src/core/network_manager.hh
@@ -40,6 +40,8 @@ public:
     bool setUserAgent(const std::string& app_version, const std::string& additional_info) override;
 
 private:
+    bool isConnectionOriented(const char* json_text);
+
     std::vector<INetworkManagerListener*> listeners;
 };
 


### PR DESCRIPTION
As it's not possible to parse token of not nugu usage types,
so when token parsing failure, it determine to connection oriented mode.