### PR TITLE
core: update position

### DIFF
--- a/src/core/media_player.cc
+++ b/src/core/media_player.cc
@@ -284,6 +284,8 @@ bool MediaPlayer::resume()
 {
     nugu_dbg("request to resume mediaplayer");
 
+    d->pos_timer->restart();
+
     if (nugu_player_resume(d->player) < 0)
         return false;
 


### PR DESCRIPTION
If only the AudioPlayer is received instead of receiving a voice response from the server in the order of TTS and AudioPlayer, polling timer is not work.